### PR TITLE
✨ Feat: Phase 5 - 컴포넌트 분리 및 커스텀 훅 추출

### DIFF
--- a/src/common/NavMenu.jsx
+++ b/src/common/NavMenu.jsx
@@ -1,0 +1,84 @@
+import { Offcanvas } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+import 'bootstrap-icons/font/bootstrap-icons.css';
+
+const NavMenu = ({ show, onClose, isLoggedIn, isAdmin, curUser, onLogout, onLogin, onSignup }) => {
+    return (
+        <Offcanvas
+            show={show}
+            onHide={onClose}
+            placement="end"
+            id="offcanvasNavbar"
+            aria-labelledby="offcanvasNavbarLabel"
+            style={{
+                width: '300px',
+                background: "linear-gradient(135deg, #283593D9 60%, #6F8AE7DD 100%)",
+                color: "white", borderTopLeftRadius: "28px", borderBottomLeftRadius: "28px",
+                boxShadow: "0 0 32px 0 rgba(40,53,147,0.13)",
+                backdropFilter: "blur(10px)", WebkitBackdropFilter: "blur(10px)"
+            }}
+        >
+            <Offcanvas.Header
+                closeButton
+                style={{ background: "none", color: "white", borderBottom: "1px solid rgba(255,255,255,0.10)" }}
+            >
+                <Offcanvas.Title
+                    id="offcanvasNavbarLabel"
+                    style={{ fontWeight: 600, letterSpacing: "0.05em", fontSize: "1.2rem" }}
+                >
+                    <i className="bi bi-menu-button-wide me-2" />메뉴
+                </Offcanvas.Title>
+            </Offcanvas.Header>
+            <Offcanvas.Body>
+                <div className="d-flex flex-column justify-content-between h-100">
+                    <div className="d-flex flex-column align-items-stretch gap-2">
+                        <MenuLink to="/post/list" icon="bi-card-list" label="여행지" onClick={onClose} />
+                        {!isLoggedIn && (
+                            <>
+                                <MenuLink to="sign/component/signinpage" icon="bi-box-arrow-in-right" label="로그인" onClick={onLogin} />
+                                <MenuLink to="sign/component/signuppage" icon="bi-person-plus" label="회원 가입" onClick={onSignup} />
+                            </>
+                        )}
+                        {isLoggedIn && (
+                            <>
+                                {isAdmin && (
+                                    <MenuLink to="/component/admnpage" icon="bi-gear" label="관리자 메뉴" onClick={onClose} />
+                                )}
+                                <MenuLink to="/common/MyPage" icon="bi-person-circle" label="마이페이지" onClick={onClose} />
+                            </>
+                        )}
+                    </div>
+                    <div className="d-flex flex-column align-items-stretch gap-2 mt-4">
+                        {isLoggedIn && (
+                            <MenuLink to="#" icon="bi-box-arrow-right" label="로그아웃" onClick={onLogout} />
+                        )}
+                        {isLoggedIn && (
+                            <span
+                                className="nav-link w-100 fs-6 text-light bg-secondary bg-opacity-50 rounded px-3 py-2 disabled"
+                                style={{ pointerEvents: 'none', opacity: 0.7, background: "rgba(100, 100, 180, 0.16)" }}
+                            >
+                                <i className="bi bi-person-badge me-2"></i>닉네임: {curUser}
+                            </span>
+                        )}
+                    </div>
+                </div>
+            </Offcanvas.Body>
+        </Offcanvas>
+    );
+};
+
+export default NavMenu;
+
+const MenuLink = ({ to, icon, label, onClick, fs = "fs-5" }) => (
+    <Link
+        to={to}
+        className={`nav-link w-100 ${fs} text-light bg-opacity-75 rounded px-3 py-2`}
+        style={{ position: "relative", transition: "background 0.2s, box-shadow 0.16s", fontWeight: 500, borderRadius: "18px", letterSpacing: "0.01em" }}
+        onClick={onClick}
+        onMouseOver={e => { e.target.style.background = "rgba(255,255,255,0.11)"; e.target.style.color = "#FFF"; e.target.style.boxShadow = "0 2px 12px 0 rgba(91,142,255,0.09)"; }}
+        onMouseOut={e => { e.target.style.background = ""; e.target.style.color = "#FFF"; e.target.style.boxShadow = ""; }}
+    >
+        <i className={`bi ${icon} me-2`} style={{ opacity: 0.96 }} />
+        {label}
+    </Link>
+);

--- a/src/common/Navbar.jsx
+++ b/src/common/Navbar.jsx
@@ -1,4 +1,4 @@
-import { Offcanvas, Button } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { useEffect, useState } from "react";
 import { useNavigate, Link } from 'react-router-dom';
 import { signOut, testAuth } from "../api/signApi";
@@ -8,6 +8,7 @@ import 'bootstrap-icons/font/bootstrap-icons.css';
 import UserAuthentication from '../sign/service/UserAuthentication';
 import { toast } from 'react-toastify';
 import useAlert from '../hooks/useAlert';
+import NavMenu from './NavMenu';
 
 const GRADIENT = "linear-gradient(90deg, #5C6BC0 0%, #283593 100%)";
 
@@ -69,9 +70,7 @@ const Navbar = () => {
 
   return (
     <>
-      <div
-        style={{ position: "fixed", top: 80, left: "50%", transform: "translateX(-50%)", minWidth: 260, zIndex: 2000 }}
-      >
+      <div style={{ position: "fixed", top: 80, left: "50%", transform: "translateX(-50%)", minWidth: 260, zIndex: 2000 }}>
         {alert.show && (
           <div className={`alert alert-${alert.type || "info"} text-center shadow`} role="alert">
             {alert.message}
@@ -107,71 +106,19 @@ const Navbar = () => {
             </Button>
           </div>
         </div>
-        <Offcanvas show={show} onHide={handleClose} placement="end" id="offcanvasNavbar"
-          aria-labelledby="offcanvasNavbarLabel"
-          style={{
-            width: '300px',
-            background: "linear-gradient(135deg, #283593D9 60%, #6F8AE7DD 100%)",
-            color: "white", borderTopLeftRadius: "28px", borderBottomLeftRadius: "28px",
-            boxShadow: "0 0 32px 0 rgba(40,53,147,0.13)",
-            backdropFilter: "blur(10px)", WebkitBackdropFilter: "blur(10px)"
-          }}>
-          <Offcanvas.Header closeButton
-            style={{ background: "none", color: "white", borderBottom: "1px solid rgba(255,255,255,0.10)" }}>
-            <Offcanvas.Title id="offcanvasNavbarLabel"
-              style={{ fontWeight: 600, letterSpacing: "0.05em", fontSize: "1.2rem" }}>
-              <i className="bi bi-menu-button-wide me-2" />메뉴
-            </Offcanvas.Title>
-          </Offcanvas.Header>
-          <Offcanvas.Body>
-            <div className="d-flex flex-column justify-content-between h-100">
-              <div className="d-flex flex-column align-items-stretch gap-2">
-                <MenuLink to="/post/list" icon="bi-card-list" label="여행지" onClick={handleClose} />
-                {!isLoggedIn && (
-                  <>
-                    <MenuLink to="sign/component/signinpage" icon="bi-box-arrow-in-right" label="로그인"
-                      onClick={() => { goToLogin(); handleClose(); }} />
-                    <MenuLink to="sign/component/signuppage" icon="bi-person-plus" label="회원 가입"
-                      onClick={() => { goToSignup(); handleClose(); }} />
-                  </>
-                )}
-                {isLoggedIn && (
-                  <>
-                    {isAdmin &&
-                      <MenuLink to="/component/admnpage" icon="bi-gear" label="관리자 메뉴" onClick={handleClose} />}
-                    <MenuLink to="/common/MyPage" icon="bi-person-circle" label="마이페이지" onClick={handleClose} />
-                  </>
-                )}
-              </div>
-              <div className="d-flex flex-column align-items-stretch gap-2 mt-4">
-                {isLoggedIn && <MenuLink to="#" icon="bi-box-arrow-right" label="로그아웃" onClick={handleLogout} />}
-                {isLoggedIn &&
-                  <span className="nav-link w-100 fs-6 text-light bg-secondary bg-opacity-50 rounded px-3 py-2 disabled"
-                    style={{ pointerEvents: 'none', opacity: 0.7, background: "rgba(100, 100, 180, 0.16)" }}>
-                    <i className="bi bi-person-badge me-2"></i>닉네임: {curUser}
-                  </span>
-                }
-              </div>
-            </div>
-          </Offcanvas.Body>
-        </Offcanvas>
+        <NavMenu
+          show={show}
+          onClose={handleClose}
+          isLoggedIn={isLoggedIn}
+          isAdmin={isAdmin}
+          curUser={curUser}
+          onLogout={handleLogout}
+          onLogin={() => { goToLogin(); handleClose(); }}
+          onSignup={() => { goToSignup(); handleClose(); }}
+        />
       </nav>
     </>
   );
 };
 
 export default Navbar;
-
-const MenuLink = ({ to, icon, label, onClick, fs = "fs-5" }) => (
-  <Link
-    to={to}
-    className={`nav-link w-100 ${fs} text-light bg-opacity-75 rounded px-3 py-2`}
-    style={{ position: "relative", transition: "background 0.2s, box-shadow 0.16s", fontWeight: 500, borderRadius: "18px", letterSpacing: "0.01em" }}
-    onClick={onClick}
-    onMouseOver={e => { e.target.style.background = "rgba(255,255,255,0.11)"; e.target.style.color = "#FFF"; e.target.style.boxShadow = "0 2px 12px 0 rgba(91,142,255,0.09)"; }}
-    onMouseOut={e => { e.target.style.background = ""; e.target.style.color = "#FFF"; e.target.style.boxShadow = ""; }}
-  >
-    <i className={`bi ${icon} me-2`} style={{ opacity: 0.96 }} />
-    {label}
-  </Link>
-);

--- a/src/hooks/useSignUpForm.js
+++ b/src/hooks/useSignUpForm.js
@@ -1,0 +1,134 @@
+import { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { checkDuplicate, signUp } from '../api/signApi';
+
+const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+~\-=\[\]{};':"\\|,.<>\/?]).{8,}$/;
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const useSignUpForm = () => {
+    const navigate = useNavigate();
+    const [formData, setFormData] = useState({
+        loginId: '',
+        password: '',
+        passwordConfirm: '',
+        email: '',
+        nickname: '',
+        gender: '',
+    });
+    const [birthDate, setBirthDate] = useState('');
+    const [alert, setAlert] = useState({ show: false, message: '', type: '' });
+    const [touched, setTouched] = useState({});
+    const [errors, setErrors] = useState({});
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [dups, setDups] = useState({
+        loginId: null,
+        email: null,
+        nickname: null,
+    });
+    const inputRefs = {
+        loginId: useRef(null),
+        password: useRef(null),
+        passwordConfirm: useRef(null),
+        nickname: useRef(null),
+        email: useRef(null),
+        gender: useRef(null),
+        birthDate: useRef(null)
+    };
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setFormData(prev => ({ ...prev, [name]: value }));
+        setTouched(prev => ({ ...prev, [name]: true }));
+        if (['loginId', 'email', 'nickname'].includes(name)) {
+            setDups(prev => ({ ...prev, [name]: null }));
+        }
+    };
+
+    useEffect(() => {
+        const debounce = {};
+        ["loginId", "email", "nickname"].forEach(field => {
+            if (!formData[field]) return;
+            if (debounce[field]) clearTimeout(debounce[field]);
+            debounce[field] = setTimeout(async () => {
+                try {
+                    const { data } = await checkDuplicate({ type: field, value: formData[field] });
+                    setDups(prev => ({ ...prev, [field]: !!data.exists }));
+                } catch {
+                    setDups(prev => ({ ...prev, [field]: false }));
+                }
+            }, 500);
+        });
+        return () => Object.values(debounce).forEach(clearTimeout);
+        // eslint-disable-next-line
+    }, [formData.loginId, formData.email, formData.nickname]);
+
+    const handleBirthDate = (e) => {
+        setBirthDate(e.target.value);
+        setTouched(prev => ({ ...prev, birthDate: true }));
+    };
+
+    useEffect(() => {
+        const newErrors = {};
+        if (!formData.loginId) newErrors.loginId = "아이디를 입력하세요.";
+        else if (dups.loginId === true) newErrors.loginId = "이미 사용중인 아이디입니다.";
+        if (!formData.password) newErrors.password = "비밀번호를 입력하세요.";
+        else if (!passwordPattern.test(formData.password)) newErrors.password = "8자 이상, 영문/숫자/특수문자 조합으로 입력하세요.";
+        if (!formData.passwordConfirm) newErrors.passwordConfirm = "비밀번호 확인을 입력하세요.";
+        else if (formData.password && formData.password !== formData.passwordConfirm) newErrors.passwordConfirm = "비밀번호가 일치하지 않습니다.";
+        if (!formData.nickname) newErrors.nickname = "닉네임을 입력하세요.";
+        else if (dups.nickname === true) newErrors.nickname = "이미 사용중인 닉네임입니다.";
+        if (!formData.email) newErrors.email = "이메일을 입력하세요.";
+        else if (!emailPattern.test(formData.email)) newErrors.email = "이메일 형식이 올바르지 않습니다.";
+        else if (dups.email === true) newErrors.email = "이미 사용중인 이메일입니다.";
+        if (!formData.gender) newErrors.gender = "성별을 선택하세요.";
+        if (!birthDate) newErrors.birthDate = "생년월일을 입력하세요.";
+        setErrors(newErrors);
+    }, [formData, birthDate, dups]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setTouched({
+            loginId: true, password: true, passwordConfirm: true, nickname: true, email: true, gender: true, birthDate: true
+        });
+        if (Object.keys(errors).length > 0) {
+            const firstError = Object.keys(errors)[0];
+            inputRefs[firstError]?.current?.focus();
+            setAlert({ show: true, message: "모든 항목을 올바르게 입력해주세요.", type: "danger" });
+            return;
+        }
+        setIsSubmitting(true);
+        try {
+            await signUp({ ...formData, birthDate });
+            toast.success("회원가입이 완료되었습니다! 🎉");
+            navigate("/");
+        } catch (error) {
+            const msg = error.response?.data;
+            setAlert({ show: true, message: msg?.message || "에러가 발생했습니다.", type: "danger" });
+            if (msg?.field && inputRefs[msg.field]) {
+                inputRefs[msg.field].current.focus();
+            }
+        }
+        setIsSubmitting(false);
+    };
+
+    const isFormValid = Object.keys(errors).length === 0 && !isSubmitting;
+
+    return {
+        formData,
+        birthDate,
+        alert,
+        setAlert,
+        touched,
+        errors,
+        isSubmitting,
+        dups,
+        isFormValid,
+        inputRefs,
+        handleChange,
+        handleBirthDate,
+        handleSubmit,
+    };
+};
+
+export default useSignUpForm;

--- a/src/post/components/PostContent.jsx
+++ b/src/post/components/PostContent.jsx
@@ -1,0 +1,82 @@
+import { Tooltip, Card, Badge, OverlayTrigger, Carousel } from "react-bootstrap";
+import { Link } from "react-router-dom";
+import { categoryColors, regionColors } from "../../constants/colorMaps";
+
+const PostContent = ({ post, liked, onLike, nickname }) => {
+    return (
+        <Card
+            className="shadow-sm flex-fill"
+            style={{ borderRadius: "18px", width: "100%", minWidth: "0", background: "#fff", display: "flex", flexDirection: "column" }}
+        >
+            <Card.Body className="pb-2 pt-4 d-flex flex-column" style={{ flex: 1 }}>
+                {post.imagePaths && post.imagePaths.length > 0 && (
+                    <Carousel
+                        interval={null}
+                        indicators={post.imagePaths.length > 1}
+                        style={{ maxWidth: 800, margin: "0 auto 24px auto", borderRadius: 16, overflow: "hidden", boxShadow: "0 6px 18px #0001" }}
+                    >
+                        {post.imagePaths.map(filename => (
+                            <Carousel.Item key={filename}>
+                                <img
+                                    src={`${process.env.REACT_APP_IMAGE_BASE_URL}${filename}`}
+                                    alt="uploaded"
+                                    style={{ width: "100%", height: 400, objectFit: "cover", display: "block", background: "#eee" }}
+                                />
+                            </Carousel.Item>
+                        ))}
+                    </Carousel>
+                )}
+                <div className="d-flex justify-content-between align-items-start mb-1">
+                    <h4 className="fw-bold mb-1">{post.title}</h4>
+                    <Badge bg={categoryColors[post.category] || "secondary"} style={{ fontSize: "1rem" }}>
+                        {post.category}
+                    </Badge>
+                </div>
+                <div className="mb-2 text-muted" style={{ fontSize: "0.96rem" }}>
+                    조회수: <span className="fw-semibold">{post.viewCount}</span> | 작성자: <span className="fw-semibold">{post.memberNickname ? post.memberNickname : 0}</span> |
+                </div>
+                <hr className="my-2" />
+                <div className="mb-2">
+                    <span className="fw-semibold"><i className="bi bi-geo-alt-fill"></i> 여행지:</span> {post.travelPlace}
+                    <div className="text-muted" style={{ fontSize: "0.97rem" }}>{post.address}</div>
+                </div>
+                <div className="mb-2 d-flex align-items-center justify-content-between">
+                    <div>
+                        <span className="fw-semibold"><i className="bi bi-map-fill"></i> 지역:</span>
+                        <Badge bg={regionColors[post.region] || "secondary"} className="ms-1">{post.region}</Badge>
+                    </div>
+                    {nickname === post.memberNickname && (
+                        <OverlayTrigger placement="top" overlay={<Tooltip id="tooltip-edit">수정하기</Tooltip>}>
+                            <Link
+                                to={`/post/edit?no=${post.id}`}
+                                className="btn btn-outline-primary btn-sm ms-2"
+                                style={{ whiteSpace: "nowrap" }}
+                            >
+                                🖊
+                            </Link>
+                        </OverlayTrigger>
+                    )}
+                </div>
+                <Card className="mb-0" style={{ background: "#f7fafc", border: "none" }}>
+                    <Card.Body className="py-2 px-3" style={{ minHeight: "50px", fontSize: "1.08rem", whiteSpace: "pre-line" }}>
+                        {post.content}
+                    </Card.Body>
+                </Card>
+                <div className="d-flex justify-content-between align-items-center mt-auto pt-3">
+                    <button
+                        className={`favorite-btn btn btn-link p-0 heart-btn${liked ? " liked" : ""}`}
+                        data-travel="123"
+                        onClick={onLike}
+                        style={{ textDecoration: "none" }}
+                        aria-label={liked ? "찜 취소" : "찜하기"}
+                    >
+                        <i className={liked ? "bi bi-heart-fill" : "bi bi-heart"} />
+                        <span className="fw-semibold"> {post.favoriteCount ? post.favoriteCount : 0}</span>
+                    </button>
+                </div>
+            </Card.Body>
+        </Card>
+    );
+};
+
+export default PostContent;

--- a/src/post/components/PostForm.jsx
+++ b/src/post/components/PostForm.jsx
@@ -1,0 +1,130 @@
+import 'bootstrap/dist/css/bootstrap.min.css';
+import CategoryCard from '../../board/component/page/CategoryCard';
+import RegionRadioComp from '../../board/component/page/RegionRadioComp';
+
+const PostForm = ({
+    post,
+    mode,
+    onChange,
+    onCategorySelect,
+    onRegionChange,
+    onSubmit,
+    onDelete,
+    imageSection,
+    alert,
+    submitDisabled = false,
+}) => {
+    const isEdit = mode === 'edit';
+
+    return (
+        <>
+            {alert.show && (
+                <div
+                    className={`alert alert-${alert.type} text-center shadow`}
+                    role="alert"
+                    style={{ position: "fixed", top: 80, left: "50%", transform: "translateX(-50%)", minWidth: 240, zIndex: 3000 }}
+                >
+                    {alert.message}
+                </div>
+            )}
+            <div
+                className={isEdit ? "py-5" : ""}
+                style={{ minHeight: "100vh", width: "100vw", overflowX: "hidden", position: "relative" }}
+            >
+                <div className="container my-5" style={{ maxWidth: '900px' }}>
+                    <div className="card shadow-lg border-0 rounded-4 p-4" style={{ background: "#ffffffeb" }}>
+                        <h2 className="mb-3 fw-bold" style={{ textAlign: 'center', letterSpacing: '2px' }}>
+                            {isEdit ? '글 수정' : '글 작성'}
+                        </h2>
+                        <div className="text-secondary text-center mb-4" style={{ fontSize: '1.07rem' }}>
+                            여행지, 사진, 지역, 카테고리, 후기를 모두 입력해 주세요!
+                        </div>
+                        {isEdit && (
+                            <div className="mb-4 d-flex justify-content-end">
+                                <span className="fw-semibold" style={{ fontSize: '1.08rem', color: '#222', marginRight: 6 }}>작성자:</span>
+                                <span className="fw-bold" style={{ fontSize: '1.08rem', minWidth: 80, display: 'inline-block' }}>
+                                    {post.memberNickname || ""}
+                                </span>
+                            </div>
+                        )}
+                        <form onSubmit={onSubmit}>
+                            <div className="mb-4">
+                                <label htmlFor="title" className="form-label fw-semibold">제목</label>
+                                <input
+                                    type="text" className="form-control form-control-lg" id="title"
+                                    required maxLength={40} placeholder="제목을 입력하세요"
+                                    value={post.title} onChange={onChange}
+                                />
+                            </div>
+                            <div className="row g-3 mb-4">
+                                <div className="col-md-5">
+                                    <label htmlFor="travelPlace" className="form-label fw-semibold">여행지 이름</label>
+                                    <input
+                                        type="text" className="form-control" id="travelPlace"
+                                        required placeholder="예: 남산타워"
+                                        value={post.travelPlace} onChange={onChange}
+                                    />
+                                </div>
+                                <div className="col-md-7">
+                                    <label htmlFor="address" className="form-label fw-semibold">여행지 주소</label>
+                                    <input
+                                        type="text" className="form-control" id="address"
+                                        required placeholder="예: 서울특별시 중구 남산공원길 105"
+                                        value={post.address} onChange={onChange}
+                                    />
+                                </div>
+                            </div>
+                            <div className="row g-3 mb-4">
+                                <div className="col-md-6">
+                                    <label className="form-label fw-semibold">카테고리</label>
+                                    <div className="bg-light rounded-4 p-2 px-3 border">
+                                        <CategoryCard selectedCategory={post.category || ''} setCategory={onCategorySelect} />
+                                    </div>
+                                </div>
+                                <div className="col-md-6">
+                                    <label className="form-label fw-semibold">지역 선택</label>
+                                    <div className="bg-light rounded-4 p-2 px-3 border">
+                                        <RegionRadioComp selectedRegion={post.region} setRegion={onRegionChange} />
+                                    </div>
+                                </div>
+                            </div>
+                            {imageSection}
+                            <div className="mb-4">
+                                <label htmlFor="content" className="form-label fw-semibold">후기 / 내용</label>
+                                <textarea
+                                    className="form-control" id="content" rows="7"
+                                    required maxLength={2000}
+                                    placeholder="여행지에 대한 후기를 자유롭게 작성해 주세요 :)"
+                                    value={post.content} onChange={onChange}
+                                    style={{ minHeight: 140 }}
+                                />
+                            </div>
+                            <div className={`d-flex pt-2 ${isEdit ? 'justify-content-between' : 'justify-content-end'}`}>
+                                {isEdit && (
+                                    <button
+                                        className="btn btn-danger px-5 py-2 fs-5 fw-bold rounded-pill shadow"
+                                        type="button"
+                                        style={{ minWidth: 140, letterSpacing: '1px' }}
+                                        onClick={onDelete}
+                                    >
+                                        삭제
+                                    </button>
+                                )}
+                                <button
+                                    type="submit"
+                                    className="btn btn-primary px-5 py-2 fs-5 fw-bold rounded-pill shadow"
+                                    style={{ minWidth: 140, letterSpacing: '1px' }}
+                                    disabled={submitDisabled}
+                                >
+                                    {isEdit ? '완료' : '글쓰기'}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default PostForm;

--- a/src/post/pages/PostDetailPage.jsx
+++ b/src/post/pages/PostDetailPage.jsx
@@ -2,14 +2,14 @@ import React, { useEffect, useRef, useState } from "react";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import 'bootstrap-icons/font/bootstrap-icons.css';
-import { Tooltip, Card, Badge, OverlayTrigger, Carousel } from "react-bootstrap";
+import { Card } from "react-bootstrap";
 
 import { getPost } from "../../api/postApi";
 import { toggleFavorite, existsFavorite } from "../../api/favoriteApi";
-import { useSearchParams, Link, useNavigate, useLocation } from "react-router-dom";
+import { useSearchParams, useNavigate, useLocation } from "react-router-dom";
 import CommentPage from "../../comment/component/CommentPage";
-import { categoryColors, regionColors } from "../../constants/colorMaps";
 import useAlert from "../../hooks/useAlert";
+import PostContent from "../components/PostContent";
 
 const PostDetailPage = () => {
   const enterTime = useRef(Date.now());
@@ -23,7 +23,6 @@ const PostDetailPage = () => {
     createdDate: '', modifiedDate: '', ratingAvg: '', viewCount: '', favoriteCount: '', commentCount: ''
   });
   const [commentFlag, setCommentFlag] = useState(false);
-
   const [liked, setLiked] = useState(false);
   const { alert, showAlert } = useAlert(2500);
 
@@ -87,14 +86,6 @@ const PostDetailPage = () => {
     }
   };
 
-  const goToEdit = () => {
-    if (localStorage.getItem('nickname') == post.memberNickname) {
-      navigate(`/post/edit?no=${post.id}`);
-    } else {
-      showAlert("권한이 없습니다.", "danger");
-    }
-  };
-
   useEffect(() => {
     viewBoard();
     getLike();
@@ -151,92 +142,27 @@ const PostDetailPage = () => {
           {alert.message}
         </div>
       )}
-      <div
-        style={{
-          minHeight: "100vh",
-          width: "100vw",
-          overflowX: "hidden",
-          position: "relative"
-        }}
-      >
+      <div style={{ minHeight: "100vh", width: "100vw", overflowX: "hidden", position: "relative" }}>
         <div className="container py-5 mt-5" style={{ minHeight: "100vh", maxWidth: "1600px" }}>
           <div style={{ display: "flex", gap: "32px", width: "95%", margin: "0 auto", alignItems: "stretch" }}>
-            <Card className="shadow-sm flex-fill"
-              style={{ borderRadius: "18px", width: "100%", minWidth: "0", background: "#fff", display: "flex", flexDirection: "column" }}>
-              <Card.Body className="pb-2 pt-4 d-flex flex-column" style={{ flex: 1 }}>
-                {post.imagePaths && post.imagePaths.length > 0 && (
-                  <Carousel
-                    interval={null}
-                    indicators={post.imagePaths.length > 1}
-                    style={{ maxWidth: 800, margin: "0 auto 24px auto", borderRadius: 16, overflow: "hidden", boxShadow: "0 6px 18px #0001" }}
-                  >
-                    {post.imagePaths.map(filename => (
-                      <Carousel.Item key={filename}>
-                        <img
-                          src={`${process.env.REACT_APP_IMAGE_BASE_URL}${filename}`}
-                          alt="uploaded"
-                          style={{ width: "100%", height: 400, objectFit: "cover", display: "block", background: "#eee" }}
-                        />
-                      </Carousel.Item>
-                    ))}
-                  </Carousel>
-                )}
-                <div className="d-flex justify-content-between align-items-start mb-1">
-                  <h4 className="fw-bold mb-1">{post.title}</h4>
-                  <Badge bg={categoryColors[post.category] || "secondary"} style={{ fontSize: "1rem" }}>
-                    {post.category}
-                  </Badge>
-                </div>
-                <div className="mb-2 text-muted" style={{ fontSize: "0.96rem" }}>
-                  조회수: <span className="fw-semibold">{post.viewCount}</span> | 작성자: <span className="fw-semibold">{post.memberNickname ? post.memberNickname : 0}</span> |
-                </div>
-                <hr className="my-2" />
-                <div className="mb-2">
-                  <span className="fw-semibold"><i className="bi bi-geo-alt-fill"></i> 여행지:</span> {post.travelPlace}
-                  <div className="text-muted" style={{ fontSize: "0.97rem" }}>{post.address}</div>
-                </div>
-                <div className="mb-2 d-flex align-items-center justify-content-between">
-                  <div>
-                    <span className="fw-semibold"><i className="bi bi-map-fill"></i> 지역:</span>
-                    <Badge bg={regionColors[post.region] || "secondary"} className="ms-1">{post.region}</Badge>
-                  </div>
-                  {(nickname === post.memberNickname) && (
-                    <OverlayTrigger placement="top" overlay={<Tooltip id="tooltip-edit">수정하기</Tooltip>}>
-                      <Link
-                        to={`/post/edit?no=${post.id}`}
-                        className="btn btn-outline-primary btn-sm ms-2"
-                        style={{ whiteSpace: "nowrap" }}
-                      >
-                        🖊
-                      </Link>
-                    </OverlayTrigger>
-                  )}
-                </div>
-                <Card className="mb-0" style={{ background: "#f7fafc", border: "none" }}>
-                  <Card.Body className="py-2 px-3" style={{ minHeight: "50px", fontSize: "1.08rem", whiteSpace: "pre-line" }}>
-                    {post.content}
-                  </Card.Body>
-                </Card>
-                <div className="d-flex justify-content-between align-items-center mt-auto pt-3">
-                  <button
-                    className={`favorite-btn btn btn-link p-0 heart-btn${liked ? " liked" : ""}`}
-                    data-travel="123"
-                    onClick={handleLike}
-                    style={{ textDecoration: "none" }}
-                    aria-label={liked ? "찜 취소" : "찜하기"}
-                  >
-                    <i className={liked ? "bi bi-heart-fill" : "bi bi-heart"} />
-                    <span className="fw-semibold"> {post.favoriteCount ? post.favoriteCount : 0}</span>
-                  </button>
-                </div>
-              </Card.Body>
-            </Card>
-            <Card className="shadow-sm flex-fill"
-              style={{ borderRadius: "18px", width: "70%", minWidth: "0", background: "#fff", display: "flex", flexDirection: "column" }}>
-              {post.id &&
+            <PostContent post={post} liked={liked} onLike={handleLike} nickname={nickname} />
+            <Card
+              className="shadow-sm flex-fill"
+              style={{ borderRadius: "18px", width: "70%", minWidth: "0", background: "#fff", display: "flex", flexDirection: "column" }}
+            >
+              {post.id && (
                 <Card.Body className="d-flex flex-column py-4" style={{ flex: 1 }}>
-                  <CommentPage no={post.id} isLoggedIn={isLoggedIn} ratingAvg={post.ratingAvg} setCommentFlag={setCommentFlag} category={post.category} region={post.region} title={post.title} />
-                </Card.Body>}
+                  <CommentPage
+                    no={post.id}
+                    isLoggedIn={isLoggedIn}
+                    ratingAvg={post.ratingAvg}
+                    setCommentFlag={setCommentFlag}
+                    category={post.category}
+                    region={post.region}
+                    title={post.title}
+                  />
+                </Card.Body>
+              )}
             </Card>
           </div>
         </div>

--- a/src/post/pages/PostEditPage.jsx
+++ b/src/post/pages/PostEditPage.jsx
@@ -1,11 +1,10 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import RadioPage from '../../board/component/page/RegionRadioComp';
 import { useEffect, useState } from 'react';
 import { getPost, editPost, removePost } from '../../api/postApi';
-import CategoryCard from '../../board/component/page/CategoryCard';
 import useAlert from '../../hooks/useAlert';
+import PostForm from '../components/PostForm';
 
 const PostEditPage = () => {
     const [searchParams] = useSearchParams();
@@ -22,7 +21,6 @@ const PostEditPage = () => {
         region: '',
         imagePaths: []
     });
-
     const [existingImages, setExistingImages] = useState([]);
     const [newImages, setNewImages] = useState([]);
     const [imagePreviews, setImagePreviews] = useState([]);
@@ -52,7 +50,7 @@ const PostEditPage = () => {
 
     useEffect(() => {
         viewBoard();
-        let nickname = localStorage.getItem("nickname");
+        const nickname = localStorage.getItem("nickname");
         if (nickname == null) {
             showAlert("로그인이 필요합니다.", "danger");
             setTimeout(() => navigate(-1), 500);
@@ -114,117 +112,59 @@ const PostEditPage = () => {
         }
     };
 
-    return (
-        <>
-            {alert.show && (
-                <div className={`alert alert-${alert.type} text-center shadow`} role="alert"
-                    style={{ position: "fixed", top: 80, left: "50%", transform: "translateX(-50%)", minWidth: 240, zIndex: 3000 }}>
-                    {alert.message}
-                </div>
-            )}
-            <div className="py-5" style={{ minHeight: "100vh", width: "100vw", overflowX: "hidden", position: "relative" }}>
-                <div className="container my-5" style={{ maxWidth: '900px' }}>
-                    <div className="card shadow-lg border-0 rounded-4 p-4" style={{ background: "#ffffffeb" }}>
-                        <h2 className="mb-3 fw-bold" style={{ textAlign: 'center', letterSpacing: '2px' }}>글 수정</h2>
-                        <div className="text-secondary text-center mb-4" style={{ fontSize: '1.07rem' }}>
-                            여행지, 사진, 지역, 카테고리, 후기를 모두 입력해 주세요!
+    const imageSection = (
+        <div className="mb-4">
+            <label className="form-label fw-semibold">
+                사진 첨부 <span className="text-secondary" style={{ fontSize: "0.95em" }}>(여러 장 첨부 가능)</span>
+            </label>
+            <div className="bg-light rounded-4 p-3 px-4 border">
+                <input type="file" accept="image/*" multiple onChange={handleImageChange} className="form-control mb-3" />
+                <div className="d-flex flex-wrap gap-3">
+                    {existingImages.map((src, idx) => (
+                        <div key={`exist-${idx}`} style={{ position: 'relative' }}>
+                            <img
+                                src={src.startsWith('/images/') ? `${process.env.REACT_APP_IMAGE_BASE_URL}${src}` : src}
+                                alt={`preview-exist-${idx}`}
+                                style={{ width: 100, height: 100, objectFit: 'cover', borderRadius: 14, border: '1px solid #eee', boxShadow: "0 2px 6px rgba(0,0,0,0.06)" }}
+                            />
+                            <button
+                                type="button" className="btn btn-danger btn-sm"
+                                style={{ position: 'absolute', top: 5, right: 5, borderRadius: '50%', padding: '2px 7px', fontSize: "1.05rem" }}
+                                onClick={() => handleExistingImageRemove(idx)}
+                            >×</button>
                         </div>
-                        <div className="mb-4 d-flex justify-content-end">
-                            <span className="fw-semibold" style={{ fontSize: '1.08rem', color: '#222', marginRight: 6 }}>작성자:</span>
-                            <span className="fw-bold" style={{ fontSize: '1.08rem', minWidth: 80, display: 'inline-block' }}>
-                                {post.memberNickname || ""}
-                            </span>
+                    ))}
+                    {newImages.map((file, idx) => (
+                        <div key={`new-${idx}`} style={{ position: 'relative' }}>
+                            <img
+                                src={imagePreviews[existingImages.length + idx]}
+                                alt={`preview-new-${idx}`}
+                                style={{ width: 100, height: 100, objectFit: 'cover', borderRadius: 14, border: '1px solid #eee', boxShadow: "0 2px 6px rgba(0,0,0,0.06)" }}
+                            />
+                            <button
+                                type="button" className="btn btn-danger btn-sm"
+                                style={{ position: 'absolute', top: 5, right: 5, borderRadius: '50%', padding: '2px 7px', fontSize: "1.05rem" }}
+                                onClick={() => handleNewImageRemove(idx)}
+                            >×</button>
                         </div>
-                        <form onSubmit={handleSubmit}>
-                            <div className="mb-4">
-                                <label htmlFor="title" className="form-label fw-semibold">제목</label>
-                                <input type="text" className="form-control form-control-lg" id="title"
-                                    required maxLength={40} placeholder="제목을 입력하세요"
-                                    value={post.title} onChange={handleChange} />
-                            </div>
-                            <div className="row g-3 mb-4">
-                                <div className="col-md-5">
-                                    <label htmlFor="travelPlace" className="form-label fw-semibold">여행지 이름</label>
-                                    <input type="text" className="form-control" id="travelPlace"
-                                        required placeholder="예: 남산타워"
-                                        value={post.travelPlace} onChange={handleChange} />
-                                </div>
-                                <div className="col-md-7">
-                                    <label htmlFor="address" className="form-label fw-semibold">여행지 주소</label>
-                                    <input type="text" className="form-control" id="address"
-                                        required placeholder="예: 서울특별시 중구 남산공원길 105"
-                                        value={post.address} onChange={handleChange} />
-                                </div>
-                            </div>
-                            <div className="row g-3 mb-4">
-                                <div className="col-md-6">
-                                    <label className="form-label fw-semibold">카테고리</label>
-                                    <div className="bg-light rounded-4 p-2 px-3 border">
-                                        <CategoryCard selectedCategory={post.category || ''} setCategory={handleCategorySelect} />
-                                    </div>
-                                </div>
-                                <div className="col-md-6">
-                                    <label className="form-label fw-semibold">지역 선택</label>
-                                    <div className="bg-light rounded-4 p-2 px-3 border">
-                                        <RadioPage selectedRegion={post.region} setRegion={handleRegionChange} />
-                                    </div>
-                                </div>
-                            </div>
-                            <div className="mb-4">
-                                <label className="form-label fw-semibold">사진 첨부 <span className="text-secondary" style={{ fontSize: "0.95em" }}>(여러 장 첨부 가능)</span></label>
-                                <div className="bg-light rounded-4 p-3 px-4 border">
-                                    <input type="file" accept="image/*" multiple onChange={handleImageChange} className="form-control mb-3" />
-                                    <div className="d-flex flex-wrap gap-3">
-                                        {existingImages.map((src, idx) => (
-                                            <div key={`exist-${idx}`} style={{ position: 'relative' }}>
-                                                <img
-                                                    src={src.startsWith('/images/') ? `${process.env.REACT_APP_IMAGE_BASE_URL}${src}` : src}
-                                                    alt={`preview-exist-${idx}`}
-                                                    style={{ width: 100, height: 100, objectFit: 'cover', borderRadius: 14, border: '1px solid #eee', boxShadow: "0 2px 6px rgba(0,0,0,0.06)" }}
-                                                />
-                                                <button type="button" className="btn btn-danger btn-sm"
-                                                    style={{ position: 'absolute', top: 5, right: 5, borderRadius: '50%', padding: '2px 7px', fontSize: "1.05rem" }}
-                                                    onClick={() => handleExistingImageRemove(idx)}>×</button>
-                                            </div>
-                                        ))}
-                                        {newImages.map((file, idx) => (
-                                            <div key={`new-${idx}`} style={{ position: 'relative' }}>
-                                                <img src={imagePreviews[existingImages.length + idx]}
-                                                    alt={`preview-new-${idx}`}
-                                                    style={{ width: 100, height: 100, objectFit: 'cover', borderRadius: 14, border: '1px solid #eee', boxShadow: "0 2px 6px rgba(0,0,0,0.06)" }}
-                                                />
-                                                <button type="button" className="btn btn-danger btn-sm"
-                                                    style={{ position: 'absolute', top: 5, right: 5, borderRadius: '50%', padding: '2px 7px', fontSize: "1.05rem" }}
-                                                    onClick={() => handleNewImageRemove(idx)}>×</button>
-                                            </div>
-                                        ))}
-                                    </div>
-                                </div>
-                            </div>
-                            <div className="mb-4">
-                                <label htmlFor="content" className="form-label fw-semibold">후기 / 내용</label>
-                                <textarea className="form-control" id="content" rows="7"
-                                    required maxLength={2000}
-                                    placeholder="여행지에 대한 후기를 자유롭게 작성해 주세요 :)"
-                                    value={post.content} onChange={handleChange} style={{ minHeight: 140 }}></textarea>
-                            </div>
-                            <div className="d-flex justify-content-between pt-2">
-                                <button className="btn btn-danger px-5 py-2 fs-5 fw-bold rounded-pill shadow"
-                                    type="button" style={{ minWidth: 140, letterSpacing: '1px' }}
-                                    onClick={removeBoard}>
-                                    삭제
-                                </button>
-                                <button type="submit"
-                                    className="btn btn-primary px-5 py-2 fs-5 fw-bold rounded-pill shadow"
-                                    style={{ minWidth: 140, letterSpacing: '1px' }}>
-                                    완료
-                                </button>
-                            </div>
-                        </form>
-                    </div>
+                    ))}
                 </div>
             </div>
-        </>
+        </div>
+    );
+
+    return (
+        <PostForm
+            post={post}
+            mode="edit"
+            onChange={handleChange}
+            onCategorySelect={handleCategorySelect}
+            onRegionChange={handleRegionChange}
+            onSubmit={handleSubmit}
+            onDelete={removeBoard}
+            imageSection={imageSection}
+            alert={alert}
+        />
     );
 };
 

--- a/src/post/pages/PostWritePage.jsx
+++ b/src/post/pages/PostWritePage.jsx
@@ -1,11 +1,10 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { useNavigate } from 'react-router-dom';
-import RegionRadioComp from '../../board/component/page/RegionRadioComp';
 import { addPost } from '../../api/postApi';
 import { useState, useEffect } from 'react';
-import CategoryCard from '../../board/component/page/CategoryCard';
 import useAlert from '../../hooks/useAlert';
+import PostForm from '../components/PostForm';
 
 const PostWritePage = () => {
     const navigate = useNavigate();
@@ -18,13 +17,12 @@ const PostWritePage = () => {
         category: '',
         region: ''
     });
-
     const [images, setImages] = useState([]);
     const [imagePreviews, setImagePreviews] = useState([]);
     const { alert, showAlert } = useAlert(500);
 
     useEffect(() => {
-        let nickname = localStorage.getItem("nickname");
+        const nickname = localStorage.getItem("nickname");
         if (!nickname) {
             showAlert("로그인이 필요합니다.", "danger");
             setTimeout(() => navigate(-1), 500);
@@ -77,93 +75,44 @@ const PostWritePage = () => {
         }
     };
 
-    return (
-        <div style={{ minHeight: "100vh", width: "100vw", overflowX: "hidden", position: "relative" }}>
-            {alert.show && (
-                <div className={`alert alert-${alert.type} text-center mb-3`} role="alert"
-                    style={{ position: "fixed", top: 80, left: "50%", transform: "translateX(-50%)", minWidth: 220, zIndex: 2000 }}>
-                    {alert.message}
-                </div>
-            )}
-            <div className="container my-5" style={{ maxWidth: '900px' }}>
-                <div className="card shadow-lg border-0 rounded-4 p-4" style={{ background: "#ffffffeb" }}>
-                    <h2 className="mb-3 text-center fw-bold" style={{ letterSpacing: '2px' }}>글 작성</h2>
-                    <div className="text-secondary text-center mb-4" style={{ fontSize: '1.07rem' }}>
-                        여행지, 사진, 지역, 카테고리, 후기를 모두 입력해 주세요!
-                    </div>
-                    <form onSubmit={handleSubmit}>
-                        <div className="mb-4">
-                            <label htmlFor="title" className="form-label fw-semibold">제목</label>
-                            <input type="text" className="form-control form-control-lg" id="title"
-                                required maxLength={40} placeholder="제목을 입력하세요"
-                                value={post.title} onChange={handleChange} />
+    const imageSection = (
+        <div className="mb-4">
+            <label className="form-label fw-semibold">
+                사진 첨부 <span className="text-secondary" style={{ fontSize: "0.95em" }}>(필수)</span>
+            </label>
+            <div className="bg-light rounded-4 p-3 px-4 border">
+                <input type="file" accept="image/*" multiple onChange={handleImageChange} className="form-control mb-3" />
+                <div className="d-flex flex-wrap gap-3">
+                    {imagePreviews.map((src, idx) => (
+                        <div key={idx} style={{ position: 'relative' }}>
+                            <img
+                                src={src} alt={`preview-${idx}`}
+                                style={{ width: 100, height: 100, objectFit: 'cover', borderRadius: 14, border: '1px solid #eee', boxShadow: "0 2px 6px rgba(0,0,0,0.06)" }}
+                            />
+                            <button
+                                type="button" className="btn btn-danger btn-sm"
+                                style={{ position: 'absolute', top: 5, right: 5, borderRadius: '50%', padding: '2px 7px', fontSize: "1.05rem" }}
+                                onClick={() => handleImageRemove(idx)}
+                            >×</button>
                         </div>
-                        <div className="row g-3 mb-4">
-                            <div className="col-md-5">
-                                <label htmlFor="travelPlace" className="form-label fw-semibold">여행지 이름</label>
-                                <input type="text" className="form-control" id="travelPlace"
-                                    required placeholder="예: 남산타워"
-                                    value={post.travelPlace} onChange={handleChange} />
-                            </div>
-                            <div className="col-md-7">
-                                <label htmlFor="address" className="form-label fw-semibold">여행지 주소</label>
-                                <input type="text" className="form-control" id="address"
-                                    required placeholder="예: 서울특별시 중구 남산공원길 105"
-                                    value={post.address} onChange={handleChange} />
-                            </div>
-                        </div>
-                        <div className="row g-3 mb-4">
-                            <div className="col-md-6 ">
-                                <label className="form-label fw-semibold">카테고리</label>
-                                <div className="bg-light rounded-4 p-2 px-3 border">
-                                    <CategoryCard selectedCategory={post.category} setCategory={handleCategorySelect} />
-                                </div>
-                            </div>
-                            <div className="col-md-6">
-                                <label className="form-label fw-semibold">지역 선택</label>
-                                <div className="bg-light rounded-4 p-2 px-3 border">
-                                    <RegionRadioComp selectedRegion={post.region} setRegion={handleRegionChange} />
-                                </div>
-                            </div>
-                        </div>
-                        <div className="mb-4">
-                            <label className="form-label fw-semibold">
-                                사진 첨부 <span className="text-secondary" style={{ fontSize: "0.95em" }}>(필수)</span>
-                            </label>
-                            <div className="bg-light rounded-4 p-3 px-4 border">
-                                <input type="file" accept="image/*" multiple onChange={handleImageChange} className="form-control mb-3" />
-                                <div className="d-flex flex-wrap gap-3">
-                                    {imagePreviews.map((src, idx) => (
-                                        <div key={idx} style={{ position: 'relative' }}>
-                                            <img src={src} alt={`preview-${idx}`}
-                                                style={{ width: 100, height: 100, objectFit: 'cover', borderRadius: 14, border: '1px solid #eee', boxShadow: "0 2px 6px rgba(0,0,0,0.06)" }} />
-                                            <button type="button" className="btn btn-danger btn-sm"
-                                                style={{ position: 'absolute', top: 5, right: 5, borderRadius: '50%', padding: '2px 7px', fontSize: "1.05rem" }}
-                                                onClick={() => handleImageRemove(idx)}>×</button>
-                                        </div>
-                                    ))}
-                                </div>
-                            </div>
-                        </div>
-                        <div className="mb-4">
-                            <label htmlFor="content" className="form-label fw-semibold">후기 / 내용</label>
-                            <textarea className="form-control" id="content" rows="7"
-                                required maxLength={2000}
-                                placeholder="여행지에 대한 후기를 자유롭게 작성해 주세요 :)"
-                                value={post.content} onChange={handleChange} style={{ minHeight: 140 }}></textarea>
-                        </div>
-                        <div className="d-flex justify-content-end pt-2">
-                            <button type="submit"
-                                className="btn btn-primary px-5 py-2 fs-5 fw-bold rounded-pill shadow"
-                                style={{ minWidth: 140, letterSpacing: '1px' }}
-                                disabled={images.length === 0}>
-                                글쓰기
-                            </button>
-                        </div>
-                    </form>
+                    ))}
                 </div>
             </div>
         </div>
+    );
+
+    return (
+        <PostForm
+            post={post}
+            mode="write"
+            onChange={handleChange}
+            onCategorySelect={handleCategorySelect}
+            onRegionChange={handleRegionChange}
+            onSubmit={handleSubmit}
+            imageSection={imageSection}
+            alert={alert}
+            submitDisabled={images.length === 0}
+        />
     );
 };
 

--- a/src/sign/component/SignUpPage.jsx
+++ b/src/sign/component/SignUpPage.jsx
@@ -1,136 +1,29 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
-import { useState, useEffect, useRef } from 'react';
-import { toast } from 'react-toastify';
-import { checkDuplicate, signUp } from '../../api/signApi';
-import { useNavigate } from 'react-router-dom';
-
-const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+~\-=\[\]{};':"\\|,.<>\/?]).{8,}$/;
-const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-
+import { useEffect } from 'react';
+import useSignUpForm from '../../hooks/useSignUpForm';
 
 const SignUpPage = () => {
-    const navigate = useNavigate();
-    const [formData, setFormData] = useState({
-        loginId: '',
-        password: '',
-        passwordConfirm: '',
-        email: '',
-        nickname: '',
-        gender: '',
-    });
-    const [birthDate, setBirthDate] = useState('');
-    const [alert, setAlert] = useState({ show: false, message: '', type: '' });
-    const [touched, setTouched] = useState({});
-    const [errors, setErrors] = useState({});
-    const [isSubmitting, setIsSubmitting] = useState(false);
-    const [dups, setDups] = useState({
-        loginId: null,  // true: 중복, false: 사용가능, null: 미확인
-        email: null,
-        nickname: null,
-    });
-    const inputRefs = {
-        loginId: useRef(null),
-        password: useRef(null),
-        passwordConfirm: useRef(null),
-        nickname: useRef(null),
-        email: useRef(null),
-        gender: useRef(null),
-        birthDate: useRef(null)
-    };
-
-    // 값 변경
-
-    const handleChange = (e) => {
-        const { name, value } = e.target;
-        setFormData(prev => ({ ...prev, [name]: value }));
-        setTouched(prev => ({ ...prev, [name]: true }));
-        // 중복 체크 항목은 변경시 중복상태 초기화
-        if (['loginId', 'email', 'nickname'].includes(name)) {
-            setDups(prev => ({ ...prev, [name]: null }));
-        }
-    };
-
-    // 중복체크 (디바운스 포함, 즉시 변경시 API 너무 많이 나가는 것 방지)
-    useEffect(() => {
-        const debounce = {};
-        ["loginId", "email", "nickname"].forEach(field => {
-            if (!formData[field]) return;
-            if (debounce[field]) clearTimeout(debounce[field]);
-            debounce[field] = setTimeout(async () => {
-                try {
-                    const { data } = await checkDuplicate({ type: field, value: formData[field] });
-                    setDups(prev => ({ ...prev, [field]: !!data.exists }));
-                } catch {
-                    setDups(prev => ({ ...prev, [field]: false }));
-                }
-            }, 500);
-        });
-        return () => Object.values(debounce).forEach(clearTimeout);
-        // eslint-disable-next-line
-    }, [formData.loginId, formData.email, formData.nickname]);
-
-
-    // 생년월일
-    const handleBirthDate = (e) => {
-        setBirthDate(e.target.value);
-        setTouched(prev => ({ ...prev, birthDate: true }));
-    };
-
-    // 유효성 검사
-    useEffect(() => {
-        const newErrors = {};
-        if (!formData.loginId) newErrors.loginId = "아이디를 입력하세요.";
-        else if (dups.loginId === true) newErrors.loginId = "이미 사용중인 아이디입니다.";
-        if (!formData.password) newErrors.password = "비밀번호를 입력하세요.";
-        else if (!passwordPattern.test(formData.password)) newErrors.password = "8자 이상, 영문/숫자/특수문자 조합으로 입력하세요.";
-        if (!formData.passwordConfirm) newErrors.passwordConfirm = "비밀번호 확인을 입력하세요.";
-        else if (formData.password && formData.password !== formData.passwordConfirm) newErrors.passwordConfirm = "비밀번호가 일치하지 않습니다.";
-        if (!formData.nickname) newErrors.nickname = "닉네임을 입력하세요.";
-        else if (dups.nickname === true) newErrors.nickname = "이미 사용중인 닉네임입니다.";
-        if (!formData.email) newErrors.email = "이메일을 입력하세요.";
-        else if (!emailPattern.test(formData.email)) newErrors.email = "이메일 형식이 올바르지 않습니다.";
-        else if (dups.email === true) newErrors.email = "이미 사용중인 이메일입니다.";
-        if (!formData.gender) newErrors.gender = "성별을 선택하세요.";
-        if (!birthDate) newErrors.birthDate = "생년월일을 입력하세요.";
-        setErrors(newErrors);
-    }, [formData, birthDate, dups]);
-
-    // 제출
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        setTouched({
-            loginId: true, password: true, passwordConfirm: true, nickname: true, email: true, gender: true, birthDate: true
-        });
-        if (Object.keys(errors).length > 0) {
-            // 첫 에러 필드로 focus
-            const firstError = Object.keys(errors)[0];
-            inputRefs[firstError]?.current?.focus();
-            setAlert({ show: true, message: "모든 항목을 올바르게 입력해주세요.", type: "danger" });
-            return;
-        }
-        setIsSubmitting(true);
-        try {
-            await signUp({ ...formData, birthDate });
-            toast.success("회원가입이 완료되었습니다! 🎉");
-            navigate("/");
-        } catch (error) {
-            const msg = error.response?.data;
-            setAlert({ show: true, message: msg?.message || "에러가 발생했습니다.", type: "danger" });
-            if (msg?.field && inputRefs[msg.field]) {
-                inputRefs[msg.field].current.focus();
-            }
-        }
-        setIsSubmitting(false);
-    };
+    const {
+        formData,
+        birthDate,
+        alert,
+        setAlert,
+        touched,
+        errors,
+        isSubmitting,
+        dups,
+        isFormValid,
+        inputRefs,
+        handleChange,
+        handleBirthDate,
+        handleSubmit,
+    } = useSignUpForm();
 
     useEffect(() => {
         document.body.classList.add('bg-body-tertiary');
         return () => document.body.classList.remove('bg-body-tertiary');
     }, []);
-    // 모든 조건 충족해야 버튼 활성화
-    const isFormValid = Object.keys(errors).length === 0 && !isSubmitting;
 
     return (
         <div className="min-vh-100 d-flex flex-column" style={{
@@ -259,7 +152,6 @@ const SignUpPage = () => {
                                 )}
                             </div>
 
-                            {/* 성별 */}
                             <div className="mb-3">
                                 <label className="form-label fw-semibold d-block mb-2">성별</label>
                                 <div className="form-check form-check-inline">


### PR DESCRIPTION
## 관련 이슈
closes #27

## 변경 사항
- `src/post/components/PostForm.jsx` 신규 생성: PostWritePage/PostEditPage 공통 폼 컴포넌트 추출
- `src/post/components/PostContent.jsx` 신규 생성: PostDetailPage 본문/이미지/좋아요 UI 분리
- `src/hooks/useSignUpForm.js` 신규 생성: SignUpPage 폼 상태/유효성 검사/중복 체크 디바운스/제출 로직 훅 분리
- `src/common/NavMenu.jsx` 신규 생성: Navbar Offcanvas 메뉴 컴포넌트 분리
- PostWritePage, PostEditPage, PostDetailPage, SignUpPage, Navbar 단순화

## 작업 방법
- PostForm: mode prop(write/edit)으로 분기, 이미지 섹션은 각 페이지에서 JSX로 주입 (write/edit 이미지 로직 상이)
- PostContent: 카드 + 캐러셀 + 배지 + 위치 + 내용 + 좋아요 버튼 포함, PostDetailPage는 데이터 페칭 + Matomo 트래킹만 담당
- useSignUpForm: useRef(inputRefs) 포함한 모든 폼 로직 훅으로 이동, SignUpPage는 JSX 렌더링만 담당
- NavMenu: Offcanvas + MenuLink 서브컴포넌트 분리, Navbar는 nav바 구조 + 상태 관리만 담당
- Matomo window.dataLayer 추적 코드 전부 보존

## 테스트
- [ ] 글 작성 (PostWritePage → PostForm write 모드)
- [ ] 글 수정/삭제 (PostEditPage → PostForm edit 모드)
- [ ] 게시글 상세 (PostDetailPage + PostContent)
- [ ] 좋아요/찜 기능 및 Matomo 트래킹
- [ ] 회원가입 (SignUpPage + useSignUpForm)
- [ ] 네비게이션 메뉴 (Navbar + NavMenu)