### PR TITLE
♻️ Refactor: Phase A - API Endpoint Swagger 기준 정합

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -1,0 +1,13 @@
+import apiClient from './client';
+
+export const login = (payload) =>
+  apiClient.post('/api/v1/auth/login', payload);
+
+export const logout = () =>
+  apiClient.post('/api/v1/auth/logout');
+
+export const refreshTokens = () =>
+  apiClient.post('/api/v1/auth/tokens/refresh');
+
+export const oauth2Tokens = (payload) =>
+  apiClient.post('/api/v1/auth/oauth2/tokens', payload);

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -52,14 +52,15 @@ apiClient.interceptors.response.use(
 
       try {
         const { data } = await axios.post(
-          `${BASE_URL}/api/sign/refresh`,
+          `${BASE_URL}/api/v1/auth/tokens/refresh`,
           {},
           { withCredentials: true }
         );
-        localStorage.setItem("accessToken", data.accessToken);
-        apiClient.defaults.headers.common.Authorization = `Bearer ${data.accessToken}`;
-        processQueue(null, data.accessToken);
-        originalRequest.headers.Authorization = `Bearer ${data.accessToken}`;
+        const accessToken = data.result?.accessToken ?? data.accessToken;
+        localStorage.setItem("accessToken", accessToken);
+        apiClient.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+        processQueue(null, accessToken);
+        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
         return apiClient(originalRequest);
       } catch (refreshError) {
         processQueue(refreshError, null);

--- a/src/api/commentApi.js
+++ b/src/api/commentApi.js
@@ -1,10 +1,21 @@
 import apiClient from './client';
 
-export const getCommentList = (no) =>
-  apiClient.get('/api/comment/list', { params: { no } });
-
+// 댓글 작성
 export const addComment = (payload) =>
-  apiClient.post('/api/comment/add', payload);
+  apiClient.post('/api/v1/comments', payload);
 
-export const removeComment = (commentId) =>
-  apiClient.post('/api/comment/remove', null, { params: { commentId } });
+// 댓글 수정
+export const updateComment = (commentId, payload) =>
+  apiClient.patch(`/api/v1/comments/${commentId}`, payload);
+
+// 댓글 삭제
+export const deleteComment = (commentId) =>
+  apiClient.delete(`/api/v1/comments/${commentId}`);
+
+// 게시글별 댓글 조회
+export const getCommentList = (postId, { page, size, sort } = {}) =>
+  apiClient.get('/api/v1/search/comments', { params: { postId, page, size, sort } });
+
+// 내가 쓴 댓글 조회
+export const getMyComments = ({ page, size } = {}) =>
+  apiClient.get('/api/v1/search/comments/me', { params: { page, size } });

--- a/src/api/likeApi.js
+++ b/src/api/likeApi.js
@@ -1,0 +1,13 @@
+import apiClient from './client';
+
+// 좋아요 등록
+export const addLike = (postId) =>
+  apiClient.post('/api/v1/likes', { postId });
+
+// 좋아요 취소
+export const deleteLike = (postId) =>
+  apiClient.delete('/api/v1/likes', { data: { postId } });
+
+// 내가 좋아요 한 게시글 목록
+export const getMyLikes = ({ page, size } = {}) =>
+  apiClient.get('/api/v1/search/likes/me', { params: { page, size } });

--- a/src/api/memberApi.js
+++ b/src/api/memberApi.js
@@ -1,0 +1,51 @@
+import apiClient from './client';
+
+// 회원가입
+export const signUp = (payload) =>
+  apiClient.post('/api/v1/members', payload);
+
+// 내 프로필 조회
+export const getMyProfile = () =>
+  apiClient.get('/api/v1/members/me');
+
+// 내 정보 수정 (닉네임)
+export const updateMyProfile = (payload) =>
+  apiClient.patch('/api/v1/members/me', payload);
+
+// 회원 탈퇴
+export const deleteMyProfile = () =>
+  apiClient.delete('/api/v1/members/me');
+
+// 비밀번호 변경
+export const changePassword = (payload) =>
+  apiClient.patch('/api/v1/members/me/password', payload);
+
+// 닉네임 중복 확인
+export const checkNickname = (nickname) =>
+  apiClient.get('/api/v1/members/availability/nickname', { params: { nickname } });
+
+// 로그인 ID 중복 확인
+export const checkLoginId = (loginId) =>
+  apiClient.get('/api/v1/members/availability/login-id', { params: { loginId } });
+
+// 이메일 중복 확인
+export const checkEmail = (email) =>
+  apiClient.get('/api/v1/members/availability/email', { params: { email } });
+
+// === Admin ===
+
+// 전체 회원 목록
+export const getAdminMembers = () =>
+  apiClient.get('/api/v1/admin/members');
+
+// 회원 상세
+export const getAdminMember = (memberId) =>
+  apiClient.get(`/api/v1/admin/members/${memberId}`);
+
+// 관리자 권한 부여
+export const updateMemberRole = (memberId) =>
+  apiClient.patch(`/api/v1/admin/members/${memberId}/role`);
+
+// 회원 강제 탈퇴
+export const deleteAdminMember = (memberId) =>
+  apiClient.delete(`/api/v1/admin/members/${memberId}`);

--- a/src/api/postApi.js
+++ b/src/api/postApi.js
@@ -1,25 +1,17 @@
 import apiClient from './client';
 
-export const getPostListBySearch = ({ keyword, category, region, sort, direction, page }) =>
-  apiClient.get('/api/board/search', { params: { keyword, category, region, sort, direction, page } });
+// 게시글 생성
+export const createPost = (payload) =>
+  apiClient.post('/api/v1/posts', payload);
 
-export const autoCompleteSearch = (keyword, signal) =>
-  apiClient.get('/api/board/autocomplete', { params: { keyword: encodeURIComponent(keyword) }, signal });
+// 게시글 수정
+export const updatePost = (postId, payload) =>
+  apiClient.patch(`/api/v1/posts/${postId}`, payload);
 
-export const getPostList = () =>
-  apiClient.get('/api/board/list');
+// 게시글 삭제
+export const deletePost = (postId) =>
+  apiClient.delete(`/api/v1/posts/${postId}`);
 
-export const getPost = (no) =>
-  apiClient.get('/api/board/view', { params: { no } });
-
-export const addPost = (formData) =>
-  apiClient.post('/api/board/add', formData);
-
-export const editPost = (formData) =>
-  apiClient.post('/api/board/edit', formData);
-
-export const removePost = (no) =>
-  apiClient.post('/api/board/remove', null, { params: { no } });
-
-export const migratePost = () =>
-  apiClient.post('/api/board/admin/migrate-data');
+// 이미지 업로드용 Presigned URL 발급
+export const getPresignedUrl = () =>
+  apiClient.get('/api/v1/posts/images/presigned-url');

--- a/src/api/postSearchApi.js
+++ b/src/api/postSearchApi.js
@@ -1,0 +1,17 @@
+import apiClient from './client';
+
+// 게시글 통합 검색
+export const getPostListBySearch = ({ keyword, category, region, sort, direction, page, size } = {}) =>
+  apiClient.get('/api/v1/search/posts', { params: { keyword, category, region, sort, direction, page, size } });
+
+// 게시글 상세 조회
+export const getPost = (postId) =>
+  apiClient.get(`/api/v1/search/posts/${postId}`);
+
+// 내 게시글 검색
+export const getMyPosts = ({ page, size } = {}) =>
+  apiClient.get('/api/v1/search/posts/me', { params: { page, size } });
+
+// 검색어 자동완성
+export const autoCompleteSearch = (keyword, signal) =>
+  apiClient.get('/api/v1/search/posts/autocomplete', { params: { keyword }, signal });

--- a/src/api/rankingApi.js
+++ b/src/api/rankingApi.js
@@ -1,0 +1,5 @@
+const BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000';
+
+// 실시간 랭킹 SSE 구독 — EventSource 인스턴스를 반환
+export const subscribeRankings = () =>
+  new EventSource(`${BASE_URL}/api/v1/rankings/live`, { withCredentials: true });

--- a/src/board/component/page/AdmnBoard.jsx
+++ b/src/board/component/page/AdmnBoard.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { getPostList, getPostListBySearch, removePost, migratePost } from "../../../api/postApi";
+import { getPostListBySearch } from "../../../api/postSearchApi";
+import { deletePost } from "../../../api/postApi";
 import { useNavigate } from "react-router-dom";
 import { Badge } from "react-bootstrap";
 import { toast } from "react-toastify";
@@ -88,22 +89,15 @@ const BoardList = ({ title, boards, loading, error, categoryColors, regionColors
 );
 
 const AdmnBoard = () => {
-    const [mysqlBoards, setMysqlBoards] = useState([]);
     const [esBoards, setEsBoards] = useState([]);
-    const [mysqlLoading, setMysqlLoading] = useState(false);
     const [esLoading, setEsLoading] = useState(false);
-    const [mysqlError, setMysqlError] = useState(null);
     const [esError, setEsError] = useState(null);
     const [showConfirm, setShowConfirm] = useState(false);
     const [removeTarget, setRemoveTarget] = useState(null);
 
-    const MYSQL_PAGE_SIZE = 10;
     const ES_PAGE_SIZE = 10;
-    const [mysqlPage, setMysqlPage] = useState(0);
     const [esPage, setEsPage] = useState(0);
     const [esDocCount, setEsDocCount] = useState(0);
-
-    const pagedMysqlBoards = mysqlBoards.slice(mysqlPage * MYSQL_PAGE_SIZE, (mysqlPage + 1) * MYSQL_PAGE_SIZE);
 
     const categoryColors = {
         축제: "danger", 공연: "primary", 행사: "success", 체험: "warning",
@@ -126,36 +120,14 @@ const AdmnBoard = () => {
 
     const removeBoard = async () => {
         try {
-            await removePost(removeTarget);
+            await deletePost(removeTarget);
             toast.success("삭제에 성공했습니다.");
-            getMysqlBoards();
             getEsBoards();
         } catch {
             toast.error("삭제에 실패했습니다.");
         } finally {
             setShowConfirm(false);
             setRemoveTarget(null);
-        }
-    };
-
-    const migrateData = async () => {
-        try {
-            await migratePost();
-            toast.success("동기화에 성공했습니다.");
-        } catch {
-            toast.error("동기화에 실패했습니다.");
-        }
-    };
-
-    const getMysqlBoards = async () => {
-        setMysqlLoading(true);
-        try {
-            const { data } = await getPostList();
-            setMysqlBoards(data);
-        } catch (e) {
-            setMysqlError(e);
-        } finally {
-            setMysqlLoading(false);
         }
     };
 
@@ -173,13 +145,12 @@ const AdmnBoard = () => {
     };
 
     useEffect(() => {
-        getMysqlBoards();
         getEsBoards(0);
     }, []);
 
     const navigate = useNavigate();
     const handleGoDetail = (board) => navigate(`/post/detail?no=${board.id}`);
-    const handleMysqlPageChange = (newPage) => setMysqlPage(newPage);
+
     const handleEsPageChange = (newPage) => {
         setEsPage(newPage);
         getEsBoards(newPage);
@@ -215,35 +186,19 @@ const AdmnBoard = () => {
             <div className="container" style={{ maxWidth: 1500, paddingBottom: 40 }}>
                 <h2 className="fw-bold">여행지 관리</h2>
                 <div className="row g-4">
-                    <div className="col-12 col-md-6">
+                    <div className="col-12">
                         <div className="panel-bg p-4 rounded-4 h-100 shadow-sm" style={{ background: "rgba(250,251,255,0.97)", minHeight: 540 }}>
                             <BoardList
-                                title={<span className="text-primary"><i className="bi bi-database me-1"></i>MySQL 게시글</span>}
-                                boards={pagedMysqlBoards} loading={mysqlLoading} error={mysqlError}
-                                categoryColors={categoryColors} regionColors={regionColors}
-                                formatDate={formatDate} onRemove={handleRemove} onClickCard={handleGoDetail}
-                            />
-                            <Pagination total={mysqlBoards.length} page={mysqlPage} onChange={handleMysqlPageChange} pageSize={MYSQL_PAGE_SIZE} />
-                        </div>
-                    </div>
-                    <div className="col-12 col-md-6">
-                        <div className="panel-bg p-4 rounded-4 h-100 shadow-sm" style={{ background: "rgba(250,251,255,0.97)", minHeight: 540 }}>
-                            <BoardList
-                                title={<span className="text-info"><i className="bi bi-search me-1"></i>Elasticsearch 게시글</span>}
+                                title={<span className="text-info"><i className="bi bi-search me-1"></i>게시글 목록</span>}
                                 boards={esBoards} loading={esLoading} error={esError}
                                 categoryColors={categoryColors} regionColors={regionColors}
-                                formatDate={formatDate} onClickCard={handleGoDetail}
+                                formatDate={formatDate} onRemove={handleRemove} onClickCard={handleGoDetail}
                             />
                             <Pagination total={esDocCount} page={esPage} onChange={handleEsPageChange} pageSize={ES_PAGE_SIZE} />
                         </div>
                     </div>
                 </div>
-                <div className="d-flex justify-content-end my-3">
-                    <button className="btn btn-danger mb-4 px-4 fw-semibold shadow-sm" onClick={migrateData}
-                        style={{ borderRadius: "1.4rem" }}>
-                        <i className="bi bi-cloud-arrow-up me-2"></i>DB 동기화 (MySQL → ES)
-                    </button>
-                </div>
+
             </div>
             <style>
                 {`

--- a/src/comment/component/CommentPage.jsx
+++ b/src/comment/component/CommentPage.jsx
@@ -33,7 +33,7 @@ const CommentPage = ({ no, isLoggedIn, ratingAvg, setCommentFlag, category, regi
     const getCommentList = async () => {
         try {
             const { data } = await commentApi.getCommentList(no);
-            setCommentList(data);
+            setCommentList(data.result?.content ?? data.result ?? data);
         } catch {}
     };
 
@@ -45,7 +45,8 @@ const CommentPage = ({ no, isLoggedIn, ratingAvg, setCommentFlag, category, regi
             onConfirm: async () => {
                 setModal(prev => ({ ...prev, show: false }));
                 try {
-                    const { data: message } = await commentApi.removeComment(commentId);
+                    await commentApi.deleteComment(commentId);
+                    const message = "댓글이 삭제되었습니다.";
                     setAlert({ show: true, message, type: "success" });
                     window.dataLayer = window.dataLayer || [];
                     window.dataLayer.push({ event: "travel_comment_remove", boardId: no, category, region, title });

--- a/src/common/ChckMyCom.jsx
+++ b/src/common/ChckMyCom.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import "bootstrap/dist/css/bootstrap.min.css";
-import { getMyComment } from "../api/commonApi";
+import { getMyComments } from "../api/commentApi";
 import { useNavigate } from "react-router-dom";
 import LoadingSpinner from "../components/LoadingSpinner";
 
@@ -21,8 +21,8 @@ const ChckMyCom = () => {
     const getCommentList = async () => {
         setLoading(true);
         try {
-            const { data } = await getMyComment(nickname);
-            setCommentList(data);
+            const { data } = await getMyComments();
+            setCommentList(data.result?.content ?? data.result ?? data);
         } catch {
             // 에러 시 빈 목록 유지
         } finally {

--- a/src/common/CheckMyArt.jsx
+++ b/src/common/CheckMyArt.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import "bootstrap/dist/css/bootstrap.min.css";
 
-import { getMyBoard } from '../api/commonApi';
+import { getMyPosts } from '../api/postSearchApi';
 
 import LoadingSpinner from "../components/LoadingSpinner";
 import useAlert from "../hooks/useAlert";
@@ -19,8 +19,8 @@ const CheckMyArt = () => {
         setLoading(true);
         setError(null);
         try {
-            const { data } = await getMyBoard(nickname);
-            setBoards(data);
+            const { data } = await getMyPosts();
+            setBoards(data.result?.content ?? data.result ?? data);
         } catch (e) {
             setError(e);
         } finally {

--- a/src/common/LikeListPage.jsx
+++ b/src/common/LikeListPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "bootstrap/dist/css/bootstrap.min.css";
 
-import { getMyFavorite } from '../api/commonApi';
+import { getMyLikes } from '../api/likeApi';
 
 import LoadingSpinner from "../components/LoadingSpinner";
 import useAlert from "../hooks/useAlert";
@@ -34,8 +34,8 @@ const LikeListPage = () => {
         setLoading(true);
         setError(null);
         try {
-            const { data } = await getMyFavorite(nickname);
-            setBoards(data);
+            const { data } = await getMyLikes();
+            setBoards(data.result?.content ?? data.result ?? data);
         } catch (e) {
             setError(e);
         } finally {

--- a/src/common/MyPage.jsx
+++ b/src/common/MyPage.jsx
@@ -1,9 +1,8 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { Link, useNavigate } from 'react-router-dom';
-import { getMemberDetail, withdraw } from '../api/signApi';
+import { getMyProfile, deleteMyProfile } from '../api/memberApi';
 import { useEffect, useState } from 'react';
-import UserAuthentication from '../sign/service/UserAuthentication';
 import { formatDate } from '../utils/dateUtils';
 import { toast } from 'react-toastify';
 
@@ -31,7 +30,7 @@ const MyPage = () => {
   const handleDelete = async () => {
     setShowConfirm(false);
     try {
-      await withdraw();
+      await deleteMyProfile();
       localStorage.removeItem('accessToken');
       localStorage.removeItem('nickname');
       toast.info("회원 탈퇴가 완료되었습니다.");
@@ -42,8 +41,8 @@ const MyPage = () => {
 
   const getMember = async () => {
     try {
-      const { data } = await getMemberDetail({ loginId: UserAuthentication.getLoginIdFromToken() });
-      setMember(data);
+      const { data } = await getMyProfile();
+      setMember(data.result ?? data);
     } catch {
       showAlert("회원 정보 조회 실패", "danger");
     }

--- a/src/common/Navbar.jsx
+++ b/src/common/Navbar.jsx
@@ -1,7 +1,7 @@
 import { Button } from 'react-bootstrap';
 import { useEffect, useState } from "react";
 import { useNavigate, Link } from 'react-router-dom';
-import { signOut, testAuth } from "../api/signApi";
+import { logout } from "../api/authApi";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import 'bootstrap-icons/font/bootstrap-icons.css';
@@ -23,7 +23,7 @@ const Navbar = () => {
 
   const handleLogout = async () => {
     try {
-      await signOut();
+      await logout();
       localStorage.removeItem('accessToken');
       localStorage.removeItem('nickname');
       toast.info("로그아웃 되었습니다.");
@@ -31,15 +31,6 @@ const Navbar = () => {
       navigate("/");
     } catch {
       toast.error("로그아웃에 실패했습니다.");
-    }
-  };
-
-  const handleTest = async () => {
-    try {
-      const { data } = await testAuth();
-      showAlert(data, "success");
-    } catch {
-      showAlert("실패", "danger");
     }
   };
 

--- a/src/hooks/useSignUpForm.js
+++ b/src/hooks/useSignUpForm.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import { checkDuplicate, signUp } from '../api/signApi';
+import { checkNickname, checkLoginId, checkEmail, signUp } from '../api/memberApi';
 
 const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+~\-=\[\]{};':"\\|,.<>\/?]).{8,}$/;
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -47,13 +47,19 @@ const useSignUpForm = () => {
 
     useEffect(() => {
         const debounce = {};
+        const checkers = {
+            loginId: () => checkLoginId(formData.loginId),
+            email:   () => checkEmail(formData.email),
+            nickname: () => checkNickname(formData.nickname),
+        };
         ["loginId", "email", "nickname"].forEach(field => {
             if (!formData[field]) return;
             if (debounce[field]) clearTimeout(debounce[field]);
             debounce[field] = setTimeout(async () => {
                 try {
-                    const { data } = await checkDuplicate({ type: field, value: formData[field] });
-                    setDups(prev => ({ ...prev, [field]: !!data.exists }));
+                    const { data } = await checkers[field]();
+                    const result = data.result ?? data;
+                    setDups(prev => ({ ...prev, [field]: result.exists === true || result.available === false }));
                 } catch {
                     setDups(prev => ({ ...prev, [field]: false }));
                 }

--- a/src/post/components/PostSearch.jsx
+++ b/src/post/components/PostSearch.jsx
@@ -6,7 +6,7 @@ import 'bootstrap-icons/font/bootstrap-icons.css';
 
 import RegionRadioComp from "../../board/component/page/RegionRadioComp";
 import CategoryCard from "../../board/component/page/CategoryCard";
-import { autoCompleteSearch } from "../../api/postApi";
+import { autoCompleteSearch } from "../../api/postSearchApi";
 
 const PostSearch = ({ selectedCategory, selectedRegion }) => {
     const [post, setPost] = useState({ category: "", region: "" });

--- a/src/post/pages/PostDetailPage.jsx
+++ b/src/post/pages/PostDetailPage.jsx
@@ -4,8 +4,8 @@ import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import 'bootstrap-icons/font/bootstrap-icons.css';
 import { Card } from "react-bootstrap";
 
-import { getPost } from "../../api/postApi";
-import { toggleFavorite, existsFavorite } from "../../api/favoriteApi";
+import { getPost } from "../../api/postSearchApi";
+import { addLike, deleteLike, getMyLikes } from "../../api/likeApi";
 import { useSearchParams, useNavigate, useLocation } from "react-router-dom";
 import CommentPage from "../../comment/component/CommentPage";
 import useAlert from "../../hooks/useAlert";
@@ -35,31 +35,19 @@ const PostDetailPage = () => {
   };
 
   const handleLike = async () => {
-    const nickname = localStorage.getItem("nickname");
-    const payload = { boardId: no, memberNickname: nickname };
     try {
-      const { data } = await toggleFavorite(payload);
-      setLiked(data);
-      if (data) {
+      if (liked) {
+        await deleteLike(Number(no));
+        setLiked(false);
         window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({
-          event: "travel_favorite_add",
-          boardId: no,
-          category: post.category,
-          region: post.region,
-          title: post.title
-        });
-        showAlert("찜 목록에 추가되었습니다.", "success");
-      } else {
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({
-          event: "travel_favorite_remove",
-          boardId: no,
-          category: post.category,
-          region: post.region,
-          title: post.title
-        });
+        window.dataLayer.push({ event: "travel_favorite_remove", boardId: no, category: post.category, region: post.region, title: post.title });
         showAlert("찜 목록에서 삭제되었습니다.", "danger");
+      } else {
+        await addLike(Number(no));
+        setLiked(true);
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({ event: "travel_favorite_add", boardId: no, category: post.category, region: post.region, title: post.title });
+        showAlert("찜 목록에 추가되었습니다.", "success");
       }
     } catch {
       showAlert("오류가 발생했습니다.", "danger");
@@ -67,11 +55,10 @@ const PostDetailPage = () => {
   };
 
   const getLike = async () => {
-    const nickname = localStorage.getItem("nickname");
-    const payload = { boardId: no, memberNickname: nickname };
     try {
-      const { data } = await existsFavorite(payload);
-      setLiked(data);
+      const { data } = await getMyLikes();
+      const likes = data.result?.content ?? data.result ?? [];
+      setLiked(likes.some((p) => String(p.postId) === String(no)));
     } catch {
       showAlert("오류가 발생했습니다.", "danger");
     }
@@ -80,7 +67,8 @@ const PostDetailPage = () => {
   const viewBoard = async () => {
     try {
       const { data } = await getPost(no);
-      setPost({ ...data, images: data.images || [] });
+      const post = data.result ?? data;
+      setPost({ ...post, images: post.images || [] });
     } catch {
       showAlert("게시글을 불러오지 못했습니다.", "danger");
     }

--- a/src/post/pages/PostEditPage.jsx
+++ b/src/post/pages/PostEditPage.jsx
@@ -2,7 +2,8 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { getPost, editPost, removePost } from '../../api/postApi';
+import { getPost } from '../../api/postSearchApi';
+import { updatePost, deletePost } from '../../api/postApi';
 import useAlert from '../../hooks/useAlert';
 import PostForm from '../components/PostForm';
 
@@ -29,10 +30,11 @@ const PostEditPage = () => {
     const viewBoard = async () => {
         try {
             const { data } = await getPost(no);
-            setPost(data);
-            setExistingImages(data.imagePaths || []);
+            const post = data.result ?? data;
+            setPost(post);
+            setExistingImages(post.imagePaths || []);
             setNewImages([]);
-            setImagePreviews(data.imagePaths || []);
+            setImagePreviews(post.imagePaths || []);
         } catch {
             showAlert("게시글을 불러오지 못했습니다.", "danger");
         }
@@ -40,7 +42,7 @@ const PostEditPage = () => {
 
     const removeBoard = async () => {
         try {
-            await removePost(no);
+            await deletePost(no);
             showAlert("삭제 성공", "success");
             setTimeout(() => navigate('/post/list'), 500);
         } catch {
@@ -104,7 +106,7 @@ const PostEditPage = () => {
         formData.append('existingImages', JSON.stringify(existingImages));
         newImages.forEach(file => formData.append('images', file));
         try {
-            await editPost(formData);
+            await updatePost(no, formData);
             showAlert("글 수정이 완료되었습니다.", "success");
             setTimeout(() => navigate('/post/list'), 500);
         } catch {

--- a/src/post/pages/PostListPage.jsx
+++ b/src/post/pages/PostListPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import "bootstrap/dist/css/bootstrap.min.css";
-import { getPostList, getPostListBySearch } from "../../api/postApi";
+import { getPostListBySearch } from "../../api/postSearchApi";
 import PostSearch from "../components/PostSearch";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import PostListCard from "../components/PostListCard";
@@ -47,19 +47,6 @@ const PostListPage = () => {
       navigate("/post/write");
     } else {
       showAlert("로그인 필요", "danger");
-    }
-  };
-
-  const getBoardListAll = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const { data } = await getPostList();
-      setPosts(data);
-    } catch (e) {
-      setError(e);
-    } finally {
-      setLoading(false);
     }
   };
 

--- a/src/post/pages/PostWritePage.jsx
+++ b/src/post/pages/PostWritePage.jsx
@@ -1,7 +1,7 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { useNavigate } from 'react-router-dom';
-import { addPost } from '../../api/postApi';
+import { createPost } from '../../api/postApi';
 import { useState, useEffect } from 'react';
 import useAlert from '../../hooks/useAlert';
 import PostForm from '../components/PostForm';
@@ -67,7 +67,7 @@ const PostWritePage = () => {
         formData.append('board', postBlob);
         images.forEach(file => formData.append('images', file));
         try {
-            await addPost(formData);
+            await createPost(formData);
             showAlert("글 작성이 완료되었습니다.", "success");
             setTimeout(() => navigate('/post/list'), 500);
         } catch {

--- a/src/sign/component/MemberManagement.jsx
+++ b/src/sign/component/MemberManagement.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getMemberList as getMemberListApi, delegateAdmin as delegateAdminApi } from '../../api/signApi';
+import { getAdminMembers, updateMemberRole } from '../../api/memberApi';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { FaTrash, FaUserShield } from 'react-icons/fa';
 
@@ -9,17 +9,17 @@ const MemberManagement = () => {
 
     const getMemberList = async () => {
         try {
-            const { data } = await getMemberListApi();
-            setMemberList(data);
+            const { data } = await getAdminMembers();
+            setMemberList(data.result?.content ?? data.result ?? data);
         } catch {
             setAlert({ show: true, message: "회원 조회 오류", type: "danger" });
         }
     };
 
-    const delegateAdmin = async ({ loginId }) => {
+    const delegateAdmin = async ({ memberId }) => {
         try {
-            const { data: msg } = await delegateAdminApi({ loginId });
-            setAlert({ show: true, message: msg, type: "success" });
+            await updateMemberRole(memberId);
+            setAlert({ show: true, message: "관리자 권한이 부여되었습니다.", type: "success" });
             getMemberList();
         } catch (error) {
             const msg = error.response?.data || "오류가 발생했습니다.";
@@ -84,7 +84,7 @@ const MemberManagement = () => {
                                         <button
                                             className="btn btn-sm btn-outline-success"
                                             title="관리자 위임"
-                                            onClick={() => delegateAdmin({ loginId: member.loginId })}
+                                            onClick={() => delegateAdmin({ memberId: member.memberId ?? member.id })}
                                             disabled={member.roles?.includes("ROLE_ADMIN")}
 
                                         >

--- a/src/sign/component/PasswordChangePage.jsx
+++ b/src/sign/component/PasswordChangePage.jsx
@@ -1,8 +1,7 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { updatePassword } from '../../api/signApi';
-import { getLoginIdFromToken } from '../../utils/tokenUtils';
+import { changePassword } from '../../api/memberApi';
 
 const cardStyle = {
     maxWidth: "420px",
@@ -71,13 +70,9 @@ const PasswordChangePage = () => {
             setAlert({ show: true, message: '새 비밀번호가 일치하지 않습니다.', type: 'danger' });
             return;
         }
-        const payload = {
-            curPassword: curPwd,
-            newPassword: newPwd,
-            loginId: getLoginIdFromToken()
-        };
+        const payload = { curPassword: curPwd, newPassword: newPwd };
         try {
-            await updatePassword(payload);
+            await changePassword(payload);
             setAlert({ show: true, message: '비밀번호가 변경되었습니다.', type: 'success' });
             setTimeout(() => navigate('/'), 1300);
         } catch (error) {

--- a/src/sign/component/SignInPage.jsx
+++ b/src/sign/component/SignInPage.jsx
@@ -1,10 +1,11 @@
 ﻿import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { useState, useEffect } from 'react';
-import { signIn, getMemberDetail } from '../../api/signApi';
+import { login } from '../../api/authApi';
+import { getMyProfile } from '../../api/memberApi';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import { getLoginIdFromToken, isAdmin } from '../../utils/tokenUtils';
+import { isAdmin } from '../../utils/tokenUtils';
 import useAlert from '../../hooks/useAlert';
 
 const SignInPage = () => {
@@ -23,16 +24,18 @@ const SignInPage = () => {
     const handleSubmit = async (e) => {
         e.preventDefault();
         try {
-            const { data } = await signIn(loginData);
-            localStorage.setItem('accessToken', data.accessToken);
-            const { data: member } = await getMemberDetail({ loginId: getLoginIdFromToken(data.accessToken) });
+            const { data } = await login(loginData);
+            const accessToken = data.result?.accessToken ?? data.accessToken;
+            localStorage.setItem('accessToken', accessToken);
+            const { data: profileRes } = await getMyProfile();
+            const member = profileRes.result ?? profileRes;
             localStorage.setItem('nickname', member.nickname);
             window._mtm = window._mtm || [];
             window._mtm.push({
                 nickname: member.nickname,
                 gender: member.gender,
                 age: member.age,
-                role: isAdmin(data.accessToken) ? "admin" : "user"
+                role: isAdmin(accessToken) ? "admin" : "user"
             });
             toast.success(`${member.nickname}님 환영합니다.`);
             navigate("/");

--- a/src/sign/component/SignUpdatePage.jsx
+++ b/src/sign/component/SignUpdatePage.jsx
@@ -2,8 +2,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getMemberDetail, updateMember } from '../../api/signApi';
-import UserAuthentication from '../service/UserAuthentication';
+import { getMyProfile, updateMyProfile } from '../../api/memberApi';
 
 const inputBoxStyle = {
     width: "100%",
@@ -51,8 +50,8 @@ const SignUpdatePage = () => {
 
     const getMember = async () => {
         try {
-            const { data } = await getMemberDetail({ loginId: UserAuthentication.getLoginIdFromToken() });
-            setFormData(data);
+            const { data } = await getMyProfile();
+            setFormData(data.result ?? data);
         } catch {
             setAlert({ show: true, message: "회원 정보 조회 실패", type: "danger" });
         }
@@ -70,7 +69,7 @@ const SignUpdatePage = () => {
     const handleSubmit = async (e) => {
         e.preventDefault();
         try {
-            await updateMember(formData);
+            await updateMyProfile({ nickname: formData.nickname });
             setAlert({ show: true, message: "회원수정 성공", type: "success" });
             localStorage.setItem('nickname', formData.nickname);
             setTimeout(() => {

--- a/src/sse/components/SseSubscriber.jsx
+++ b/src/sse/components/SseSubscriber.jsx
@@ -9,7 +9,7 @@ const SseSubscriber = () => {
     const [test2, settest2] = useState("not send");
 
     useEffect(() => {
-        const eventSource = new EventSource(`${process.env.REACT_APP_API_BASE_URL}/sse/subscribe`);
+        const eventSource = new EventSource(`${process.env.REACT_APP_API_BASE_URL}/api/v1/rankings/live`, { withCredentials: true });
         eventSource.onopen = () => {
             setTest("connected!!");
         };

--- a/src/sse/components/ViewItem.jsx
+++ b/src/sse/components/ViewItem.jsx
@@ -1,6 +1,4 @@
-// ViewItem.jsx
 import React, { useEffect, useRef } from 'react';
-import { sendItem } from '../../api/sseApi';
 
 const ViewItem = ({ query, onClose }) => {
     const overlayRef = useRef(null);
@@ -22,13 +20,6 @@ const ViewItem = ({ query, onClose }) => {
     for (const [key, value] of params.entries()) {
         parsed[key] = value;
     }
-    const handleSend = async () => {
-        try {
-            await sendItem(parsed);
-        } catch {
-            console.error("Error sending item");
-        }
-    };
 
     return (
         <div ref={overlayRef} style={overlayStyle}>
@@ -39,7 +30,6 @@ const ViewItem = ({ query, onClose }) => {
                     <p key={k}><strong>{k}:</strong> {v}</p>
                 ))}
                 <button onClick={onClose}>닫기</button>
-                <button onClick={handleSend}>Send</button>
             </div>
         </div>
     );


### PR DESCRIPTION
## 관련 이슈
closes #33

## 변경 사항
- `client.js`: 토큰 갱신 엔드포인트 `/api/sign/refresh` → `/api/v1/auth/tokens/refresh`
- `authApi.js` 신규 생성: login, logout, refreshTokens, oauth2Tokens
- `memberApi.js` 신규 생성: 회원 CRUD(`/api/v1/members/**`), 중복확인(3개 엔드포인트), Admin API
- `postApi.js` 재작성: CUD 전용 `/api/v1/posts/**` (createPost / updatePost / deletePost / getPresignedUrl)
- `postSearchApi.js` 신규 생성: Read 전용 `/api/v1/search/posts/**`
- `commentApi.js` 재작성: `/api/v1/comments/**`, `/api/v1/search/comments/**`
- `likeApi.js` 신규 생성: POST/DELETE `/api/v1/likes`, GET `/api/v1/search/likes/me`
- `rankingApi.js` 신규 생성: SSE `/api/v1/rankings/live`
- 구 파일(signApi / favoriteApi / commonApi / sseApi) import를 전체 컴포넌트에서 제거

## 작업 방법
- Swagger 명세의 엔드포인트·HTTP Method를 기준으로 API 파일을 도메인별로 분리
- 공통 응답 래퍼(`result?.field ?? field`) 패턴으로 구·신 백엔드 호환 fallback 적용
- 컴포넌트는 import 경로와 함수명만 변경, 내부 로직 최소화 (Response 필드 바인딩은 Phase C에서 처리)

## 테스트
- [ ] 로그인 / 로그아웃
- [ ] 회원가입 (중복 확인 포함)
- [ ] 게시글 목록·검색·상세
- [ ] 게시글 작성 / 수정 / 삭제
- [ ] 댓글 작성 / 삭제
- [ ] 좋아요 등록 / 취소 / 목록
- [ ] 내 게시글 / 내 댓글 조회