### PR TITLE
♻️ Refactor: Phase B - Request 필드명 Swagger 정합

### DIFF
--- a/src/comment/component/CommentPage.jsx
+++ b/src/comment/component/CommentPage.jsx
@@ -63,8 +63,7 @@ const CommentPage = ({ no, isLoggedIn, ratingAvg, setCommentFlag, category, regi
     const addComment = async ({ rating, comment }) => {
         window.dataLayer = window.dataLayer || [];
         window.dataLayer.push({ event: "travel_comment_add", boardId: no, category, region, title });
-        const nickname = localStorage.getItem("nickname");
-        const payload = { rating, content: comment, nickname, no };
+        const payload = { postId: parseInt(no), content: comment, star: rating };
         try {
             const { data: message } = await commentApi.addComment(payload);
             setAlert({ show: true, message, type: "success" });

--- a/src/hooks/useSignUpForm.js
+++ b/src/hooks/useSignUpForm.js
@@ -105,7 +105,8 @@ const useSignUpForm = () => {
         }
         setIsSubmitting(true);
         try {
-            await signUp({ ...formData, birthDate });
+            const { passwordConfirm: _, ...rest } = formData;
+            await signUp({ ...rest, birthDate });
             toast.success("회원가입이 완료되었습니다! 🎉");
             navigate("/");
         } catch (error) {

--- a/src/post/pages/PostEditPage.jsx
+++ b/src/post/pages/PostEditPage.jsx
@@ -3,38 +3,55 @@ import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { getPost } from '../../api/postSearchApi';
-import { updatePost, deletePost } from '../../api/postApi';
+import { updatePost, deletePost, getPresignedUrl } from '../../api/postApi';
 import useAlert from '../../hooks/useAlert';
 import PostForm from '../components/PostForm';
+
+const IMAGE_BASE_URL = process.env.REACT_APP_IMAGE_BASE_URL || '';
+
+const uploadImageToS3 = async (file, sortOrder) => {
+    const { data } = await getPresignedUrl();
+    const { url, imageKey } = data.result;
+    await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': file.type },
+        body: file,
+    });
+    return { imageKey, sortOrder };
+};
 
 const PostEditPage = () => {
     const [searchParams] = useSearchParams();
     const no = searchParams.get('no');
     const navigate = useNavigate();
     const [post, setPost] = useState({
-        no: '',
         title: '',
         content: '',
-        memberNickname: '',
         travelPlace: '',
         address: '',
         category: '',
         region: '',
-        imagePaths: []
     });
+    // 기존 이미지: { imageKey, sortOrder }[]
     const [existingImages, setExistingImages] = useState([]);
-    const [newImages, setNewImages] = useState([]);
-    const [imagePreviews, setImagePreviews] = useState([]);
+    const [newImageFiles, setNewImageFiles] = useState([]);
+    const [newImagePreviews, setNewImagePreviews] = useState([]);
+    const [uploading, setUploading] = useState(false);
     const { alert, showAlert } = useAlert(500);
 
-    const viewBoard = async () => {
+    const loadPost = async () => {
         try {
             const { data } = await getPost(no);
-            const post = data.result ?? data;
-            setPost(post);
-            setExistingImages(post.imagePaths || []);
-            setNewImages([]);
-            setImagePreviews(post.imagePaths || []);
+            const postData = data.result ?? data;
+            setPost({
+                title: postData.title,
+                content: postData.content,
+                travelPlace: postData.travelPlace,
+                address: postData.address,
+                category: postData.category,
+                region: postData.region,
+            });
+            setExistingImages(postData.images || []);
         } catch {
             showAlert("게시글을 불러오지 못했습니다.", "danger");
         }
@@ -51,14 +68,13 @@ const PostEditPage = () => {
     };
 
     useEffect(() => {
-        viewBoard();
         const nickname = localStorage.getItem("nickname");
-        if (nickname == null) {
+        if (!nickname) {
             showAlert("로그인이 필요합니다.", "danger");
             setTimeout(() => navigate(-1), 500);
             return;
         }
-        setPost(prev => ({ ...prev, memberNickname: nickname }));
+        loadPost();
     }, [no]);
 
     const handleChange = (e) => {
@@ -74,43 +90,41 @@ const PostEditPage = () => {
         setPost(prev => ({ ...prev, region: regionValue }));
     };
 
-    const handleImageChange = (e) => {
+    const handleNewImageChange = (e) => {
         const files = Array.from(e.target.files);
-        const allFilenames = new Set([
-            ...existingImages.map(path => path.split('/').pop()),
-            ...newImages.map(file => file.name),
-        ]);
-        const newFiles = files.filter(f => !allFilenames.has(f.name));
-        setNewImages(prev => [...prev, ...newFiles]);
-        setImagePreviews(prev => [...prev, ...newFiles.map(file => URL.createObjectURL(file))]);
+        const existingNames = new Set(newImageFiles.map(f => f.name));
+        const newFiles = files.filter(f => !existingNames.has(f.name));
+        setNewImageFiles(prev => [...prev, ...newFiles]);
+        setNewImagePreviews(prev => [...prev, ...newFiles.map(file => URL.createObjectURL(file))]);
     };
 
     const handleExistingImageRemove = (idx) => {
         setExistingImages(prev => prev.filter((_, i) => i !== idx));
-        setImagePreviews(prev => prev.filter((_, i) => i !== idx));
     };
 
     const handleNewImageRemove = (idx) => {
-        setNewImages(prev => prev.filter((_, i) => i !== idx));
-        setImagePreviews(prev => {
-            const existLen = existingImages.length;
-            return prev.filter((_, i) => i !== (existLen + idx));
-        });
+        setNewImageFiles(prev => prev.filter((_, i) => i !== idx));
+        setNewImagePreviews(prev => prev.filter((_, i) => i !== idx));
     };
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-        const formData = new FormData();
-        const postBlob = new Blob([JSON.stringify(post)], { type: "application/json" });
-        formData.append('board', postBlob);
-        formData.append('existingImages', JSON.stringify(existingImages));
-        newImages.forEach(file => formData.append('images', file));
+        setUploading(true);
         try {
-            await updatePost(no, formData);
+            const startOrder = existingImages.length;
+            const uploadedImages = await Promise.all(
+                newImageFiles.map((file, idx) => uploadImageToS3(file, startOrder + idx))
+            );
+            // 기존 이미지 sortOrder 재정렬 후 신규 이미지 합산
+            const reorderedExisting = existingImages.map((img, idx) => ({ ...img, sortOrder: idx }));
+            const images = [...reorderedExisting, ...uploadedImages];
+            await updatePost(no, { ...post, images });
             showAlert("글 수정이 완료되었습니다.", "success");
             setTimeout(() => navigate('/post/list'), 500);
         } catch {
             showAlert("글 수정에 실패하였습니다.", "danger");
+        } finally {
+            setUploading(false);
         }
     };
 
@@ -120,13 +134,13 @@ const PostEditPage = () => {
                 사진 첨부 <span className="text-secondary" style={{ fontSize: "0.95em" }}>(여러 장 첨부 가능)</span>
             </label>
             <div className="bg-light rounded-4 p-3 px-4 border">
-                <input type="file" accept="image/*" multiple onChange={handleImageChange} className="form-control mb-3" />
+                <input type="file" accept="image/*" multiple onChange={handleNewImageChange} className="form-control mb-3" />
                 <div className="d-flex flex-wrap gap-3">
-                    {existingImages.map((src, idx) => (
+                    {existingImages.map((img, idx) => (
                         <div key={`exist-${idx}`} style={{ position: 'relative' }}>
                             <img
-                                src={src.startsWith('/images/') ? `${process.env.REACT_APP_IMAGE_BASE_URL}${src}` : src}
-                                alt={`preview-exist-${idx}`}
+                                src={`${IMAGE_BASE_URL}/${img.imageKey}`}
+                                alt={`existing-${idx}`}
                                 style={{ width: 100, height: 100, objectFit: 'cover', borderRadius: 14, border: '1px solid #eee', boxShadow: "0 2px 6px rgba(0,0,0,0.06)" }}
                             />
                             <button
@@ -136,11 +150,11 @@ const PostEditPage = () => {
                             >×</button>
                         </div>
                     ))}
-                    {newImages.map((file, idx) => (
+                    {newImagePreviews.map((src, idx) => (
                         <div key={`new-${idx}`} style={{ position: 'relative' }}>
                             <img
-                                src={imagePreviews[existingImages.length + idx]}
-                                alt={`preview-new-${idx}`}
+                                src={src}
+                                alt={`new-${idx}`}
                                 style={{ width: 100, height: 100, objectFit: 'cover', borderRadius: 14, border: '1px solid #eee', boxShadow: "0 2px 6px rgba(0,0,0,0.06)" }}
                             />
                             <button
@@ -166,6 +180,7 @@ const PostEditPage = () => {
             onDelete={removeBoard}
             imageSection={imageSection}
             alert={alert}
+            submitDisabled={uploading}
         />
     );
 };

--- a/src/post/pages/PostWritePage.jsx
+++ b/src/post/pages/PostWritePage.jsx
@@ -1,17 +1,27 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import { useNavigate } from 'react-router-dom';
-import { createPost } from '../../api/postApi';
+import { createPost, getPresignedUrl } from '../../api/postApi';
 import { useState, useEffect } from 'react';
 import useAlert from '../../hooks/useAlert';
 import PostForm from '../components/PostForm';
+
+const uploadImageToS3 = async (file, sortOrder) => {
+    const { data } = await getPresignedUrl();
+    const { url, imageKey } = data.result;
+    await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': file.type },
+        body: file,
+    });
+    return { imageKey, sortOrder };
+};
 
 const PostWritePage = () => {
     const navigate = useNavigate();
     const [post, setPost] = useState({
         title: '',
         content: '',
-        memberNickname: '',
         travelPlace: '',
         address: '',
         category: '',
@@ -19,6 +29,7 @@ const PostWritePage = () => {
     });
     const [images, setImages] = useState([]);
     const [imagePreviews, setImagePreviews] = useState([]);
+    const [uploading, setUploading] = useState(false);
     const { alert, showAlert } = useAlert(500);
 
     useEffect(() => {
@@ -26,9 +37,7 @@ const PostWritePage = () => {
         if (!nickname) {
             showAlert("로그인이 필요합니다.", "danger");
             setTimeout(() => navigate(-1), 500);
-            return;
         }
-        setPost(prev => ({ ...prev, memberNickname: nickname }));
     }, [navigate]);
 
     const handleChange = (e) => {
@@ -62,16 +71,18 @@ const PostWritePage = () => {
             showAlert("사진을 한 장 이상 첨부해 주세요!", "danger");
             return;
         }
-        const formData = new FormData();
-        const postBlob = new Blob([JSON.stringify(post)], { type: "application/json" });
-        formData.append('board', postBlob);
-        images.forEach(file => formData.append('images', file));
+        setUploading(true);
         try {
-            await createPost(formData);
+            const uploadedImages = await Promise.all(
+                images.map((file, idx) => uploadImageToS3(file, idx))
+            );
+            await createPost({ ...post, images: uploadedImages });
             showAlert("글 작성이 완료되었습니다.", "success");
             setTimeout(() => navigate('/post/list'), 500);
         } catch {
             showAlert("글 작성에 실패하였습니다.", "danger");
+        } finally {
+            setUploading(false);
         }
     };
 
@@ -111,7 +122,7 @@ const PostWritePage = () => {
             onSubmit={handleSubmit}
             imageSection={imageSection}
             alert={alert}
-            submitDisabled={images.length === 0}
+            submitDisabled={images.length === 0 || uploading}
         />
     );
 };


### PR DESCRIPTION
## 관련 이슈
closes #36

## 변경 사항

### 1. 댓글 작성 Request 필드명 수정 (`CommentPage.jsx`)
- `{ rating, content: comment, nickname, no }` → `{ postId: parseInt(no), content: comment, star: rating }`
- Swagger 기준: `postId (integer)`, `content (string)`, `star (integer)`

### 2. 회원가입 Request 필드 정리 (`useSignUpForm.js`)
- `signUp({ ...formData, birthDate })` 에서 `passwordConfirm` 필드 제거
- 백엔드 명세에 없는 필드 전송 차단

### 3. 게시글 생성 Request 전환 (`PostWritePage.jsx`)
- FormData multipart (`board` blob + files) → JSON body + Presigned URL S3 업로드
- 이미지마다 `GET /api/v1/posts/images/presigned-url` 호출 → S3 PUT 업로드 → imageKey 수집
- 최종 요청: `{ title, content, travelPlace, address, category, region, images: [{ imageKey, sortOrder }] }`

### 4. 게시글 수정 Request 전환 (`PostEditPage.jsx`)
- FormData multipart → JSON body + Presigned URL 플로우
- 기존 이미지: Response의 `images[].imageKey` 기반 관리 (Phase C 연동)
- 신규 이미지: Presigned URL 업로드 후 imageKey 수집
- 기존 + 신규 이미지 sortOrder 통합 후 JSON body 전송

## 작업 방법
- Presigned URL 발급 → S3 직접 PUT (fetch 사용, apiClient 미사용)
- Promise.all로 병렬 업로드 처리
- 업로드 중 submitDisabled 처리로 중복 제출 방지

## 테스트
- [ ] 로그인 (기존 동작 유지)
- [ ] 회원가입 (passwordConfirm 미전송 확인)
- [ ] 댓글 작성 (postId/content/star 필드 확인)
- [ ] 게시글 작성 (Presigned URL 업로드 + JSON body)
- [ ] 게시글 수정 (기존 이미지 유지 + 신규 이미지 추가)