### PR TITLE
♻️ Refactor: Phase 2 — 공통 패턴 클래스화 (common.css 신설, JSX <style> 태그 제거)

### DIFF
--- a/src/board/component/page/AdmnBoard.jsx
+++ b/src/board/component/page/AdmnBoard.jsx
@@ -201,23 +201,6 @@ const AdmnBoard = () => {
                 </div>
 
             </div>
-            <style>
-                {`
-.board-list-card {
-  transition: box-shadow 0.18s, transform 0.16s, background 0.16s, border 0.13s;
-  border: 1.5px solid #f0f0f7;
-  background: #f9faff;
-  border-radius: 1.1rem;
-}
-.board-list-card:hover, .board-list-card:focus {
-  box-shadow: 0 8px 28px 0 rgba(123,82,255,0.16), 0 2px 16px rgba(60,0,128,0.04);
-  border-color: #a084ee;
-  background: #f6f3ff;
-  transform: translateY(-2px) scale(1.012);
-  cursor: pointer;
-}
-                `}
-            </style>
         </div>
     );
 };

--- a/src/board/component/page/MainPageCard/MainPageCard.jsx
+++ b/src/board/component/page/MainPageCard/MainPageCard.jsx
@@ -3,27 +3,6 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import CountUp from 'react-countup';
 
-// 1등 왕관 배지 스타일 (z-index: 99, pointerEvents: "none")
-const firstRankBadgeStyle = {
-  position: 'absolute',
-  top: 22,
-  left: 22,
-  background: 'linear-gradient(135deg, #ffd700 70%, #fff9c4 100%)',
-  color: "#725b10",
-  fontWeight: 900,
-  borderRadius: "50%",
-  width: 54,
-  height: 54,
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  fontSize: "2rem",
-  boxShadow: "0 4px 12px rgba(180,140,20,0.13)",
-  border: "3px solid #fffbe8",
-  zIndex: 99,            // 왕관을 카드보다 항상 위에!
-  pointerEvents: "none", // 카드 클릭 방해 X
-};
-
 const MainPageCard = ({ postId, score, rank }) => {
   const navigate = useNavigate();
   const [board, setBoard] = useState({
@@ -51,8 +30,8 @@ const MainPageCard = ({ postId, score, rank }) => {
     >
       {/* 1등 왕관 배지 (hover와 무관, 항상 위) */}
       {(rank === 1 || rank === undefined) && (
-        <div style={firstRankBadgeStyle}>
-          <span role="img" aria-label="king-crown" style={{ fontSize: "2.2rem", marginTop: "-4px" }}>👑</span>
+        <div className="main-rank-crown">
+          <span role="img" aria-label="king-crown">👑</span>
         </div>
       )}
 
@@ -127,16 +106,6 @@ const MainPageCard = ({ postId, score, rank }) => {
           </div>
         </div>
       </div>
-      {/* Hover 효과 CSS */}
-      <style>
-        {`
-          .mainpage-card-hover:hover {
-            transform: scale(1.035);
-            box-shadow: 0 12px 36px 0 rgba(100,100,150,0.19);
-            z-index: 2; /* 이 값도 왕관(99)보다 낮아야 함 */
-          }
-        `}
-      </style>
     </div>
   );
 };

--- a/src/board/component/page/MainPageCard/MainPageCard2.jsx
+++ b/src/board/component/page/MainPageCard/MainPageCard2.jsx
@@ -29,24 +29,9 @@ const MainPageCard2 = ({ postId, score, rank }) => {
 
   return (
     <div className="w-100 h-100 d-flex align-items-stretch position-relative" style={{ minHeight: 112, position: 'relative' }}>
-      {/* --- 순위 뱃지 --- */}
+      {/* --- 순위 뱃지 (배경색은 rank별 런타임 값이라 인라인 유지) --- */}
       {rank &&
-        <div style={{
-          position: 'absolute',
-          top: 12, left: 12,
-          background: rankColors[(rank - 1) % 5],
-          color: "#fff",
-          fontWeight: 900,
-          borderRadius: "50%",
-          width: 40, height: 40,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          fontSize: "1.2rem",
-          boxShadow: "0 2px 8px rgba(0,0,0,0.10)",
-          zIndex: 99,           // 카드 hover보다 확실히 위!
-          pointerEvents: "none" // 클릭 이벤트는 카드로 전달
-        }}>
+        <div className="main-rank-badge" style={{ background: rankColors[(rank - 1) % 5] }}>
           {rank}
         </div>
       }
@@ -123,17 +108,6 @@ const MainPageCard2 = ({ postId, score, rank }) => {
           </div>
         </div>
       </div>
-
-      {/* Hover 효과 스타일 */}
-      <style>
-        {`
-          .mainpage-card2-hover:hover {
-            transform: scale(1.035);
-            box-shadow: 0 8px 32px 0 rgba(100,100,150,0.19);
-            z-index: 2; /* 뱃지(99)보다 낮거나 같게 유지 */
-          }
-        `}
-      </style>
     </div>
   );
 };

--- a/src/board/component/page/MainPageCard/RankCard.jsx
+++ b/src/board/component/page/MainPageCard/RankCard.jsx
@@ -47,27 +47,6 @@ const images = {
   "체험": 체험
 };
 
-// 1등 왕관 배지 스타일 (z-index: 99, pointerEvents: "none")
-const firstRankBadgeStyle = {
-    position: 'absolute',
-    top: 22,
-    left: 22,
-    background: 'linear-gradient(135deg, #ffd700 70%, #fff9c4 100%)',
-    color: "#725b10",
-    fontWeight: 900,
-    borderRadius: "50%",
-    width: 54,
-    height: 54,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    fontSize: "2rem",
-    boxShadow: "0 4px 12px rgba(180,140,20,0.13)",
-    border: "3px solid #fffbe8",
-    zIndex: 99,            // 왕관을 카드보다 항상 위에!
-    pointerEvents: "none", // 카드 클릭 방해 X
-};
-
 const RankCard = ({ data, type, rank }) => {
     const navigate = useNavigate();
 
@@ -83,8 +62,8 @@ const RankCard = ({ data, type, rank }) => {
         >
             {/* 1등 왕관 배지 (hover와 무관, 항상 위) */}
             {(rank === 1 || rank === undefined) && (
-                <div style={firstRankBadgeStyle}>
-                    <span role="img" aria-label="king-crown" style={{ fontSize: "2.2rem", marginTop: "-4px" }}>👑</span>
+                <div className="main-rank-crown">
+                    <span role="img" aria-label="king-crown">👑</span>
                 </div>
             )}
 
@@ -142,16 +121,6 @@ const RankCard = ({ data, type, rank }) => {
                     </div>
                 </div>
             </div>
-            {/* Hover 효과 CSS */}
-            <style>
-                {`
-          .mainpage-card-hover:hover {
-            transform: scale(1.035);
-            box-shadow: 0 12px 36px 0 rgba(100,100,150,0.19);
-            z-index: 2; /* 이 값도 왕관(99)보다 낮아야 함 */
-          }
-        `}
-            </style>
         </div>
     );
 };

--- a/src/common/ChckMyCom.jsx
+++ b/src/common/ChckMyCom.jsx
@@ -66,15 +66,6 @@ const ChckMyCom = () => {
                     </div>
                 </div>
             </div>
-            <style>
-                {`
-          .mainpage-card-hover:hover {
-            transform: scale(1.035);
-            box-shadow: 0 12px 36px 0 rgba(100,100,150,0.19);
-            z-index: 2;
-          }
-        `}
-            </style>
         </div>
     );
 };

--- a/src/common/CheckMyArt.jsx
+++ b/src/common/CheckMyArt.jsx
@@ -36,8 +36,7 @@ const CheckMyArt = () => {
             <div className="container py-3" style={{ maxWidth: 850 }}>
                 <div className="d-flex justify-content-between align-items-center mb-4">
                     <div>
-                        <h3 className="fw-bold mb-1"
-                            style={{ color: "#6c45e0", fontFamily: "'Montserrat', 'Gowun Dodum', sans-serif", fontSize: "2rem" }}>
+                        <h3 className="fw-bold mb-1 page-title">
                             나의 여행지 목록
                         </h3>
                     </div>
@@ -56,20 +55,6 @@ const CheckMyArt = () => {
                     </div>
                 )}
             </div>
-            <style>
-                {`
-.post-list-card {
-  transition: box-shadow 0.18s, transform 0.16s, background 0.16s, border 0.13s;
-}
-.post-list-card:hover, .post-list-card:focus {
-  box-shadow: 0 6px 24px 0 rgba(123,82,255,0.14), 0 1.5px 10px rgba(60,0,128,0.04);
-  border-color: #a084ee;
-  background: #faf8ff;
-  transform: translateY(-2px) scale(1.012);
-  cursor: pointer;
-}
-        `}
-            </style>
         </div>
     );
 };

--- a/src/common/Footers.jsx
+++ b/src/common/Footers.jsx
@@ -3,10 +3,7 @@
 const Footers = () => {
   return (
     <div className="container">
-      <footer
-        className="row row-cols-1 row-cols-sm-2 row-cols-md-5 border-top"
-        style={{ margin: "100px 0 0 0", padding: "64px 0 32px 0" }} // ← 추가!
-      >
+      <footer className="row row-cols-1 row-cols-sm-2 row-cols-md-5 border-top app-footer">
 
 
       </footer>

--- a/src/common/LikeListPage.jsx
+++ b/src/common/LikeListPage.jsx
@@ -47,8 +47,7 @@ const LikeListPage = () => {
             <div className="container py-3" style={{ maxWidth: 850 }}>
                 <div className="d-flex justify-content-between align-items-center mb-4">
                     <div>
-                        <h3 className="fw-bold mb-1"
-                            style={{ color: "#6c45e0", fontFamily: "'Montserrat', 'Gowun Dodum', sans-serif", fontSize: "2rem" }}>
+                        <h3 className="fw-bold mb-1 page-title">
                             찜 목록
                         </h3>
                     </div>
@@ -67,20 +66,6 @@ const LikeListPage = () => {
                     </div>
                 )}
             </div>
-            <style>
-                {`
-.post-list-card {
-  transition: box-shadow 0.18s, transform 0.16s, background 0.16s, border 0.13s;
-}
-.post-list-card:hover, .post-list-card:focus {
-  box-shadow: 0 6px 24px 0 rgba(123,82,255,0.14), 0 1.5px 10px rgba(60,0,128,0.04);
-  border-color: #a084ee;
-  background: #faf8ff;
-  transform: translateY(-2px) scale(1.012);
-  cursor: pointer;
-}
-        `}
-            </style>
         </div>
     );
 };

--- a/src/common/NavMenu.jsx
+++ b/src/common/NavMenu.jsx
@@ -9,22 +9,10 @@ const NavMenu = ({ show, onClose, isLoggedIn, isAdmin, curUser, onLogout, onLogi
             placement="end"
             id="offcanvasNavbar"
             aria-labelledby="offcanvasNavbarLabel"
-            style={{
-                width: '300px',
-                background: "linear-gradient(135deg, #283593D9 60%, #6F8AE7DD 100%)",
-                color: "white", borderTopLeftRadius: "28px", borderBottomLeftRadius: "28px",
-                boxShadow: "0 0 32px 0 rgba(40,53,147,0.13)",
-                backdropFilter: "blur(10px)", WebkitBackdropFilter: "blur(10px)"
-            }}
+            className="nav-menu"
         >
-            <Offcanvas.Header
-                closeButton
-                style={{ background: "none", color: "white", borderBottom: "1px solid rgba(255,255,255,0.10)" }}
-            >
-                <Offcanvas.Title
-                    id="offcanvasNavbarLabel"
-                    style={{ fontWeight: 600, letterSpacing: "0.05em", fontSize: "1.2rem" }}
-                >
+            <Offcanvas.Header closeButton className="nav-menu-header">
+                <Offcanvas.Title id="offcanvasNavbarLabel" className="nav-menu-title">
                     <i className="bi bi-menu-button-wide me-2" />메뉴
                 </Offcanvas.Title>
             </Offcanvas.Header>
@@ -52,10 +40,7 @@ const NavMenu = ({ show, onClose, isLoggedIn, isAdmin, curUser, onLogout, onLogi
                             <MenuLink to="#" icon="bi-box-arrow-right" label="로그아웃" onClick={onLogout} />
                         )}
                         {isLoggedIn && (
-                            <span
-                                className="nav-link w-100 fs-6 text-light bg-secondary bg-opacity-50 rounded px-3 py-2 disabled"
-                                style={{ pointerEvents: 'none', opacity: 0.7, background: "rgba(100, 100, 180, 0.16)" }}
-                            >
+                            <span className="nav-link w-100 fs-6 text-light bg-secondary bg-opacity-50 rounded px-3 py-2 disabled nav-menu-nickname">
                                 <i className="bi bi-person-badge me-2"></i>닉네임: {curUser}
                             </span>
                         )}
@@ -71,13 +56,10 @@ export default NavMenu;
 const MenuLink = ({ to, icon, label, onClick, fs = "fs-5" }) => (
     <Link
         to={to}
-        className={`nav-link w-100 ${fs} text-light bg-opacity-75 rounded px-3 py-2`}
-        style={{ position: "relative", transition: "background 0.2s, box-shadow 0.16s", fontWeight: 500, borderRadius: "18px", letterSpacing: "0.01em" }}
+        className={`nav-link w-100 ${fs} text-light bg-opacity-75 rounded px-3 py-2 nav-menu-link`}
         onClick={onClick}
-        onMouseOver={e => { e.target.style.background = "rgba(255,255,255,0.11)"; e.target.style.color = "#FFF"; e.target.style.boxShadow = "0 2px 12px 0 rgba(91,142,255,0.09)"; }}
-        onMouseOut={e => { e.target.style.background = ""; e.target.style.color = "#FFF"; e.target.style.boxShadow = ""; }}
     >
-        <i className={`bi ${icon} me-2`} style={{ opacity: 0.96 }} />
+        <i className={`bi ${icon} me-2`} />
         {label}
     </Link>
 );

--- a/src/common/Navbar.jsx
+++ b/src/common/Navbar.jsx
@@ -7,8 +7,6 @@ import { toast } from 'react-toastify';
 import useAlert from '../hooks/useAlert';
 import NavMenu from './NavMenu';
 
-const GRADIENT = "linear-gradient(90deg, #5C6BC0 0%, #283593 100%)";
-
 const Navbar = () => {
   const [curUser, setCurUser] = useState('');
   const [show, setShow] = useState(false);
@@ -58,38 +56,25 @@ const Navbar = () => {
 
   return (
     <>
-      <div style={{ position: "fixed", top: 80, left: "50%", transform: "translateX(-50%)", minWidth: 260, zIndex: 2000 }}>
+      <div className="app-alert-fixed">
         {alert.show && (
           <div className={`alert alert-${alert.type || "info"} text-center shadow`} role="alert">
             {alert.message}
           </div>
         )}
       </div>
-      <nav
-        className="navbar navbar-dark fixed-top shadow"
-        style={{
-          background: GRADIENT, color: "#fff",
-          boxShadow: "0 4px 32px rgba(40,53,147,0.18)",
-          borderRadius: "0 0 24px 24px", minHeight: 68, padding: 0, zIndex: 1030,
-        }}
-      >
-        <div className="container-fluid px-3 d-flex align-items-center" style={{ minHeight: 68, margin: "0 auto" }}>
-          <div style={{ minWidth: 180, display: "flex", alignItems: "center" }}>
-            <Link to="/" className="navbar-brand mb-0 h1"
-              style={{
-                display: "inline-block", fontWeight: 800, padding: "0.5rem 1.6rem", borderRadius: "2rem",
-                background: "linear-gradient(90deg, #B794F4 40%, #90CDF4 100%)", color: "#fff",
-                fontSize: "1.35rem", letterSpacing: "0.02em", boxShadow: "0 2px 12px rgba(136,97,255,0.13)", border: "none"
-              }}>
-              <i className="bi bi-airplane-engines-fill me-2" style={{ fontSize: "1.2rem" }} />
+      <nav className="navbar navbar-dark fixed-top shadow app-navbar">
+        <div className="container-fluid px-3 d-flex align-items-center app-navbar-inner">
+          <div className="nav-brand-wrap">
+            <Link to="/" className="navbar-brand mb-0 h1 nav-brand">
+              <i className="bi bi-airplane-engines-fill me-2" />
               Trip Now
             </Link>
           </div>
           <div className="flex-grow-1 d-flex justify-content-center"></div>
-          <div style={{ minWidth: 54 }} className="d-flex justify-content-end">
-            <Button variant="dark" className="navbar-toggler shadow-sm" onClick={handleShow}
-              aria-controls="offcanvasNavbar"
-              style={{ background: "rgba(44,62,160,0.88)", borderColor: "rgba(44,62,160,0.88)", borderRadius: "16px", transition: "box-shadow 0.2s" }}>
+          <div className="d-flex justify-content-end nav-toggler-wrap">
+            <Button variant="dark" className="navbar-toggler shadow-sm nav-toggler" onClick={handleShow}
+              aria-controls="offcanvasNavbar">
               <span className="navbar-toggler-icon" />
             </Button>
           </div>

--- a/src/css/common.css
+++ b/src/css/common.css
@@ -1,0 +1,128 @@
+/* 공통 레이아웃: Navbar / NavMenu / Footer / 공통 패턴 */
+
+/* ===== 상단 고정 알림 (Navbar) ===== */
+.app-alert-fixed {
+  position: fixed;
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 260px;
+  z-index: var(--z-alert);
+}
+
+/* ===== Navbar ===== */
+.app-navbar {
+  background: var(--brand-gradient);
+  color: #fff;
+  box-shadow: var(--nav-shadow);
+  border-radius: var(--radius-nav);
+  min-height: var(--nav-height);
+  padding: 0;
+  z-index: var(--z-navbar);
+}
+
+.app-navbar-inner {
+  min-height: var(--nav-height);
+  margin: 0 auto;
+}
+
+.nav-brand-wrap {
+  min-width: 180px;
+  display: flex;
+  align-items: center;
+}
+
+.nav-brand {
+  display: inline-block;
+  font-weight: 800;
+  padding: 0.5rem 1.6rem;
+  border-radius: var(--radius-pill);
+  background: var(--brand-badge-gradient);
+  color: #fff;
+  font-size: 1.35rem;
+  letter-spacing: 0.02em;
+  box-shadow: var(--nav-brand-shadow);
+  border: none;
+}
+
+.nav-brand i {
+  font-size: 1.2rem;
+}
+
+.nav-toggler-wrap {
+  min-width: 54px;
+}
+
+.nav-toggler,
+.nav-toggler:hover,
+.nav-toggler:focus,
+.nav-toggler:active {
+  background: var(--nav-toggler-bg);
+  border-color: var(--nav-toggler-bg);
+}
+
+.nav-toggler {
+  border-radius: 16px;
+  transition: box-shadow 0.2s;
+}
+
+/* ===== NavMenu (Offcanvas) ===== */
+.nav-menu {
+  width: 300px;
+  background: var(--nav-menu-gradient);
+  color: #fff;
+  border-top-left-radius: var(--radius-menu);
+  border-bottom-left-radius: var(--radius-menu);
+  box-shadow: var(--nav-menu-shadow);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.nav-menu-header {
+  background: none;
+  color: #fff;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.10);
+}
+
+.nav-menu-title {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  font-size: 1.2rem;
+}
+
+.nav-menu-link {
+  position: relative;
+  transition: background 0.2s, box-shadow 0.16s;
+  font-weight: 500;
+  border-radius: 18px;
+  letter-spacing: 0.01em;
+}
+
+.nav-menu-link:hover {
+  background: rgba(255, 255, 255, 0.11);
+  color: #fff;
+  box-shadow: 0 2px 12px 0 rgba(91, 142, 255, 0.09);
+}
+
+.nav-menu-link i {
+  opacity: 0.96;
+}
+
+.nav-menu-nickname {
+  pointer-events: none;
+  opacity: 0.7;
+  background: rgba(100, 100, 180, 0.16);
+}
+
+/* ===== Footer ===== */
+.app-footer {
+  margin: 100px 0 0 0;
+  padding: 64px 0 32px 0;
+}
+
+/* ===== 공통 페이지 타이틀 ===== */
+.page-title {
+  color: var(--page-title-color);
+  font-family: var(--font-display);
+  font-size: 2rem;
+}

--- a/src/css/log.css
+++ b/src/css/log.css
@@ -1,0 +1,33 @@
+/* 로그 관리 Admin 도메인 */
+
+/* 이름 클릭 hover (프로세스/포맷/필터/중복제거 공통) */
+.process-name-hover,
+.format-name-hover,
+.dedup-name-hover {
+  font-weight: bold;
+  cursor: pointer;
+  text-decoration: none;
+  transition: text-decoration 0.13s;
+}
+
+.process-name-hover:hover,
+.format-name-hover:hover,
+.dedup-name-hover:hover {
+  text-decoration: underline;
+}
+
+/* 중앙 상단 고정 경고창 (로그 관리 화면 공통) */
+.custom-alert-center {
+  position: fixed;
+  top: 64px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: var(--z-form-alert);
+  min-width: 220px;
+  max-width: 380px;
+  border-radius: 0.95rem;
+  box-shadow: 0 3px 12px 0 rgba(0, 0, 0, 0.14);
+  font-size: 1.06rem;
+  padding: 0.7rem 2rem;
+  pointer-events: none;
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,0 +1,77 @@
+/* 메인(board) 도메인: 랭킹 카드, 관리자 게시글 목록 */
+
+/* 랭킹 카드 hover (MainPageCard / RankCard / ChckMyCom 공통) */
+.mainpage-card-hover:hover {
+  transform: scale(1.035);
+  box-shadow: 0 12px 36px 0 rgba(100, 100, 150, 0.19);
+  z-index: 2; /* 왕관 배지(99)보다 낮아야 함 */
+}
+
+/* 랭킹 리스트 카드 hover (MainPageCard2) */
+.mainpage-card2-hover:hover {
+  transform: scale(1.035);
+  box-shadow: 0 8px 32px 0 rgba(100, 100, 150, 0.19);
+  z-index: 2; /* 순위 뱃지(99)보다 낮거나 같게 유지 */
+}
+
+/* 1등 왕관 배지 (MainPageCard / RankCard 공통) — 카드보다 항상 위, 클릭 방해 X */
+.main-rank-crown {
+  position: absolute;
+  top: 22px;
+  left: 22px;
+  background: linear-gradient(135deg, #ffd700 70%, #fff9c4 100%);
+  color: #725b10;
+  font-weight: 900;
+  border-radius: 50%;
+  width: 54px;
+  height: 54px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  box-shadow: 0 4px 12px rgba(180, 140, 20, 0.13);
+  border: 3px solid #fffbe8;
+  z-index: 99;
+  pointer-events: none;
+}
+
+.main-rank-crown span {
+  font-size: 2.2rem;
+  margin-top: -4px;
+}
+
+/* 순위 뱃지 (MainPageCard2) — 배경색은 rank별 런타임 값이라 인라인 유지 */
+.main-rank-badge {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  color: #fff;
+  font-weight: 900;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.10);
+  z-index: 99;
+  pointer-events: none;
+}
+
+/* 관리자 게시글 카드 (AdmnBoard) */
+.board-list-card {
+  transition: box-shadow 0.18s, transform 0.16s, background 0.16s, border 0.13s;
+  border: 1.5px solid #f0f0f7;
+  background: #f9faff;
+  border-radius: 1.1rem;
+}
+
+.board-list-card:hover,
+.board-list-card:focus {
+  box-shadow: 0 8px 28px 0 rgba(123, 82, 255, 0.16), 0 2px 16px rgba(60, 0, 128, 0.04);
+  border-color: #a084ee;
+  background: #f6f3ff;
+  transform: translateY(-2px) scale(1.012);
+  cursor: pointer;
+}

--- a/src/css/post.css
+++ b/src/css/post.css
@@ -1,0 +1,27 @@
+/* post 도메인: 여행지 목록/상세 */
+
+/* 여행지 목록 카드 hover (PostListPage / LikeListPage / CheckMyArt 공통) */
+.post-list-card {
+  transition: box-shadow 0.18s, transform 0.16s, background 0.16s, border 0.13s;
+}
+
+.post-list-card:hover,
+.post-list-card:focus {
+  box-shadow: 0 6px 24px 0 rgba(123, 82, 255, 0.14), 0 1.5px 10px rgba(60, 0, 128, 0.04);
+  border-color: #a084ee;
+  background: #faf8ff;
+  transform: translateY(-2px) scale(1.012);
+  cursor: pointer;
+}
+
+/* 찜(하트) 버튼 (PostDetailPage) */
+.heart-btn {
+  font-size: 1.7rem;
+  color: #b0b0b0;
+  transition: color 0.15s;
+}
+
+.heart-btn.liked,
+.heart-btn:hover {
+  color: #e64980 !important;
+}

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -24,4 +24,17 @@
   --z-alert: 2000;
   --z-form-alert: 3000;
   --z-floating: 9999;
+
+  /* 네비게이션 */
+  --nav-height: 68px;
+  --nav-shadow: 0 4px 32px rgba(40, 53, 147, 0.18);
+  --nav-brand-shadow: 0 2px 12px rgba(136, 97, 255, 0.13);
+  --nav-toggler-bg: rgba(44, 62, 160, 0.88);
+  --nav-menu-gradient: linear-gradient(135deg, #283593D9 60%, #6F8AE7DD 100%);
+  --nav-menu-shadow: 0 0 32px 0 rgba(40, 53, 147, 0.13);
+  --radius-menu: 28px;
+
+  /* 타이포그래피 */
+  --font-display: 'Montserrat', 'Gowun Dodum', sans-serif;
+  --page-title-color: #6c45e0;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,10 @@ import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import 'bootstrap-icons/font/bootstrap-icons.css';
 import './css/tokens.css';
 import './css/index.css';
+import './css/common.css';
+import './css/post.css';
+import './css/main.css';
+import './css/log.css';
 
 import App from './App';
 import { getUserIdForMatomo } from './utils/tokenUtils';

--- a/src/log/components/deduplication/DeduplicationManagement.jsx
+++ b/src/log/components/deduplication/DeduplicationManagement.jsx
@@ -56,33 +56,6 @@ const DeduplicationManagement = ({ processId, onMenuClick }) => {
 
   return (
     <div style={{ marginTop: '80px' }}>
-      {/* 인라인 스타일 또는 App.css로 분리 가능 */}
-      <style>{`
-        .dedup-name-hover {
-          font-weight: bold;
-          cursor: pointer;
-          text-decoration: none;
-          transition: text-decoration 0.13s;
-        }
-        .dedup-name-hover:hover {
-          text-decoration: underline;
-        }
-          .custom-alert-center {
-                  position: fixed;
-                  top: 64px;
-                  left: 50%;
-                  transform: translateX(-50%);
-                  z-index: 3000;
-                  min-width: 220px;
-                  max-width: 380px;
-                  border-radius: 0.95rem;
-                  box-shadow: 0 3px 12px 0 rgba(0,0,0,0.14);
-                  font-size: 1.06rem;
-                  padding: 0.7rem 2rem;
-                  pointer-events: none;
-                }
-      `}</style>
-
       <h2 className="fw-bold mb-4">중복 제거 관리</h2>
 
       {/* 중앙 상단 고정 경고창 */}

--- a/src/log/components/filter/FilterManagement.jsx
+++ b/src/log/components/filter/FilterManagement.jsx
@@ -40,32 +40,6 @@ const FilterManagement = ({ processId, onMenuClick }) => {
 
     return (
         <div style={{ marginTop: '80px' }}>
-            <style>{`
-                .format-name-hover {
-                    font-weight: bold;
-                    cursor: pointer;
-                    text-decoration: none;
-                    transition: text-decoration 0.13s;
-                }
-                .format-name-hover:hover {
-                    text-decoration: underline;
-                }
-                .custom-alert-center {
-                    position: fixed;
-                    top: 64px;
-                    left: 50%;
-                    transform: translateX(-50%);
-                    z-index: 3000;
-                    min-width: 220px;
-                    max-width: 380px;
-                    border-radius: 0.95rem;
-                    box-shadow: 0 3px 12px 0 rgba(0,0,0,0.14);
-                    font-size: 1.06rem;
-                    padding: 0.7rem 2rem;
-                    pointer-events: none;
-                }
-            `}</style>
-
             {/* 화면 중앙 위 고정 알림 */}
             {alert && (
                 <div className={`alert alert-${alert.type} fw-semibold mb-0 text-center custom-alert-center`}>

--- a/src/log/components/format/FormatManagement.jsx
+++ b/src/log/components/format/FormatManagement.jsx
@@ -33,32 +33,6 @@ const FormatManagement = ({ processId, onMenuClick }) => {
 
     return (
         <div style={{ marginTop: '80px' }}>
-            <style>{`
-                .format-name-hover {
-                  font-weight: bold;
-                  cursor: pointer;
-                  text-decoration: none;
-                  transition: text-decoration 0.13s;
-                }
-                .format-name-hover:hover {
-                  text-decoration: underline;
-                }
-                .custom-alert-center {
-                  position: fixed;
-                  top: 64px;
-                  left: 50%;
-                  transform: translateX(-50%);
-                  z-index: 3000;
-                  min-width: 220px;
-                  max-width: 380px;
-                  border-radius: 0.95rem;
-                  box-shadow: 0 3px 12px 0 rgba(0,0,0,0.14);
-                  font-size: 1.06rem;
-                  padding: 0.7rem 2rem;
-                  pointer-events: none;
-                }
-            `}</style>
-
             <h2 className="fw-bold mb-4">포맷 관리</h2>
 
             {/* 중앙 상단 고정 경고창 */}

--- a/src/log/components/process/ProcessManagement.jsx
+++ b/src/log/components/process/ProcessManagement.jsx
@@ -49,32 +49,6 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
 
     return (
         <div style={{ marginTop: '80px' }}>
-            <style>{`
-                .process-name-hover {
-                    font-weight: bold;
-                    cursor: pointer;
-                    text-decoration: none;
-                    transition: text-decoration 0.13s;
-                }
-                .process-name-hover:hover {
-                    text-decoration: underline;
-                }
-                .custom-alert-center {
-                    position: fixed;
-                    top: 64px;
-                    left: 50%;
-                    transform: translateX(-50%);
-                    z-index: 3000;
-                    min-width: 220px;
-                    max-width: 380px;
-                    border-radius: 0.95rem;
-                    box-shadow: 0 3px 12px 0 rgba(0,0,0,0.14);
-                    font-size: 1.06rem;
-                    padding: 0.7rem 2rem;
-                    pointer-events: none;
-                }
-            `}</style>
-
             <div className="d-flex align-items-center mb-4" style={{ minHeight: 40 }}>
                 <h2 className="fw-bold" style={{ color: "#34a853", paddingBottom: "2px" }}>●</h2>
                 <h2 className="fw-bold" style={{ marginLeft: "7px" }}>프로세스 관리</h2>

--- a/src/post/pages/PostDetailPage.jsx
+++ b/src/post/pages/PostDetailPage.jsx
@@ -107,19 +107,6 @@ const PostDetailPage = () => {
 
   return (
     <>
-      <style>
-        {`
-        .heart-btn {
-          font-size: 1.7rem;
-          color: #b0b0b0;
-          transition: color 0.15s;
-        }
-        .heart-btn.liked,
-        .heart-btn:hover {
-          color: #e64980 !important;
-        }
-        `}
-      </style>
       {alert.show && (
         <div
           className={`alert alert-${alert.type} alert-dismissible`}

--- a/src/post/pages/PostListPage.jsx
+++ b/src/post/pages/PostListPage.jsx
@@ -111,8 +111,7 @@ const PostListPage = () => {
       <div className="container py-3" style={{ maxWidth: 850 }}>
         <div className="d-flex justify-content-between align-items-center mb-4">
           <div>
-            <h3 className="fw-bold mb-1"
-              style={{ color: "#6c45e0", fontFamily: "'Montserrat', 'Gowun Dodum', sans-serif", fontSize: "2rem" }}>
+            <h3 className="fw-bold mb-1 page-title">
               여행지 목록
             </h3>
             <div className="text-secondary" style={{ fontSize: "1.07rem" }}>
@@ -201,20 +200,6 @@ const PostListPage = () => {
           </button>
         </div>
       </div>
-      <style>
-        {`
-.post-list-card {
-  transition: box-shadow 0.18s, transform 0.16s, background 0.16s, border 0.13s;
-}
-.post-list-card:hover, .post-list-card:focus {
-  box-shadow: 0 6px 24px 0 rgba(123,82,255,0.14), 0 1.5px 10px rgba(60,0,128,0.04);
-  border-color: #a084ee;
-  background: #faf8ff;
-  transform: translateY(-2px) scale(1.012);
-  cursor: pointer;
-}
-        `}
-      </style>
     </div>
   );
 };


### PR DESCRIPTION
## 관련 이슈
closes #48

## 변경 사항
- `src/css/common.css` 신설 — Navbar / NavMenu / Footers 인라인 스타일을 클래스로 이동, 공통 페이지 타이틀(`.page-title`) 추출
- `src/css/post.css` / `main.css` / `log.css` 신설 — JSX 내 `<style>` 문자열 태그 13곳을 도메인 CSS 파일로 이동
- 중복 스타일 통합: `.post-list-card`(3곳 중복), `.mainpage-card-hover`(3곳), `.custom-alert-center`(4곳), 1등 왕관 배지 스타일 객체(2곳 → `.main-rank-crown`)
- NavMenu의 `onMouseOver`/`onMouseOut` JS hover 우회 제거 → CSS `:hover`로 대체
- `tokens.css`에 nav/타이포 토큰 추가(`--nav-*`, `--font-display`, `--page-title-color`), 기존 토큰(`--brand-gradient`, `--brand-badge-gradient`, `--radius-nav`, `--z-*`) 참조로 전환
- `index.js`에서 신설 CSS 4개 로드 (bootstrap → tokens → index → common → 도메인 순서 유지)

## 작업 방법
- **시각 동일성 보장을 위해 `<style>` 태그 내용은 원문 그대로 도메인 CSS로 이동** — Bootstrap 유틸리티(`!important`)·인라인 스타일과의 캐스케이드 우선순위가 이동 전후 동일하게 유지되도록 값 변경/병합을 하지 않음
- 런타임 계산 값(MainPageCard2 순위 뱃지의 rank별 배경색)만 인라인으로 유지
- 도메인 CSS는 `index.js`에서 bootstrap 이후 순서로 로드해 기존 `<style>` 태그(문서 후순위)와 동일한 우선순위 확보
- 나머지 화면별 인라인 스타일은 Phase 3에서 화면 단위로 처리, radius/shadow 토큰 수렴은 Phase 4에서 진행

## 테스트
- [x] `react-scripts build` 성공 (JS −1.98kB / CSS +1.38kB — JSX→CSS 이동에 따른 정상 변화)
- [ ] 시각 동일성 스크린샷 비교: 메인(랭킹 카드 hover·왕관 배지), 여행지 목록(카드 hover), 상세(하트 버튼), Navbar/Offcanvas 메뉴(hover 효과), 로그 관리 4개 화면(이름 hover·경고창)

🤖 Generated with [Claude Code](https://claude.com/claude-code)