### PR TITLE
♻️ Phase 3 — post 화면 인라인 스타일 제거 (post.css)

### DIFF
--- a/src/css/post.css
+++ b/src/css/post.css
@@ -1,7 +1,50 @@
-/* post 도메인: 여행지 목록/상세 */
+/* post 도메인: 여행지 목록/상세/작성 */
 
-/* 여행지 목록 카드 hover (PostListPage / LikeListPage / CheckMyArt 공통) */
+/* ===== 공통 ===== */
+.post-viewport {
+  min-height: 100vh;
+  width: 100vw;
+  overflow-x: hidden;
+  position: relative;
+}
+
+.post-subtitle {
+  font-size: 1.07rem;
+}
+
+/* ===== 여행지 목록 (PostListPage) ===== */
+.post-list-page {
+  overflow-x: hidden;
+}
+
+.post-list-container {
+  max-width: 850px;
+}
+
+.post-list-divider {
+  height: 3.5px;
+  width: 60px;
+  margin: 1rem auto 5rem auto;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(90deg, #bdaafc 20%, #92e0f6 90%);
+  opacity: 0.88;
+}
+
+.post-write-btn,
+.post-write-btn:hover,
+.post-write-btn:focus,
+.post-write-btn:active {
+  background: linear-gradient(90deg, #a084ee 30%, #7c3aed 100%);
+  color: #fff;
+  border: none;
+}
+
+/* ===== 목록 카드 (PostListCard — LikeListPage / CheckMyArt 공통 재사용) ===== */
 .post-list-card {
+  background: var(--card-bg);
+  min-height: 88px;
+  box-shadow: var(--card-shadow);
+  position: relative;
   transition: box-shadow 0.18s, transform 0.16s, background 0.16s, border 0.13s;
 }
 
@@ -14,7 +57,274 @@
   cursor: pointer;
 }
 
-/* 찜(하트) 버튼 (PostDetailPage) */
+.post-list-card-title-row {
+  font-size: 1.12rem;
+  margin-bottom: 6px;
+}
+
+.post-list-card-title {
+  max-width: 75%;
+}
+
+.post-list-card-title-text {
+  color: #222;
+  font-weight: bold;
+  font-family: var(--font-display);
+}
+
+.post-list-card-date {
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+
+.post-list-card-meta {
+  font-size: 0.97rem;
+}
+
+.post-list-card-author {
+  color: #222;
+}
+
+.post-list-card-stat {
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.post-list-card-star {
+  color: #ffc107;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+/* ===== 검색 (PostSearch) ===== */
+.post-search-card {
+  max-width: 700px;
+  padding: 32px 36px;
+  background: var(--card-bg);
+}
+
+.post-search-input {
+  height: 40px;
+  flex-grow: 1;
+  z-index: 11;
+}
+
+.post-search-btn {
+  white-space: nowrap;
+  padding: 0.2rem 0.35rem;
+  height: 40px;
+}
+
+.post-search-suggestions {
+  position: absolute;
+  top: 44px;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  margin: 0;
+  padding: 0;
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 0 0 12px 12px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+  list-style: none;
+  max-height: 260px;
+  overflow-y: auto;
+  min-width: 200px;
+  transition: box-shadow 0.2s;
+}
+
+.post-search-suggestion {
+  padding: 12px 16px;
+  cursor: pointer;
+  color: #333;
+  border-bottom: 1px solid #f5f5f5;
+  font-size: 17px;
+  transition: background 0.1s;
+}
+
+.post-search-suggestion:last-child {
+  border-bottom: none;
+}
+
+.post-search-suggestion.active {
+  background: #f8f9fa;
+  font-weight: bold;
+}
+
+.post-search-suggestion-empty {
+  padding: 12px 16px;
+  color: #bbb;
+  font-style: italic;
+}
+
+.post-search-highlight {
+  background: #ffe066;
+  padding: 0;
+}
+
+/* ===== 상세 (PostDetailPage) ===== */
+.post-detail-alert {
+  position: fixed;
+  top: 80px;
+  right: 24px;
+  z-index: var(--z-floating);
+  min-width: 260px;
+}
+
+.post-detail-container {
+  min-height: 100vh;
+  max-width: var(--container-detail-max-width);
+}
+
+.post-detail-row {
+  display: flex;
+  gap: 32px;
+  width: 95%;
+  margin: 0 auto;
+  align-items: stretch;
+}
+
+.post-detail-comment-card {
+  border-radius: var(--radius-card);
+  width: 70%;
+  min-width: 0;
+  background: var(--card-bg);
+  display: flex;
+  flex-direction: column;
+}
+
+.post-detail-comment-body {
+  flex: 1;
+}
+
+.post-detail-fab {
+  position: fixed;
+  bottom: 36px;
+  right: 48px;
+  z-index: var(--z-floating);
+  border-radius: 50%;
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 6px 16px #0002;
+  font-size: 2rem;
+}
+
+/* ===== 상세 본문 (PostContent) ===== */
+.post-content-card {
+  border-radius: var(--radius-card);
+  width: 100%;
+  min-width: 0;
+  background: var(--card-bg);
+  display: flex;
+  flex-direction: column;
+}
+
+.post-content-body {
+  flex: 1;
+}
+
+.post-content-carousel {
+  max-width: 800px;
+  margin: 0 auto 24px auto;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 6px 18px #0001;
+}
+
+.post-content-image {
+  width: 100%;
+  height: 400px;
+  object-fit: cover;
+  display: block;
+  background: #eee;
+}
+
+.post-content-badge {
+  font-size: 1rem;
+}
+
+.post-content-body-card {
+  background: #f7fafc;
+  border: none;
+}
+
+.post-content-body-text {
+  min-height: 50px;
+  font-size: 1.08rem;
+  white-space: pre-line;
+}
+
+/* ===== 작성/수정 폼 (PostForm) ===== */
+.post-form-alert {
+  position: fixed;
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 240px;
+  z-index: var(--z-form-alert);
+}
+
+.post-form-container {
+  max-width: var(--container-form-max-width);
+}
+
+.post-form-card {
+  background: #ffffffeb;
+}
+
+.post-form-title {
+  letter-spacing: 2px;
+}
+
+.post-form-author-label {
+  font-size: 1.08rem;
+  color: #222;
+  margin-right: 6px;
+}
+
+.post-form-author-value {
+  font-size: 1.08rem;
+  min-width: 80px;
+  display: inline-block;
+}
+
+.post-form-textarea {
+  min-height: 140px;
+}
+
+.post-form-action-btn {
+  min-width: 140px;
+  letter-spacing: 1px;
+}
+
+/* ===== 이미지 첨부 (PostWritePage / PostEditPage) ===== */
+.post-image-hint {
+  font-size: 0.95em;
+}
+
+.post-image-preview {
+  width: var(--thumbnail-size);
+  height: var(--thumbnail-size);
+  object-fit: cover;
+  border-radius: var(--radius-thumbnail);
+  border: 1px solid #eee;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+}
+
+.post-image-remove-btn {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  border-radius: 50%;
+  padding: 2px 7px;
+  font-size: 1.05rem;
+}
+
+/* ===== 찜(하트) 버튼 (PostContent) ===== */
 .heart-btn {
   font-size: 1.7rem;
   color: #b0b0b0;

--- a/src/post/components/PostContent.jsx
+++ b/src/post/components/PostContent.jsx
@@ -7,23 +7,20 @@ const PostContent = ({ post, liked, onLike, nickname }) => {
     const categoryLabel = CATEGORY_CODE_TO_LABEL[post.category] ?? post.category;
     const regionLabel = REGION_CODE_TO_LABEL[post.region] ?? post.region;
     return (
-        <Card
-            className="shadow-sm flex-fill"
-            style={{ borderRadius: "18px", width: "100%", minWidth: "0", background: "#fff", display: "flex", flexDirection: "column" }}
-        >
-            <Card.Body className="pb-2 pt-4 d-flex flex-column" style={{ flex: 1 }}>
+        <Card className="shadow-sm flex-fill post-content-card">
+            <Card.Body className="pb-2 pt-4 d-flex flex-column post-content-body">
                 {post.images && post.images.length > 0 && (
                     <Carousel
                         interval={null}
                         indicators={post.images.length > 1}
-                        style={{ maxWidth: 800, margin: "0 auto 24px auto", borderRadius: 16, overflow: "hidden", boxShadow: "0 6px 18px #0001" }}
+                        className="post-content-carousel"
                     >
                         {post.images.map(img => (
                             <Carousel.Item key={img.imageKey}>
                                 <img
                                     src={`${process.env.REACT_APP_IMAGE_BASE_URL}/${img.imageKey}`}
                                     alt="uploaded"
-                                    style={{ width: "100%", height: 400, objectFit: "cover", display: "block", background: "#eee" }}
+                                    className="post-content-image"
                                 />
                             </Carousel.Item>
                         ))}
@@ -31,7 +28,7 @@ const PostContent = ({ post, liked, onLike, nickname }) => {
                 )}
                 <div className="d-flex justify-content-between align-items-start mb-1">
                     <h4 className="fw-bold mb-1">{post.title}</h4>
-                    <Badge bg={categoryColors[categoryLabel] || "secondary"} style={{ fontSize: "1rem" }}>
+                    <Badge bg={categoryColors[categoryLabel] || "secondary"} className="post-content-badge">
                         {categoryLabel}
                     </Badge>
                 </div>
@@ -52,16 +49,15 @@ const PostContent = ({ post, liked, onLike, nickname }) => {
                         <OverlayTrigger placement="top" overlay={<Tooltip id="tooltip-edit">수정하기</Tooltip>}>
                             <Link
                                 to={`/post/edit?no=${post.postId}`}
-                                className="btn btn-outline-primary btn-sm ms-2"
-                                style={{ whiteSpace: "nowrap" }}
+                                className="btn btn-outline-primary btn-sm ms-2 text-nowrap"
                             >
                                 🖊
                             </Link>
                         </OverlayTrigger>
                     )}
                 </div>
-                <Card className="mb-0" style={{ background: "#f7fafc", border: "none" }}>
-                    <Card.Body className="py-2 px-3" style={{ minHeight: "50px", fontSize: "1.08rem", whiteSpace: "pre-line" }}>
+                <Card className="mb-0 post-content-body-card">
+                    <Card.Body className="py-2 px-3 post-content-body-text">
                         {post.content}
                     </Card.Body>
                 </Card>

--- a/src/post/components/PostForm.jsx
+++ b/src/post/components/PostForm.jsx
@@ -19,29 +19,25 @@ const PostForm = ({
         <>
             {alert.show && (
                 <div
-                    className={`alert alert-${alert.type} text-center shadow`}
+                    className={`alert alert-${alert.type} text-center shadow post-form-alert`}
                     role="alert"
-                    style={{ position: "fixed", top: 80, left: "50%", transform: "translateX(-50%)", minWidth: 240, zIndex: 3000 }}
                 >
                     {alert.message}
                 </div>
             )}
-            <div
-                className={isEdit ? "py-5" : ""}
-                style={{ minHeight: "100vh", width: "100vw", overflowX: "hidden", position: "relative" }}
-            >
-                <div className="container my-5" style={{ maxWidth: '900px' }}>
-                    <div className="card shadow-lg border-0 rounded-4 p-4" style={{ background: "#ffffffeb" }}>
-                        <h2 className="mb-3 fw-bold text-center" style={{ letterSpacing: '2px' }}>
+            <div className={`post-viewport ${isEdit ? "py-5" : ""}`}>
+                <div className="container my-5 post-form-container">
+                    <div className="card shadow-lg border-0 rounded-4 p-4 post-form-card">
+                        <h2 className="mb-3 fw-bold text-center post-form-title">
                             {isEdit ? '글 수정' : '글 작성'}
                         </h2>
-                        <div className="text-secondary text-center mb-4" style={{ fontSize: '1.07rem' }}>
+                        <div className="text-secondary text-center mb-4 post-subtitle">
                             여행지, 사진, 지역, 카테고리, 후기를 모두 입력해 주세요!
                         </div>
                         {isEdit && (
                             <div className="mb-4 d-flex justify-content-end">
-                                <span className="fw-semibold" style={{ fontSize: '1.08rem', color: '#222', marginRight: 6 }}>작성자:</span>
-                                <span className="fw-bold" style={{ fontSize: '1.08rem', minWidth: 80, display: 'inline-block' }}>
+                                <span className="fw-semibold post-form-author-label">작성자:</span>
+                                <span className="fw-bold post-form-author-value">
                                     {post.memberNickname || ""}
                                 </span>
                             </div>
@@ -91,19 +87,17 @@ const PostForm = ({
                             <div className="mb-4">
                                 <label htmlFor="content" className="form-label fw-semibold">후기 / 내용</label>
                                 <textarea
-                                    className="form-control" id="content" rows="7"
+                                    className="form-control post-form-textarea" id="content" rows="7"
                                     required maxLength={2000}
                                     placeholder="여행지에 대한 후기를 자유롭게 작성해 주세요 :)"
                                     value={post.content} onChange={onChange}
-                                    style={{ minHeight: 140 }}
                                 />
                             </div>
                             <div className={`d-flex pt-2 ${isEdit ? 'justify-content-between' : 'justify-content-end'}`}>
                                 {isEdit && (
                                     <button
-                                        className="btn btn-danger px-5 py-2 fs-5 fw-bold rounded-pill shadow"
+                                        className="btn btn-danger px-5 py-2 fs-5 fw-bold rounded-pill shadow post-form-action-btn"
                                         type="button"
-                                        style={{ minWidth: 140, letterSpacing: '1px' }}
                                         onClick={onDelete}
                                     >
                                         삭제
@@ -111,8 +105,7 @@ const PostForm = ({
                                 )}
                                 <button
                                     type="submit"
-                                    className="btn btn-primary px-5 py-2 fs-5 fw-bold rounded-pill shadow"
-                                    style={{ minWidth: 140, letterSpacing: '1px' }}
+                                    className="btn btn-primary px-5 py-2 fs-5 fw-bold rounded-pill shadow post-form-action-btn"
                                     disabled={submitDisabled}
                                 >
                                     {isEdit ? '완료' : '글쓰기'}

--- a/src/post/components/PostListCard.jsx
+++ b/src/post/components/PostListCard.jsx
@@ -17,57 +17,35 @@ const PostListCard = ({ post, navigateTo, navigateState }) => {
   return (
     <div
       className="p-3 rounded-3 border post-list-card"
-      style={{
-        background: "#fff",
-        minHeight: "88px",
-        boxShadow: "0 2px 10px 0 rgba(0,0,0,0.04)",
-        position: "relative",
-      }}
       onClick={handleClick}
       tabIndex={0}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") handleClick();
       }}
     >
-      <div
-        className="d-flex justify-content-between align-items-start fw-bold"
-        style={{ fontSize: "1.12rem", marginBottom: 6 }}
-      >
-        <div
-          className="text-truncate"
-          style={{ maxWidth: "75%", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}
-        >
-          <span
-            style={{
-              color: "#222",
-              fontWeight: "bold",
-              fontFamily: "'Montserrat', 'Gowun Dodum', sans-serif",
-            }}
-            title={post.title}
-          >
+      <div className="d-flex justify-content-between align-items-start fw-bold post-list-card-title-row">
+        <div className="text-truncate post-list-card-title">
+          <span className="post-list-card-title-text" title={post.title}>
             {post.title}
           </span>
         </div>
-        <span className="text-secondary ms-2" style={{ fontSize: "0.95rem", whiteSpace: "nowrap" }}>
+        <span className="text-secondary ms-2 post-list-card-date">
           {formatDate(post.updatedAt)}
         </span>
       </div>
 
-      <div
-        className="d-flex align-items-center flex-wrap gap-2 justify-content-between"
-        style={{ fontSize: "0.97rem" }}
-      >
+      <div className="d-flex align-items-center flex-wrap gap-2 justify-content-between post-list-card-meta">
         <div>
           <Badge bg={categoryColors[categoryLabel]} className="me-1">{categoryLabel}</Badge>
           <Badge bg={regionColors[regionLabel]} className="me-2">{regionLabel}</Badge>
-          <span style={{ color: "#222" }}>by {post.memberNickname}</span>
+          <span className="post-list-card-author">by {post.memberNickname}</span>
         </div>
         <div className="d-flex align-items-center">
-          <span className="badge text-dark d-flex align-items-center" style={{ fontSize: "1rem", fontWeight: 500 }}>
+          <span className="badge text-dark d-flex align-items-center post-list-card-stat">
             <i className="bi bi-eye me-1" />
             {post.viewCount}
           </span>
-          <span className="badge" style={{ color: "#ffc107", fontSize: "1rem", fontWeight: 500 }}>
+          <span className="badge post-list-card-star">
             <i className="bi bi-star-fill me-1" />
             {post.starAvg ? post.starAvg.toFixed(1) : 0}
           </span>

--- a/src/post/components/PostSearch.jsx
+++ b/src/post/components/PostSearch.jsx
@@ -113,7 +113,7 @@ const PostSearch = ({ selectedCategory, selectedRegion }) => {
         return (
             <>
                 {text.slice(0, idx)}
-                <mark style={{ background: "#ffe066", padding: 0 }}>{text.slice(idx, idx + keyword.length)}</mark>
+                <mark className="post-search-highlight">{text.slice(idx, idx + keyword.length)}</mark>
                 {text.slice(idx + keyword.length)}
             </>
         );
@@ -121,7 +121,7 @@ const PostSearch = ({ selectedCategory, selectedRegion }) => {
 
     return (
         <div>
-            <Card className="shadow-sm rounded-4 mx-auto" style={{ maxWidth: 700, padding: '32px 36px', background: '#fff' }}>
+            <Card className="shadow-sm rounded-4 mx-auto post-search-card">
                 <Row className="g-3">
                     <Col md={6}>
                         <div className="bg-light rounded-4 p-2 px-3 border">
@@ -136,7 +136,7 @@ const PostSearch = ({ selectedCategory, selectedRegion }) => {
                 </Row>
                 <Form className="mb-4" onSubmit={handleSubmit}>
                     <div className="text-center mb-3"></div>
-                    <div className="d-flex" style={{ gap: 8, position: "relative" }}>
+                    <div className="d-flex gap-2 position-relative">
                         <Form.Control
                             ref={inputRef}
                             type="search"
@@ -148,21 +148,12 @@ const PostSearch = ({ selectedCategory, selectedRegion }) => {
                             onFocus={() => setShowList(true)}
                             onBlur={handleBlur}
                             onKeyDown={handleKeyDown}
-                            style={{ height: "40px", flexGrow: 1, zIndex: 11 }}
+                            className="post-search-input"
                         />
                         {showList && (
-                            <ul
-                                ref={listRef}
-                                style={{
-                                    position: "absolute", top: 44, left: 0, right: 0, zIndex: 10,
-                                    margin: 0, padding: 0, background: "white",
-                                    border: "1px solid #eee", borderRadius: "0 0 12px 12px",
-                                    boxShadow: "0 6px 20px rgba(0,0,0,0.08)", listStyle: "none",
-                                    maxHeight: 260, overflowY: "auto", minWidth: 200, transition: "box-shadow 0.2s"
-                                }}
-                            >
+                            <ul ref={listRef} className="post-search-suggestions">
                                 {suggestions.length === 0 && (
-                                    <li style={{ padding: "12px 16px", color: "#bbb", fontStyle: "italic" }}>
+                                    <li className="post-search-suggestion-empty">
                                         검색 결과가 없습니다
                                     </li>
                                 )}
@@ -170,14 +161,7 @@ const PostSearch = ({ selectedCategory, selectedRegion }) => {
                                     <li
                                         key={idx}
                                         onMouseDown={() => handleSuggestionClick(item)}
-                                        style={{
-                                            padding: "12px 16px", cursor: "pointer",
-                                            background: idx === highlightIdx ? "#f8f9fa" : "transparent",
-                                            fontWeight: idx === highlightIdx ? "bold" : "normal",
-                                            color: "#333",
-                                            borderBottom: idx < suggestions.length - 1 ? "1px solid #f5f5f5" : "none",
-                                            fontSize: 17, transition: "background 0.1s"
-                                        }}
+                                        className={`post-search-suggestion${idx === highlightIdx ? " active" : ""}`}
                                         onMouseEnter={() => setHighlightIdx(idx)}
                                     >
                                         {highlightText(item)}
@@ -185,8 +169,7 @@ const PostSearch = ({ selectedCategory, selectedRegion }) => {
                                 ))}
                             </ul>
                         )}
-                        <Button variant="dark btn-sm" type="submit"
-                            style={{ whiteSpace: 'nowrap', padding: '0.2rem 0.35rem', height: "40px" }}>
+                        <Button variant="dark btn-sm" type="submit" className="post-search-btn">
                             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="mx-3" role="img" viewBox="0 0 24 24"><title>Search</title><circle cx="10.5" cy="10.5" r="7.5"></circle><path d="M21 21l-5.2-5.2"></path></svg>
                         </Button>
                     </div>

--- a/src/post/pages/PostDetailPage.jsx
+++ b/src/post/pages/PostDetailPage.jsx
@@ -108,23 +108,17 @@ const PostDetailPage = () => {
   return (
     <>
       {alert.show && (
-        <div
-          className={`alert alert-${alert.type} alert-dismissible`}
-          style={{ position: "fixed", top: 80, right: 24, zIndex: 9999, minWidth: 260 }}
-        >
+        <div className={`alert alert-${alert.type} alert-dismissible post-detail-alert`}>
           {alert.message}
         </div>
       )}
-      <div style={{ minHeight: "100vh", width: "100vw", overflowX: "hidden", position: "relative" }}>
-        <div className="container py-5 mt-5" style={{ minHeight: "100vh", maxWidth: "1600px" }}>
-          <div style={{ display: "flex", gap: "32px", width: "95%", margin: "0 auto", alignItems: "stretch" }}>
+      <div className="post-viewport">
+        <div className="container py-5 mt-5 post-detail-container">
+          <div className="post-detail-row">
             <PostContent post={post} liked={liked} onLike={handleLike} nickname={nickname} />
-            <Card
-              className="shadow-sm flex-fill"
-              style={{ borderRadius: "18px", width: "70%", minWidth: "0", background: "#fff", display: "flex", flexDirection: "column" }}
-            >
+            <Card className="shadow-sm flex-fill post-detail-comment-card">
               {post.postId && (
-                <Card.Body className="d-flex flex-column py-4" style={{ flex: 1 }}>
+                <Card.Body className="d-flex flex-column py-4 post-detail-comment-body">
                   <CommentPage
                     no={post.postId}
                     isLoggedIn={isLoggedIn}
@@ -141,13 +135,7 @@ const PostDetailPage = () => {
         </div>
         <button
           onClick={goToList}
-          className="btn btn-lg btn-primary"
-          style={{
-            position: "fixed", bottom: "36px", right: "48px", zIndex: 9999,
-            borderRadius: "50%", width: "64px", height: "64px",
-            display: "flex", alignItems: "center", justifyContent: "center",
-            boxShadow: "0 6px 16px #0002", fontSize: "2rem",
-          }}
+          className="btn btn-lg btn-primary post-detail-fab"
           title="목록으로 이동"
         >
           <i className="bi bi-list"></i>

--- a/src/post/pages/PostEditPage.jsx
+++ b/src/post/pages/PostEditPage.jsx
@@ -142,35 +142,33 @@ const PostEditPage = () => {
     const imageSection = (
         <div className="mb-4">
             <label className="form-label fw-semibold">
-                사진 첨부 <span className="text-secondary" style={{ fontSize: "0.95em" }}>(여러 장 첨부 가능)</span>
+                사진 첨부 <span className="text-secondary post-image-hint">(여러 장 첨부 가능)</span>
             </label>
             <div className="bg-light rounded-4 p-3 px-4 border">
                 <input type="file" accept="image/*" multiple onChange={handleNewImageChange} className="form-control mb-3" />
                 <div className="d-flex flex-wrap gap-3">
                     {existingImages.map((img, idx) => (
-                        <div key={`exist-${idx}`} style={{ position: 'relative' }}>
+                        <div key={`exist-${idx}`} className="position-relative">
                             <img
                                 src={`${IMAGE_BASE_URL}/${img.imageKey}`}
                                 alt={`existing-${idx}`}
-                                style={{ width: 100, height: 100, objectFit: 'cover', borderRadius: 14, border: '1px solid #eee', boxShadow: "0 2px 6px rgba(0,0,0,0.06)" }}
+                                className="post-image-preview"
                             />
                             <button
-                                type="button" className="btn btn-danger btn-sm"
-                                style={{ position: 'absolute', top: 5, right: 5, borderRadius: '50%', padding: '2px 7px', fontSize: "1.05rem" }}
+                                type="button" className="btn btn-danger btn-sm post-image-remove-btn"
                                 onClick={() => handleExistingImageRemove(idx)}
                             >×</button>
                         </div>
                     ))}
                     {newImagePreviews.map((src, idx) => (
-                        <div key={`new-${idx}`} style={{ position: 'relative' }}>
+                        <div key={`new-${idx}`} className="position-relative">
                             <img
                                 src={src}
                                 alt={`new-${idx}`}
-                                style={{ width: 100, height: 100, objectFit: 'cover', borderRadius: 14, border: '1px solid #eee', boxShadow: "0 2px 6px rgba(0,0,0,0.06)" }}
+                                className="post-image-preview"
                             />
                             <button
-                                type="button" className="btn btn-danger btn-sm"
-                                style={{ position: 'absolute', top: 5, right: 5, borderRadius: '50%', padding: '2px 7px', fontSize: "1.05rem" }}
+                                type="button" className="btn btn-danger btn-sm post-image-remove-btn"
                                 onClick={() => handleNewImageRemove(idx)}
                             >×</button>
                         </div>

--- a/src/post/pages/PostListPage.jsx
+++ b/src/post/pages/PostListPage.jsx
@@ -98,23 +98,17 @@ const PostListPage = () => {
   };
 
   return (
-    <div className="bg-light min-vh-100 py-4" style={{ overflowX: "hidden" }}>
-      <div style={{ marginTop: "3rem" }} />
+    <div className="bg-light min-vh-100 py-4 post-list-page">
+      <div className="mt-5" />
       <PostSearch selectedCategory={category} selectedRegion={region} />
-      <div
-        style={{
-          height: "3.5px", width: "60px", margin: "0.7rem auto 1.1rem auto",
-          borderRadius: "2rem", background: "linear-gradient(90deg,#bdaafc 20%, #92e0f6 90%)",
-          opacity: 0.88, marginTop: "1rem", marginBottom: "5rem"
-        }}
-      />
-      <div className="container py-3" style={{ maxWidth: 850 }}>
+      <div className="post-list-divider" />
+      <div className="container py-3 post-list-container">
         <div className="d-flex justify-content-between align-items-center mb-4">
           <div>
             <h3 className="fw-bold mb-1 page-title">
               여행지 목록
             </h3>
-            <div className="text-secondary" style={{ fontSize: "1.07rem" }}>
+            <div className="text-secondary post-subtitle">
               인기 여행지의 다양한 후기를 만나보세요!
             </div>
           </div>
@@ -135,8 +129,7 @@ const PostListPage = () => {
             </div>
             {isLoggedIn && (
               <button
-                className="btn fw-bold px-4"
-                style={{ background: "linear-gradient(90deg, #a084ee 30%, #7c3aed 100%)", color: "#fff", border: "none" }}
+                className="btn fw-bold px-4 post-write-btn"
                 onClick={goToWrite}
               >글쓰기</button>
             )}
@@ -183,9 +176,8 @@ const PostListPage = () => {
           {Array.from({ length: pagination.totalPages }, (_, i) => i).map(num => (
             <button
               key={num}
-              className={`btn mx-1 px-3 ${page === num ? 'btn-primary' : 'btn-outline-primary'}`}
+              className={`btn mx-1 px-3 ${page === num ? 'btn-primary fw-bold' : 'btn-outline-primary'}`}
               onClick={() => handlePage(num)}
-              style={{ fontWeight: page === num ? 'bold' : undefined }}
             >
               {num + 1}
             </button>

--- a/src/post/pages/PostWritePage.jsx
+++ b/src/post/pages/PostWritePage.jsx
@@ -99,20 +99,19 @@ const PostWritePage = () => {
     const imageSection = (
         <div className="mb-4">
             <label className="form-label fw-semibold">
-                사진 첨부 <span className="text-secondary" style={{ fontSize: "0.95em" }}>(필수)</span>
+                사진 첨부 <span className="text-secondary post-image-hint">(필수)</span>
             </label>
             <div className="bg-light rounded-4 p-3 px-4 border">
                 <input type="file" accept="image/*" multiple onChange={handleImageChange} className="form-control mb-3" />
                 <div className="d-flex flex-wrap gap-3">
                     {imagePreviews.map((src, idx) => (
-                        <div key={idx} style={{ position: 'relative' }}>
+                        <div key={idx} className="position-relative">
                             <img
                                 src={src} alt={`preview-${idx}`}
-                                style={{ width: 100, height: 100, objectFit: 'cover', borderRadius: 14, border: '1px solid #eee', boxShadow: "0 2px 6px rgba(0,0,0,0.06)" }}
+                                className="post-image-preview"
                             />
                             <button
-                                type="button" className="btn btn-danger btn-sm"
-                                style={{ position: 'absolute', top: 5, right: 5, borderRadius: '50%', padding: '2px 7px', fontSize: "1.05rem" }}
+                                type="button" className="btn btn-danger btn-sm post-image-remove-btn"
                                 onClick={() => handleImageRemove(idx)}
                             >×</button>
                         </div>


### PR DESCRIPTION
## 관련 이슈
closes #50

## 변경 사항
- `src/post/` 8개 파일의 인라인 `style={{...}}` **61곳**을 `src/css/post.css` 클래스로 이관
- 색상/그라디언트/shadow/radius/z-index는 `tokens.css` 변수 참조 (`--card-shadow`, `--radius-card`, `--z-floating`, `--container-*` 등)
- 이미지 미리보기 스타일(썸네일/삭제 버튼)을 Write/Edit 공용 클래스(`post-image-preview`, `post-image-remove-btn`)로 통합

## 작업 방법
- 정적 인라인 스타일 → 케밥케이스 `post-` 접두사 클래스로 추출
- 검색 자동완성 highlight: 런타임 인라인 대신 `:last-child`(구분선) / `.active`(강조) CSS 클래스로 처리
- 레이아웃 간격은 Bootstrap 유틸리티 우선 (`mt-5`=3rem, `gap-2`=8px, `position-relative`, `text-nowrap`)
- 페이지네이션 활성 버튼 `fontWeight` 인라인 → 조건부 `fw-bold` 클래스

## 테스트
- ESLint 통과 (0 errors)
- 인라인 스타일 잔여 0곳 확인 (`grep "style={{" src/post/`)
- 시각 동일성: 값 변환 없이 동일 값으로 클래스화 (여행지 목록/상세/작성/수정/검색 화면)
- `PostListCard`는 `LikeListPage`/`CheckMyArt`에서도 재사용 → 동일 값 이관으로 영향 없음