### PR TITLE
♻️ Phase 3 — board/sign/comment/log 화면 인라인 스타일 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ src/css/
 - [ ] JSX 내 `<style>` 태그 13곳을 CSS 파일로 이동
 - [ ] Navbar/Footer/NavMenu 인라인 스타일 → `common.css`
 
-### Phase 3 — 화면 단위 인라인 스타일 제거 (화면당 1 PR)
+### Phase 3 — 화면 단위 인라인 스타일 제거
 - [ ] post 화면 (`src/post/`) → `post.css`
 - [ ] 메인/랭킹 화면 (`src/board/`) → `main.css`
 - [ ] sign/마이페이지 (`src/sign/`, `src/common/MyPage` 등) → `sign.css`

--- a/src/board/component/page/AdmnBoard.jsx
+++ b/src/board/component/page/AdmnBoard.jsx
@@ -46,32 +46,31 @@ const BoardList = ({ title, boards, loading, error, categoryColors, regionColors
                     <div
                         key={board.postId}
                         className="p-3 rounded-3 border board-list-card"
-                        style={{ background: "#fff", minHeight: "88px", boxShadow: "0 2px 10px 0 rgba(0,0,0,0.04)", position: "relative" }}
                         tabIndex={0}
                         onClick={() => onClickCard(board)}
                         onKeyDown={e => { if (e.key === "Enter" || e.key === " ") onClickCard(board); }}
                     >
-                        <div className="d-flex justify-content-between align-items-start fw-bold" style={{ fontSize: "1.12rem", marginBottom: 6 }}>
-                            <div className="text-truncate" style={{ maxWidth: "75%" }}>
-                                <span style={{ color: "#222", fontWeight: "bold", fontFamily: "'Montserrat', 'Gowun Dodum', sans-serif" }} title={board.title}>
+                        <div className="d-flex justify-content-between align-items-start fw-bold board-list-card-title-row">
+                            <div className="text-truncate board-list-card-title">
+                                <span className="board-list-card-title-text" title={board.title}>
                                     {board.title}
                                 </span>
                             </div>
-                            <span className="text-secondary ms-2" style={{ fontSize: "0.95rem", whiteSpace: "nowrap" }}>
+                            <span className="text-secondary ms-2 board-list-card-date">
                                 {formatDate(board.updatedAt)}
                             </span>
                         </div>
-                        <div className="d-flex align-items-center flex-wrap gap-2 justify-content-between" style={{ fontSize: "0.97rem", minHeight: "36px" }}>
+                        <div className="d-flex align-items-center flex-wrap gap-2 justify-content-between board-list-card-meta">
                             <div>
                                 <Badge bg={categoryColors[CATEGORY_CODE_TO_LABEL[board.category] ?? board.category]} className="me-1">{CATEGORY_CODE_TO_LABEL[board.category] ?? board.category}</Badge>
                                 <Badge bg={regionColors[REGION_CODE_TO_LABEL[board.region] ?? board.region]} className="me-2">{REGION_CODE_TO_LABEL[board.region] ?? board.region}</Badge>
-                                <span style={{ color: "#222" }}>by {board.memberNickname}</span>
+                                <span className="board-list-card-author">by {board.memberNickname}</span>
                             </div>
                             <div className="d-flex align-items-center">
-                                <span className="badge text-dark d-flex align-items-center" style={{ fontSize: "1rem", fontWeight: 500 }}>
+                                <span className="badge text-dark d-flex align-items-center board-list-card-stat">
                                     <i className="bi bi-eye me-1" />{board.viewCount || 0}
                                 </span>
-                                <span className="badge" style={{ color: "#ffc107", fontSize: "1rem", fontWeight: 500 }}>
+                                <span className="badge board-list-card-star">
                                     <i className="bi bi-star-fill me-1" />{board.starAvg ? board.starAvg.toFixed(1) : 0}
                                 </span>
                                 {onRemove &&
@@ -158,18 +157,17 @@ const AdmnBoard = () => {
     };
 
     return (
-        <div style={{ marginTop: 80 }}>
+        <div className="admin-page-spacer">
             {showConfirm && (
-                <div className="modal show fade d-block" tabIndex={-1}
-                    style={{ background: 'rgba(22, 22, 37, 0.40)', backdropFilter: "blur(2px)", zIndex: 1050 }}>
+                <div className="modal show fade d-block admin-modal-backdrop" tabIndex={-1}>
                     <div className="modal-dialog modal-dialog-centered">
-                        <div className="modal-content" style={{ borderRadius: "1.3rem", boxShadow: "0 6px 32px 0 rgba(80,55,255,0.08)" }}>
+                        <div className="modal-content admin-modal-content">
                             <div className="modal-header border-0">
                                 <h5 className="modal-title text-danger fw-semibold">
                                     <i className="bi bi-trash3 me-2"></i>게시글 삭제
                                 </h5>
-                                <button type="button" className="btn-close" aria-label="닫기"
-                                    style={{ filter: "invert(0.5)" }} onClick={() => setShowConfirm(false)} />
+                                <button type="button" className="btn-close admin-modal-close-icon" aria-label="닫기"
+                                    onClick={() => setShowConfirm(false)} />
                             </div>
                             <div className="modal-body text-center">
                                 <p className="fs-5 mb-3 text-dark">정말 <span className="fw-bold text-danger">삭제</span>하시겠습니까?</p>
@@ -184,11 +182,11 @@ const AdmnBoard = () => {
                     </div>
                 </div>
             )}
-            <div className="container" style={{ maxWidth: 1500, paddingBottom: 40 }}>
+            <div className="container admin-board-container">
                 <h2 className="fw-bold">여행지 관리</h2>
                 <div className="row g-4">
                     <div className="col-12">
-                        <div className="panel-bg p-4 rounded-4 h-100 shadow-sm" style={{ background: "rgba(250,251,255,0.97)", minHeight: 540 }}>
+                        <div className="panel-bg p-4 rounded-4 h-100 shadow-sm admin-board-panel">
                             <BoardList
                                 title={<span className="text-info"><i className="bi bi-search me-1"></i>게시글 목록</span>}
                                 boards={esBoards} loading={esLoading} error={esError}

--- a/src/board/component/page/AdmnPage.jsx
+++ b/src/board/component/page/AdmnPage.jsx
@@ -8,7 +8,7 @@ const AdmnPage = () => {
 
     <div>
 
-      <header style={{ marginTop: '80px' }}>        {/* 간격조정 */}
+      <header className="admin-page-spacer">        {/* 간격조정 */}
 
       </header>
 

--- a/src/board/component/page/CategoryCard.jsx
+++ b/src/board/component/page/CategoryCard.jsx
@@ -2,17 +2,9 @@
 const CategoryCard = ({ selectedCategory, setCategory }) => {
     const categories = ["축제", "공연", "행사", "체험", "쇼핑", "자연", "역사", "가족", "음식"];
     return (
-        <div style={{ minWidth: 240, maxWidth: 350 }}>
-            <div className="fw-bold mb-3 d-flex align-items-center" style={{ color: "#1565c0", fontSize: "1.18rem" }}>
-                <i
-                    className="bi bi-tag-fill me-2"
-                    style={{
-                        fontSize: "1.3rem",
-                        background: "linear-gradient(90deg, #42a5f5 10%, #7e57c2 80%)",
-                        WebkitBackgroundClip: "text",
-                        WebkitTextFillColor: "transparent"
-                    }}
-                />
+        <div className="selector-panel">
+            <div className="fw-bold mb-3 d-flex align-items-center selector-heading">
+                <i className="bi bi-tag-fill me-2 selector-icon-gradient" />
                 카테고리 선택
             </div>
             <div className="row row-cols-3 g-3">
@@ -22,22 +14,6 @@ const CategoryCard = ({ selectedCategory, setCategory }) => {
                             className={`text-center category-card-btn shadow-sm
                                 ${selectedCategory === category ? "category-card-active" : ""}`}
                             onClick={() => setCategory(selectedCategory === category ? "" : category)}
-                            style={{
-                                borderRadius: "18px",
-                                background: selectedCategory === category
-                                    ? "linear-gradient(90deg,#e3f2fd 70%,#ede7f6 100%)"
-                                    : "#f7fafd",
-                                color: selectedCategory === category ? "#1760c6" : "#7b8da3",
-                                fontWeight: selectedCategory === category ? 700 : 500,
-                                cursor: "pointer",
-                                padding: "14px 0",
-                                boxShadow: selectedCategory === category
-                                    ? "0 4px 16px 0 rgba(33, 150, 243, 0.10)"
-                                    : "0 2px 7px 0 rgba(90,120,180,0.06)",
-                                outline: "none",
-                                transform: selectedCategory === category ? "scale(1.07)" : "scale(1)",
-                                transition: "all 0.16s cubic-bezier(.5,1.7,.76,1.18)"
-                            }}
                             tabIndex={0}
                             onKeyPress={e => {
                                 if (e.key === "Enter" || e.key === " ") setCategory(category);

--- a/src/board/component/page/MainPage.jsx
+++ b/src/board/component/page/MainPage.jsx
@@ -42,136 +42,40 @@ const MainPage = () => {
   }, []);
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        background: "#F5F6FF",
-        width: "100%",
-        overflowX: "hidden",
-        marginTop: "-1px"
-      }}
-    >
+    <div className="mainpage-root">
       {/* 히어로 섹션 */}
       <div
+        className="mainpage-hero"
         style={{
-          width: "100%",
-          minHeight: "500px",
           background: `linear-gradient(180deg, rgba(70,70,110,0.14) 15%, rgba(255,255,255,0.91) 65%), url(${tgd3}) center/cover no-repeat`,
-          position: "relative",
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          marginBottom: "32px",
-
         }}
       >
         {/* 히어로 콘텐츠 */}
-        <div
-          style={{
-            width: "100%",
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            position: "relative",
-            zIndex: 2,
-
-          }}
-        >
-          <div
-            style={{
-              textAlign: "center",
-              position: "relative",
-              display: "inline-block",
-              padding: "1rem 4.5rem 10rem 4.5rem",
-              background: "rgba(255,255,255,0.65)",
-              boxShadow: "0 6px 36px rgba(80,60,180,0.08)",
-              backdropFilter: "blur(4px)",
-              border: "1.5px solid rgba(190,180,255,0.13)",
-              zIndex: 3,
-              minWidth: 320,
-              maxWidth: "94vw"
-            }}
-          >
+        <div className="mainpage-hero-content">
+          <div className="mainpage-hero-panel">
             {/* 그라데이션 타이틀 */}
-            <h2
-              style={{
-                fontSize: "3.42rem",
-                fontWeight: 900,
-                letterSpacing: "-0.04em",
-                background: "linear-gradient(90deg, #B794F4 40%, #90CDF4 100%)",
-                WebkitBackgroundClip: "text",
-                WebkitTextFillColor: "transparent",
-                backgroundClip: "text",
-                color: "transparent",
-                textShadow: "0 1px 10px rgba(160,160,220,0.09)",
-                margin: 0,
-                fontFamily: "'Montserrat', 'Gowun Dodum', sans-serif"
-              }}
-            >
+            <h2 className="mainpage-hero-title">
               Trip Now!
             </h2>
             {/* 장식선 */}
-            <div
-              style={{
-                height: "3.5px",
-                width: "60px",
-                margin: "0.7rem auto 1.1rem auto",
-                borderRadius: "2rem",
-                background: "linear-gradient(90deg,#bdaafc 20%, #92e0f6 90%)",
-                opacity: 0.88
-              }}
-            />
+            <div className="mainpage-hero-divider" />
             {/* 서브텍스트 */}
-            <p style={{
-              color: "#5B4B9A",
-              fontWeight: 500,
-              fontSize: "1.16rem",
-              margin: "0.7rem 0 0 0",
-              textShadow: "0 2px 8px rgba(255,255,255,0.09)"
-            }}>
+            <p className="mainpage-hero-subtext">
               지금, 가장 인기 있는 여행지를 만나보세요!<br />
               모두의 이야기에서 당신만의 여행을 찾아보세요.
             </p>
           </div>
         </div>
         {/* 하단 블러/그라데이션 오버레이 */}
-        <div style={{
-          position: "absolute",
-          left: 0, right: 0, bottom: 0,
-          height: "100px",
-          background: "linear-gradient(180deg, rgba(245,245,255,0) 0%, rgba(245,245,255,0.84) 100%)",
-          zIndex: 2
-        }} />
+        <div className="mainpage-hero-overlay" />
       </div>
 
       {/* 본문 컨테이너 (검색 + 카드) */}
-      <div
-        style={{
-          position: "relative",
-          left: "50%",
-          transform: "translateX(-50%)",
-          width: "100%",
-          maxWidth: "1020px",
-          zIndex: 2,
-          padding: "0 16px",
-          marginTop: "-265px"
-        }}
-      >
+      <div className="mainpage-body-container">
         <div >
           <PostSearch />
-          <div style={{ marginBottom: "32px", marginTop: "5rem" }}>
-            <h2 style={{
-              textAlign: "start",
-              width: "100%",
-              fontFamily: "'Montserrat', 'Gowun Dodum', sans-serif",
-              color: "#a68eff",
-              fontWeight: 900,
-              fontSize: "2.35rem",
-              margin: "0 0 26px 0",
-              letterSpacing: "-0.03em",
-              textShadow: "0 2px 16px rgba(92,67,226,0.08)",
-              transform: "translateY(28px)"
-            }}>
+          <div className="mainpage-top5-section">
+            <h2 className="mainpage-section-title">
               실시간 인기 여행지
             </h2>
 
@@ -183,32 +87,12 @@ const MainPage = () => {
 
       {/* 지역/카테고리별 */}
       <div >
-        <div style={{ marginTop: "8rem" }} >
-          <h4 style={{            
-            paddingLeft: "19rem",
-            textAlign: "left",
-            fontFamily: "'Montserrat', 'Gowun Dodum', sans-serif",
-            color: "#b7aaff",
-            fontWeight: 700,
-            fontSize: "1.55rem",
-            letterSpacing: "-0.03em",
-            marginBottom: "1.4rem"
-          }}
-            className="text-left mb-4">실시간 인기 카테고리</h4>
+        <div className="mainpage-category-section" >
+          <h4 className="text-left mb-4 mainpage-subsection-title">실시간 인기 카테고리</h4>
           <MainPageCardsLayout2 top5Data={top5Category} />
         </div>
-        <div style={{ marginTop: "6rem"}}>
-          <h4 style={{
-            paddingLeft: "19rem",
-            textAlign: "left",
-            fontFamily: "'Montserrat', 'Gowun Dodum', sans-serif",
-            color: "#b7aaff",
-            fontWeight: 700,
-            fontSize: "1.55rem",
-            letterSpacing: "-0.03em",
-            marginBottom: "1.4rem"
-          }}
-            className="text-left mb-4">실시간 인기 지역</h4>
+        <div className="mainpage-region-section">
+          <h4 className="text-left mb-4 mainpage-subsection-title">실시간 인기 지역</h4>
           <MainPageCardsLayout2 top5Data={top5Region} />
         </div>
 

--- a/src/board/component/page/MainPageCard/MainPageCard.jsx
+++ b/src/board/component/page/MainPageCard/MainPageCard.jsx
@@ -24,10 +24,7 @@ const MainPageCard = ({ postId, score, rank }) => {
   }, [postId]);
 
   return (
-    <div
-      className="w-100 h-100 d-flex align-items-stretch position-relative"
-      style={{ position: 'relative' }} // 반드시 필요!
-    >
+    <div className="w-100 h-100 d-flex align-items-stretch position-relative">
       {/* 1등 왕관 배지 (hover와 무관, 항상 위) */}
       {(rank === 1 || rank === undefined) && (
         <div className="main-rank-crown">
@@ -37,53 +34,21 @@ const MainPageCard = ({ postId, score, rank }) => {
 
       {/* 카드 본문 */}
       <div
-        className="mainpage-card-hover card border-0 shadow-lg rounded-4 overflow-hidden w-100"
-        style={{
-          background: "rgba(250,250,255,0.96)",
-          boxShadow: "0 8px 32px rgba(60,60,100,0.14)",
-          height: "100%",
-          display: "flex",
-          flexDirection: "column",
-          transition: "transform 0.25s cubic-bezier(.19,1,.22,1), box-shadow 0.22s",
-          cursor: "pointer",
-          zIndex: 1, // 왕관보다 낮음 (중요)
-        }}
+        className="mainpage-card-hover mainpage-card-body card border-0 shadow-lg rounded-4 overflow-hidden w-100"
         onClick={() => navigate(`/post/detail/?no=${board.postId}`)}
       >
         {/* 이미지 */}
-        <div style={{ position: "relative", width: "100%" }}>
+        <div className="mainpage-card-image-wrap">
           {board.images && board.images.length > 0 ? (
             <img
               src={`${process.env.REACT_APP_IMAGE_BASE_URL}/${board.images[0].imageKey}`}
               alt="Main visual"
-              className="card-img-top"
-              style={{
-                height: '390px',
-                width: '100%',
-                objectFit: 'cover',
-                filter: "brightness(98%)",
-                display: 'block'
-              }}
+              className="card-img-top mainpage-card-image"
             />
           ) : (
-            <div style={{ height: '390px', background: "#f3f3f8" }} />
+            <div className="mainpage-card-image-placeholder" />
           )}
-          <div style={{
-            position: "absolute",
-            bottom: "18px",
-            left: "20px",
-            background: "rgba(30,30,55,0.56)",
-            color: "#fff",
-            padding: "0.75rem 1.25rem",
-            borderRadius: "1.2rem",
-            fontWeight: 600,
-            fontSize: "1.2rem",
-            letterSpacing: "-0.01em",
-            boxShadow: "0 2px 8px rgba(0,0,0,0.07)",
-            display: "flex",
-            alignItems: "center",
-            gap: "0.6rem"
-          }}>
+          <div className="mainpage-card-overlay-badge">
             Score:
             {/* start prop을 주면 react-countup이 렌더 중 ref가 붙기 전 인스턴스를 생성해 크래시 — preserveValue가 이전 값 유지를 담당 */}
             <CountUp
@@ -95,13 +60,13 @@ const MainPageCard = ({ postId, score, rank }) => {
           </div>
         </div>
         <div className="card-body px-4 py-4">
-          <div className="mb-3" style={{ fontSize: "1.09rem", color: "#333", fontWeight: 500 }}>
+          <div className="mb-3 mainpage-card-title">
             {board.title}
           </div>
           <div className="d-flex justify-content-between align-items-center mt-2">
             {/* 작성자 이름 한 줄로 보이게 수정?*/}
-            <small className="text-muted" style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', display: 'block', maxWidth: 220 }}>
-              by <b style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', verticalAlign: 'bottom', maxWidth: 90, display: 'inline-block' }}>{board.memberNickname}</b>
+            <small className="text-muted mainpage-card-nickname">
+              by <b className="mainpage-card-nickname-name">{board.memberNickname}</b>
             </small>
           </div>
         </div>

--- a/src/board/component/page/MainPageCard/MainPageCard2.jsx
+++ b/src/board/component/page/MainPageCard/MainPageCard2.jsx
@@ -28,7 +28,7 @@ const MainPageCard2 = ({ postId, score, rank }) => {
   }, [postId]);
 
   return (
-    <div className="w-100 h-100 d-flex align-items-stretch position-relative" style={{ minHeight: 112, position: 'relative' }}>
+    <div className="w-100 h-100 d-flex align-items-stretch position-relative mainpage-card2-wrap">
       {/* --- 순위 뱃지 (배경색은 rank별 런타임 값이라 인라인 유지) --- */}
       {rank &&
         <div className="main-rank-badge" style={{ background: rankColors[(rank - 1) % 5] }}>
@@ -37,60 +37,26 @@ const MainPageCard2 = ({ postId, score, rank }) => {
       }
 
       <div
-        className="mainpage-card2-hover card border-0 shadow rounded-4 overflow-hidden w-100"
-        style={{
-          height: '100%',
-          width: "100%",
-          borderRadius: "1.3rem",
-          display: "flex",
-          flexDirection: "row",
-          alignItems: "center",
-          transition: "transform 0.22s cubic-bezier(.19,1,.22,1), box-shadow 0.18s",
-          cursor: "pointer",
-          zIndex: 1, // 뱃지보다 낮게!
-        }}
+        className="mainpage-card2-hover mainpage-card2-body card border-0 shadow rounded-4 overflow-hidden w-100"
         onClick={() => { navigate(`/post/detail/?no=${board.postId}`); }}
       >
         {/* 이미지 or 배경 */}
-        <div style={{ width: "40%", height: "100%" }}>
+        <div className="mainpage-card2-image-wrap">
           {board.images && board.images.length > 0 ? (
             <img
               src={`${process.env.REACT_APP_IMAGE_BASE_URL}/${board.images[0].imageKey}`}
               alt="preview"
-              style={{
-                width: "100%",
-                height: "100%",
-                objectFit: "cover",
-                borderTopLeftRadius: "1.3rem",
-                borderBottomLeftRadius: "1.3rem"
-              }}
+              className="mainpage-card2-image"
             />
           ) : (
-            <div style={{
-              width: "100%",
-              height: "100%",
-              background: "#e9e5fa"
-            }} />
+            <div className="mainpage-card2-image-placeholder" />
           )}
         </div>
-        <div className="card-body py-3 px-4 d-flex flex-column justify-content-center" style={{ width: "60%" }}>
-          <h6 className="fw-bold" style={{
-            color: "#6247aa",
-            fontSize: "1.09rem",
-            marginBottom: 6,
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis"
-          }}>
+        <div className="card-body py-3 px-4 d-flex flex-column justify-content-center mainpage-card2-content">
+          <h6 className="fw-bold mainpage-card2-title">
             {board.title}
           </h6>
-          <div style={{
-            color: "#555",
-            fontSize: "0.97rem",
-            height: "2.3em",
-            overflow: "hidden",
-            textOverflow: "ellipsis"
-          }}>
+          <div className="mainpage-card2-score">
             score:&nbsp;
             {/* start prop을 주면 react-countup이 렌더 중 ref가 붙기 전 인스턴스를 생성해 크래시 — preserveValue가 이전 값 유지를 담당 */}
             <CountUp
@@ -102,8 +68,8 @@ const MainPageCard2 = ({ postId, score, rank }) => {
           </div>
           <div className="d-flex justify-content-between align-items-center mt-2">
             {/* 닉네임 한줄로 보이게 수정 */}
-            <small className="text-muted" style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', display: 'block', maxWidth: 220 }}>
-              by <b style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', verticalAlign: 'bottom', maxWidth: 90, display: 'inline-block' }}>{board.memberNickname}</b>
+            <small className="text-muted mainpage-card-nickname">
+              by <b className="mainpage-card-nickname-name">{board.memberNickname}</b>
             </small>
           </div>
         </div>

--- a/src/board/component/page/MainPageCard/RankCard.jsx
+++ b/src/board/component/page/MainPageCard/RankCard.jsx
@@ -56,10 +56,7 @@ const RankCard = ({ data, type, rank }) => {
         : (CATEGORY_CODE_TO_LABEL[data] || data);
 
     return (
-        <div
-            className="w-100 h-100 d-flex align-items-stretch position-relative"
-            style={{ position: 'relative' }} // 반드시 필요!
-        >
+        <div className="w-100 h-100 d-flex align-items-stretch position-relative">
             {/* 1등 왕관 배지 (hover와 무관, 항상 위) */}
             {(rank === 1 || rank === undefined) && (
                 <div className="main-rank-crown">
@@ -69,55 +66,22 @@ const RankCard = ({ data, type, rank }) => {
 
             {/* 카드 본문 */}
             <div
-                className="mainpage-card-hover card border-0 shadow-lg rounded-4 overflow-hidden w-100"
-                style={{
-                    background: "rgba(250,250,255,0.96)",
-                    boxShadow: "0 8px 32px rgba(60,60,100,0.14)",
-                    height: "100%",
-                    display: "flex",
-                    flexDirection: "column",
-                    transition: "transform 0.25s cubic-bezier(.19,1,.22,1), box-shadow 0.22s",
-                    cursor: "pointer",
-                    zIndex: 1, // 왕관보다 낮음 (중요)
-                }}
+                className="mainpage-card-hover mainpage-card-body card border-0 shadow-lg rounded-4 overflow-hidden w-100"
                 onClick={() => navigate(`/post/list/?${type}=${data}`)}
             >
                 {/* 이미지 */}
-                <div style={{ position: "relative", width: "100%" }}>
+                <div className="mainpage-card-image-wrap">
                     {data ? (
                         <img
                             src={images[label]}
                             alt="Main visual"
-                            className="card-img-top"
-                            style={{
-                                height: '200px',
-                                width: '100%',
-                                objectFit: 'cover',
-                                filter: "brightness(98%)",
-                                display: 'block'
-                            }}
+                            className="card-img-top rank-card-image"
                         />
                     ) : (
-                        <div style={{ height: '200px', background: "#f3f3f8" }} />
+                        <div className="rank-card-image-placeholder" />
                     )}
-                    <div style={{
-                        position: "absolute",
-                        bottom: "18px",
-                        left: "20px",
-                        background: "rgba(30,30,55,0.56)",
-                        color: "#fff",
-                        padding: "0.75rem 1.25rem",
-                        borderRadius: "1.2rem",
-                        fontWeight: 600,
-                        fontSize: "1.2rem",
-                        letterSpacing: "-0.01em",
-                        boxShadow: "0 2px 8px rgba(0,0,0,0.07)",
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "0.6rem"
-                    }}>
-                        <span style={{ color: "#e0c3fc", fontWeight: 700 }}>{label}</span>
-
+                    <div className="mainpage-card-overlay-badge">
+                        <span className="mainpage-card-overlay-label">{label}</span>
                     </div>
                 </div>
             </div>

--- a/src/board/component/page/MainPageCardsLayout.jsx
+++ b/src/board/component/page/MainPageCardsLayout.jsx
@@ -21,24 +21,9 @@ const MainPageCardsLayout = ({ top5Posts }) => {
 
     // 데이터 있을 때 카드 레이아웃 렌더링
     return (
-        <div
-            className="d-flex justify-content-center align-items-stretch"
-            style={{
-                minHeight: `${mainCardHeight}px`,
-                gap: '36px',
-                width: "100%",
-                marginTop: "48px"
-            }}
-        >
+        <div className="d-flex justify-content-center align-items-stretch mainpage-layout-row">
             {/* 왼쪽 큰 카드 (1위) */}
-            <div
-                style={{
-                    width: "720px",
-                    height: `${mainCardHeight}px`,
-                    display: 'flex',
-                    alignItems: 'stretch'
-                }}
-            >
+            <div className="mainpage-layout-primary">
                 <AnimatePresence mode="wait">
                     <motion.div
                         key={top5Posts[0].postId}
@@ -46,30 +31,10 @@ const MainPageCardsLayout = ({ top5Posts }) => {
                         animate={{ opacity: 1, scale: 1, y: 0 }}
                         exit={{ opacity: 0, scale: 0.93, y: -18 }}
                         transition={{ type: "spring", stiffness: 360, damping: 30 }}
-                        style={{ width: "100%", height: "100%", position: 'relative' }}
+                        className="mainpage-layout-primary-motion"
                     >
                         <AnimatePresence mode="wait">
-                            <div
-                                style={{
-                                    position: 'absolute',
-                                    top: 22,
-                                    left: 22,
-                                    zIndex: 99,
-                                    pointerEvents: "none",
-                                    width: 54,
-                                    height: 54,
-                                    display: "flex",
-                                    alignItems: "center",
-                                    justifyContent: "center",
-                                    background: 'linear-gradient(135deg, #ffd700 70%, #fff9c4 100%)',
-                                    color: "#725b10",
-                                    fontWeight: 900,
-                                    borderRadius: "50%",
-                                    fontSize: "2rem",
-                                    border: "3px solid #fffbe8",
-                                    boxShadow: "0 4px 12px rgba(180,140,20,0.13)"
-                                }}
-                            >
+                            <div className="main-rank-crown">
                                 <motion.div
                                     key={top5Posts[0].postId}
                                     initial={{ opacity: 0.6, scale: 1.1, boxShadow: "0 0 14px 8px #ffd70044" }}
@@ -91,26 +56,9 @@ const MainPageCardsLayout = ({ top5Posts }) => {
                                         ease: "easeInOut",
                                         exit: { duration: 1.5, ease: "easeInOut" }
                                     }}
-                                    style={{
-                                        display: "flex",
-                                        alignItems: "center",
-                                        justifyContent: "center",
-                                        width: "100%",
-                                        height: "100%",
-                                        borderRadius: "50%",
-                                        background: "none",
-                                        boxShadow: "none"
-                                    }}
+                                    className="mainpage-layout-crown-glow"
                                 >
-                                    <span
-                                        role="img"
-                                        aria-label="king-crown"
-                                        style={{
-                                            fontSize: "2.2rem",
-                                            marginTop: "-4px",
-                                            pointerEvents: "none"
-                                        }}
-                                    >
+                                    <span role="img" aria-label="king-crown">
                                         👑
                                     </span>
                                 </motion.div>
@@ -125,25 +73,12 @@ const MainPageCardsLayout = ({ top5Posts }) => {
             </div>
 
             {/* 오른쪽 2~5위 카드 */}
-            <div
-                style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    justifyContent: "space-between",
-                    height: `${mainCardHeight}px`,
-                    width: "360px",
-                    gap: "18px"
-                }}
-            >
+            <div className="mainpage-layout-secondary">
                 {top5Posts.slice(1, 5).map((board, idx) => (
                     <motion.div
                         key={board.postId}
                         layout
-                        style={{
-                            height: `calc((100% - 54px) / 4)`,
-                            minHeight: "0",
-                            display: 'flex'
-                        }}
+                        className="mainpage-layout-secondary-item"
                         transition={{ type: "spring", stiffness: 350, damping: 34 }}
                     >
                         <MainPageCard2 postId={board.postId} score={board.score} rank={idx + 2} />

--- a/src/board/component/page/MainPageCardsLayout2.jsx
+++ b/src/board/component/page/MainPageCardsLayout2.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import RankCard from './MainPageCard/RankCard';
 import LoadingSpinner from '../../../components/LoadingSpinner';
 
-const cardWidth = 240;
 const cardHeight = 200;
 
 const MainPageCardsLayout2 = ({ top5Data }) => {
@@ -13,32 +12,10 @@ const MainPageCardsLayout2 = ({ top5Data }) => {
 
     // 데이터 있을 때 카드 렌더링
     return (
-        <div
-            className="d-flex justify-content-center align-items-center"
-            style={{
-                width: "100%",
-                maxWidth: "1400px",
-                margin: "0 auto",           // ★ 화면 가로 중앙
-                gap: "24px",                // 카드 사이 여백
-                overflowX: "auto",          // 스크롤
-                padding: "8px 0",
-            }}
-        >
+        <div className="d-flex justify-content-center align-items-center mainpage-layout2-row">
             {top5Data.map((data, idx) => (
                 <div key={idx}>
-                    <div
-                        style={{
-                            width: `${cardWidth}px`,
-                            height: `${cardHeight}px`,
-                            flexShrink: 0,
-                            borderRadius: "16px",
-                            overflow: "hidden",
-                            background: "#fff",
-                            boxShadow: "0 2px 12px rgba(0,0,0,0.09)",
-                            display: "flex",
-                            alignItems: "stretch"
-                        }}
-                    >
+                    <div className="mainpage-layout2-card">
                         {/* RankCard */}
                         <RankCard
                             data={data.region || data.category}
@@ -46,21 +23,8 @@ const MainPageCardsLayout2 = ({ top5Data }) => {
                             rank={idx + 1}
                         />
                     </div>
-                    <div style={{
-                        background: "rgba(30,30,55,0.56)",
-                        color: "#fff",
-                        padding: "1.75rem 0rem 0.2rem 4.75rem",
-                        borderRadius: "1.2rem",
-                        fontWeight: 600,
-                        fontSize: "1.2rem",
-                        letterSpacing: "-0.01em",
-                        boxShadow: "0 2px 8px rgba(0,0,0,0.07)",
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "0.6rem",
-                        marginTop: "-25px",
-                    }}>
-                        <span style={{ color: "#fff", fontWeight: 700 }}>
+                    <div className="mainpage-layout2-badge">
+                        <span>
                             Score: {data.score}
                         </span>
                     </div>

--- a/src/board/component/page/RegionRadioComp.jsx
+++ b/src/board/component/page/RegionRadioComp.jsx
@@ -2,17 +2,9 @@
 const RegionRadioCard = ({ selectedRegion, setRegion }) => {
     const cities = ["강원", "경기", "대구", "부산", "서울", "인천", "전남", "제주", "기타"];
     return (
-        <div style={{ minWidth: 240, maxWidth: 350 }}>
-            <div className="fw-bold mb-3 d-flex align-items-center" style={{ color: "#1565c0", fontSize: "1.18rem" }}>
-                <i
-                    className="bi bi-geo-alt-fill me-2"
-                    style={{
-                        fontSize: "1.3rem",
-                        background: "linear-gradient(90deg, #42a5f5 10%, #7e57c2 80%)",
-                        WebkitBackgroundClip: "text",
-                        WebkitTextFillColor: "transparent"
-                    }}
-                />
+        <div className="selector-panel">
+            <div className="fw-bold mb-3 d-flex align-items-center selector-heading">
+                <i className="bi bi-geo-alt-fill me-2 selector-icon-gradient" />
                 지역 선택
             </div>
             <div className="row row-cols-3 g-3">
@@ -22,22 +14,6 @@ const RegionRadioCard = ({ selectedRegion, setRegion }) => {
                             className={`text-center region-card-btn shadow-sm
                                 ${selectedRegion === city ? "region-card-active" : ""}`}
                             onClick={() => setRegion(selectedRegion === city ? "" : city)}
-                            style={{
-                                borderRadius: "18px",
-                                background: selectedRegion === city
-                                    ? "linear-gradient(90deg,#e3f2fd 70%,#ede7f6 100%)"
-                                    : "#fff",
-                                color: selectedRegion === city ? "#1760c6" : "#7b8da3",
-                                fontWeight: selectedRegion === city ? 700 : 500,
-                                cursor: "pointer",
-                                padding: "14px 0",
-                                boxShadow: selectedRegion === city
-                                    ? "0 4px 16px 0 rgba(33, 150, 243, 0.12)"
-                                    : "0 2px 7px 0 rgba(90,120,180,0.08)",
-                                outline: "none",
-                                transform: selectedRegion === city ? "scale(1.07)" : "scale(1)",
-                                transition: "all 0.16s cubic-bezier(.5,1.7,.76,1.18)"
-                            }}
                             tabIndex={0}
                             onKeyPress={e => {
                                 if (e.key === "Enter" || e.key === " ") setRegion(city);

--- a/src/comment/component/CommentList.jsx
+++ b/src/comment/component/CommentList.jsx
@@ -5,10 +5,8 @@ const renderStarsStatic = (score = 0) => (
         {[1, 2, 3, 4, 5].map(star => (
             <span
                 key={star}
-                style={{
-                    fontSize: "1.15rem",
-                    color: star <= score ? "#ffc107" : "#e4e5e9"
-                }}
+                className="comment-star"
+                style={{ color: star <= score ? "#ffc107" : "#e4e5e9" }}
             >★</span>
         ))}
     </span>
@@ -17,23 +15,17 @@ const renderStarsStatic = (score = 0) => (
 const CommentList = ({ comments = [], onRemoveComment, ratingAvg }) => {
     return (
         <div className="container my-4">
-            <div className="card shadow-sm border-1 rounded-4 mx-auto" style={{ maxWidth: 520, background: "#fafdffcc" }}>
+            <div className="card shadow-sm border-1 rounded-4 mx-auto comment-list-card">
                 <div className="card-body p-4">
                     {/* 타이틀, 댓글수, 평점수 한 줄에 정렬 */}
                     <div className="d-flex align-items-center mb-4 justify-content-between">
                         <h5 className="mb-0 fw-bold">댓글 목록</h5>
-                        <div className="d-flex align-items-center" style={{ gap: "1.1rem" }}>
-                            <span className="text-secondary" style={{ fontSize: "1rem" }}>
+                        <div className="d-flex align-items-center comment-header-gap">
+                            <span className="text-secondary comment-count-text">
                                 댓글 수 <span className="fw-semibold">{comments.length}</span>
                             </span>
-                            <span className="text-secondary" style={{ fontSize: "1rem" }}>
-                                <span
-                                    className="ms-1"
-                                    style={{
-                                        fontSize: "1.15rem",
-                                        color: "#ffc107"
-                                    }}
-                                >★
+                            <span className="text-secondary comment-count-text">
+                                <span className="ms-1 comment-rating-star">★
                                 </span>
                                 <span className="fw-semibold"> {ratingAvg ? ratingAvg.toFixed(1) : 0}</span>
                             </span>
@@ -49,16 +41,7 @@ const CommentList = ({ comments = [], onRemoveComment, ratingAvg }) => {
                                     {localStorage.getItem("nickname") === c.memberNickname &&
                                         <button
                                             type="button"
-                                            className="btn btn-sm btn-light position-absolute"
-                                            style={{
-                                                top: 8,
-                                                right: 10,
-                                                border: "none",
-                                                fontSize: "1.25rem",
-                                                color: "#bbb",
-                                                background: "transparent",
-                                                zIndex: 10,
-                                            }}
+                                            className="btn btn-sm btn-light position-absolute comment-delete-btn"
                                             onClick={() => onRemoveComment({ commentId: c.commentId })}
                                             aria-label="댓글 삭제"
                                         >
@@ -68,7 +51,7 @@ const CommentList = ({ comments = [], onRemoveComment, ratingAvg }) => {
 
                                     <div className="d-flex align-items mb-2">
                                         <strong className="me-2">{c.memberNickname || "(탈퇴 회원)"}</strong>
-                                        <span style={{ fontSize: "0.96rem", color: "#aaa" }}>
+                                        <span className="comment-item-meta">
                                             {c.star > 0 && (
                                                 <div className="mb-1">{renderStarsStatic(c.star)}</div>
                                             )}

--- a/src/comment/component/CommentPage.jsx
+++ b/src/comment/component/CommentPage.jsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react";
 function ConfirmModal({ show, type = "danger", message, onConfirm, onCancel }) {
     if (!show) return null;
     return (
-        <div className="modal show fade" tabIndex="-1" style={{ display: "block", background: "rgba(0,0,0,0.23)", zIndex: 1060 }}>
+        <div className="modal show fade comment-modal-backdrop" tabIndex="-1">
             <div className="modal-dialog modal-dialog-centered">
                 <div className={`modal-content border-${type}`}>
                     <div className={`modal-header bg-${type} bg-opacity-10`}>
@@ -97,8 +97,7 @@ const CommentPage = ({ no, isLoggedIn, ratingAvg, setCommentFlag, category, regi
     return (
         <div>
             {alert.show && (
-                <div className={`alert alert-${alert.type} text-center`} role="alert"
-                    style={{ position: "fixed", top: 80, left: "50%", transform: "translateX(-50%)", minWidth: 220, zIndex: 2000 }}>
+                <div className={`alert alert-${alert.type} text-center comment-alert`} role="alert">
                     {alert.message}
                 </div>
             )}

--- a/src/comment/component/WriteComment.jsx
+++ b/src/comment/component/WriteComment.jsx
@@ -13,14 +13,8 @@ const WriteComment = ({ onAddComment }) => {
             {[1, 2, 3, 4, 5].map(star => (
                 <i
                     key={star}
-                    className={star <= rating ? "bi bi-star-fill" : "bi bi-star"}
-                    style={{
-                        color: star <= rating ? "#ffc107" : "#dee2e6",
-                        fontSize: "1.25rem",
-                        cursor: "pointer",
-                        marginLeft: 3,
-                        marginRight: 1
-                    }}
+                    className={`${star <= rating ? "bi bi-star-fill" : "bi bi-star"} comment-write-star`}
+                    style={{ color: star <= rating ? "#ffc107" : "#dee2e6" }}
                     onClick={() => setRating(star)}
                 />
             ))}
@@ -49,22 +43,21 @@ const WriteComment = ({ onAddComment }) => {
     };
 
     return (
-        <div className="card shadow-sm rounded-4 px-4 py-3 mx-auto" style={{ maxWidth: 520, margin: "0 auto" }}>
+        <div className="card shadow-sm rounded-4 px-4 py-3 mx-auto comment-write-card">
             <form onSubmit={handleSubmit}>
                 <div className="d-flex justify-content-between align-items-center mb-2">
-                    <label className="form-label mb-0" htmlFor="comment" style={{ fontWeight: 500 }}>
+                    <label className="form-label mb-0 comment-write-label" htmlFor="comment">
                         댓글
                     </label>
                     {renderStars()}
                 </div>
                 <textarea
                     id="comment"
-                    className="form-control mb-3"
+                    className="form-control mb-3 comment-write-textarea"
                     rows={3}
                     value={comment}
                     onChange={e => setComment(e.target.value)}
                     placeholder="댓글을 입력하세요"
-                    style={{ resize: "none" }}
                 />
                 <div className="d-flex justify-content-end">
 

--- a/src/common/ChckMyCom.jsx
+++ b/src/common/ChckMyCom.jsx
@@ -6,7 +6,7 @@ import LoadingSpinner from "../components/LoadingSpinner";
 const renderStarsStatic = (score = 0) => (
     <span>
         {[1, 2, 3, 4, 5].map(star => (
-            <span key={star} style={{ fontSize: "1.15rem", color: star <= score ? "#ffc107" : "#e4e5e9" }}>★</span>
+            <span key={star} className="mypage-comment-star" style={{ color: star <= score ? "#ffc107" : "#e4e5e9" }}>★</span>
         ))}
     </span>
 );
@@ -34,17 +34,17 @@ const ChckMyCom = () => {
     }, []);
 
     if (loading) {
-        return <div style={{ marginTop: "100px" }}><LoadingSpinner minHeight={140} /></div>;
+        return <div className="mypage-comment-loading"><LoadingSpinner minHeight={140} /></div>;
     }
 
     return (
-        <div className="container" style={{ marginTop: "70px" }}>
-            <div className="card shadow-sm border-1 rounded-4 mx-auto" style={{ maxWidth: 520, background: "#fafdffcc" }}>
+        <div className="container mypage-comment-page">
+            <div className="card shadow-sm border-1 rounded-4 mx-auto mypage-comment-card">
                 <div className="card-body p-4">
                     <div className="d-flex align-items-center mb-4 justify-content-between">
                         <h5 className="mb-0 fw-bold">작성 댓글 목록</h5>
-                        <div className="d-flex align-items-center" style={{ gap: "1.1rem" }}>
-                            <span className="text-secondary" style={{ fontSize: "1rem" }}>
+                        <div className="d-flex align-items-center mypage-comment-header-gap">
+                            <span className="text-secondary mypage-comment-count">
                                 작성 댓글 수 <span className="fw-semibold">{commentList.length}</span>
                             </span>
                         </div>

--- a/src/common/CheckMyArt.jsx
+++ b/src/common/CheckMyArt.jsx
@@ -32,8 +32,8 @@ const CheckMyArt = () => {
     }, []);
 
     return (
-        <div className="bg-light min-vh-100 py-4" style={{ overflowX: "hidden" }}>
-            <div className="container py-3" style={{ maxWidth: 850 }}>
+        <div className="bg-light min-vh-100 py-4 mypage-list-page">
+            <div className="container py-3 mypage-list-container">
                 <div className="d-flex justify-content-between align-items-center mb-4">
                     <div>
                         <h3 className="fw-bold mb-1 page-title">

--- a/src/common/LikeListPage.jsx
+++ b/src/common/LikeListPage.jsx
@@ -43,8 +43,8 @@ const LikeListPage = () => {
     };
 
     return (
-        <div className="bg-light min-vh-100 py-4" style={{ overflowX: "hidden" }}>
-            <div className="container py-3" style={{ maxWidth: 850 }}>
+        <div className="bg-light min-vh-100 py-4 mypage-list-page">
+            <div className="container py-3 mypage-list-container">
                 <div className="d-flex justify-content-between align-items-center mb-4">
                     <div>
                         <h3 className="fw-bold mb-1 page-title">

--- a/src/common/MyPage.jsx
+++ b/src/common/MyPage.jsx
@@ -51,16 +51,15 @@ const MyPage = () => {
   }, []);
 
   return (
-    <div style={{ background: 'linear-gradient(135deg,#eaf4fc 60%,#fff 100%)', minHeight: '100vh', paddingTop: 110, paddingBottom: 36 }}>
+    <div className="mypage-root">
       {alert.show && (
-        <div className={`alert alert-${alert.type} text-center`}
-          style={{ position: "fixed", top: 60, left: "50%", transform: "translateX(-50%)", minWidth: 200, zIndex: 2000 }}
+        <div className={`alert alert-${alert.type} text-center mypage-alert`}
           role="alert">
           {alert.message}
         </div>
       )}
       {showConfirm && (
-        <div className="modal show fade d-block" tabIndex={-1} style={{ background: 'rgba(0,0,0,0.28)' }}>
+        <div className="modal show fade d-block mypage-modal-backdrop" tabIndex={-1}>
           <div className="modal-dialog modal-dialog-centered">
             <div className="modal-content">
               <div className="modal-header">
@@ -79,10 +78,9 @@ const MyPage = () => {
       <div className="container mb-3">
         <div className="row justify-content-center">
           <div className="col-12 col-md-7 col-lg-5">
-            <div className="card shadow rounded-4 p-4 text-center border-0" style={{ background: "#fffdfcf2" }}>
-              <img src={myPageImage} alt="프로필" className="rounded-circle shadow-sm mx-auto d-block"
-                style={{ width: 108, height: 108, objectFit: 'cover', background: '#f4f6fa', border: '4px solid #e3e8ee' }} />
-              <h3 className="fw-bold mt-3 mb-1" style={{ color: "#274071", letterSpacing: "1px" }}>
+            <div className="card shadow rounded-4 p-4 text-center border-0 mypage-card">
+              <img src={myPageImage} alt="프로필" className="rounded-circle shadow-sm mx-auto d-block mypage-avatar" />
+              <h3 className="fw-bold mt-3 mb-1 mypage-nickname">
                 {member.nickname || "-"}
               </h3>
               <div>
@@ -98,8 +96,7 @@ const MyPage = () => {
                     <div className="d-flex align-items-center bg-light rounded-3 px-3 py-2 shadow-sm mb-2">
                       <i className="bi bi-envelope-fill text-primary me-2" />
                       <span className="text-secondary small fw-semibold me-2">이메일</span>
-                      <span className="fw-bold ms-auto text-dark"
-                        style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', display: 'block', textAlign: 'right' }}
+                      <span className="fw-bold ms-auto text-dark mypage-email-value"
                         title={member.email}>{member.email || '-'}</span>
                     </div>
                   </div>
@@ -144,7 +141,7 @@ const MyPage = () => {
                   <i className="bi bi-chat-text me-1" /> 작성 댓글
                 </Link>
               </div>
-              <hr style={{ marginTop: "2rem" }} />
+              <hr className="mypage-divider" />
               <div className="gap-2 mt-3">
                 <Link to="/sign/update" className="btn btn-outline-primary rounded-pill px-3 shadow-sm me-2">
                   <i className="bi bi-pencil-square me-1" /> 정보수정

--- a/src/css/comment.css
+++ b/src/css/comment.css
@@ -1,0 +1,75 @@
+/* comment 도메인: 댓글 목록/작성 */
+
+/* ===== 삭제 확인 모달 / 알림 (CommentPage) ===== */
+.comment-modal-backdrop {
+  display: block;
+  background: rgba(0, 0, 0, 0.23);
+  z-index: 1060;
+}
+
+.comment-alert {
+  position: fixed;
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 220px;
+  z-index: var(--z-alert);
+}
+
+/* ===== 댓글 목록 (CommentList) ===== */
+.comment-list-card {
+  max-width: 520px;
+  background: #fafdffcc;
+}
+
+.comment-header-gap {
+  gap: 1.1rem;
+}
+
+.comment-count-text {
+  font-size: 1rem;
+}
+
+.comment-rating-star {
+  font-size: 1.15rem;
+  color: #ffc107;
+}
+
+.comment-star {
+  font-size: 1.15rem;
+}
+
+.comment-item-meta {
+  font-size: 0.96rem;
+  color: #aaa;
+}
+
+.comment-delete-btn {
+  top: 8px;
+  right: 10px;
+  border: none;
+  font-size: 1.25rem;
+  color: #bbb;
+  background: transparent;
+  z-index: 10;
+}
+
+/* ===== 댓글 작성 (WriteComment) ===== */
+.comment-write-card {
+  max-width: 520px;
+}
+
+.comment-write-label {
+  font-weight: 500;
+}
+
+.comment-write-textarea {
+  resize: none;
+}
+
+.comment-write-star {
+  font-size: 1.25rem;
+  cursor: pointer;
+  margin-left: 3px;
+  margin-right: 1px;
+}

--- a/src/css/log.css
+++ b/src/css/log.css
@@ -31,3 +31,229 @@
   padding: 0.7rem 2rem;
   pointer-events: none;
 }
+
+/* ===== 관리 화면 공통 (Process/Filter/Format/Deduplication/Log Management) ===== */
+.log-page-spacer {
+  margin-top: 80px;
+}
+
+.log-page-padding {
+  padding-top: 80px;
+}
+
+.log-card-noborder {
+  border: 0;
+}
+
+.log-btn-rounded {
+  border-radius: 0.7rem;
+  font-weight: 600;
+}
+
+.log-btn-rounded-sm {
+  border-radius: 0.7rem;
+  font-weight: 500;
+}
+
+.log-modal-backdrop-30 {
+  display: block;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 1050;
+}
+
+.log-modal-backdrop-50 {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.log-modal-dialog-sm {
+  max-width: 480px;
+}
+
+/* 테이블 헤더 열 너비 (Process/Filter/Format/Deduplication 공통) */
+.log-col-10 { width: 10%; }
+.log-col-15 { width: 15%; }
+.log-col-18 { width: 18%; }
+.log-col-25 { width: 25%; }
+.log-col-30 { width: 30%; }
+
+/* ===== 프로세스 관리 (ProcessManagement) ===== */
+.process-header-row {
+  min-height: 40px;
+}
+
+.process-status-dot {
+  color: #34a853;
+  padding-bottom: 2px;
+}
+
+.process-header-title {
+  margin-left: 7px;
+}
+
+.process-edit-row {
+  background: #f6f8fa;
+  border-bottom-left-radius: 0.7rem;
+  border-bottom-right-radius: 0.7rem;
+}
+
+/* 프로세스 추가/수정 카드 (InputProcess / EditProcess) */
+.log-process-card {
+  max-width: 400px;
+}
+
+/* ===== 필터 조건 빌더 (ConditionBuilder) ===== */
+.log-condition-container {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.log-expression-spacer {
+  margin-top: 10px;
+}
+
+.log-select-field {
+  width: 120px;
+}
+
+.log-select-operator {
+  width: 80px;
+}
+
+.log-input-value {
+  width: 100px;
+}
+
+/* ===== 필터 상세 (DetailFilter) ===== */
+.log-filter-detail-container {
+  max-width: 950px;
+}
+
+.log-expression-box {
+  font-size: 17px;
+}
+
+.log-expression-code {
+  font-size: 16px;
+}
+
+.log-select-field-lg {
+  width: 150px;
+}
+
+.log-select-operator-lg {
+  width: 100px;
+}
+
+.log-input-value-lg {
+  width: 130px;
+}
+
+.log-condition-row {
+  background: #f8f9fa;
+  border-radius: 8px;
+  margin-bottom: 6px;
+}
+
+/* ===== 포맷 상세/추가 (DetailFormat / InputFormat) ===== */
+.log-format-detail-container {
+  padding: 24px;
+  border-radius: 12px;
+  max-width: 900px;
+  margin: 30px auto;
+  background: #fff;
+  box-shadow: 0 2px 10px #eee;
+}
+
+.log-format-detail-name-input {
+  width: 415px;
+  transform: translateY(-28px);
+}
+
+.log-format-input-name-input {
+  width: 360px;
+  text-align: center;
+}
+
+.log-format-flex-1 {
+  flex: 1;
+}
+
+.log-format-flex-2 {
+  flex: 2;
+}
+
+/* ===== 처리 기록 테이블 (LogTable) ===== */
+.log-table-scroll {
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+.log-table-sortable-th {
+  cursor: pointer;
+}
+
+.log-table-row-clickable {
+  cursor: pointer;
+}
+
+.log-table-sort-icon {
+  font-size: 0.75em;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+
+.log-table-detail-pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: hidden;
+}
+
+/* ===== 중복 제거 (DeduplicationRow / InputDeduplication) ===== */
+.dedup-row-card {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
+  position: relative;
+}
+
+.dedup-field-select {
+  max-width: 200px;
+}
+
+.dedup-matchtype-select {
+  max-width: 120px;
+}
+
+.dedup-time-input {
+  width: 90px;
+  text-align: right;
+  display: inline-block;
+}
+
+.dedup-time-label {
+  min-width: 28px;
+  text-align: center;
+  display: inline-block;
+}
+
+.dedup-input-container {
+  background: #fff;
+  border-radius: 12px;
+  padding: 28px 24px 24px 24px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.09);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* ===== Kibana 모니터링 ===== */
+.kibana-container {
+  width: 80vw;
+  height: 100vh;
+  margin-top: -75px;
+  padding: 0;
+  overflow: hidden;
+}
+
+.kibana-iframe {
+  border: none;
+  width: 80vw;
+  height: 100vh;
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -63,8 +63,11 @@
 .board-list-card {
   transition: box-shadow 0.18s, transform 0.16s, background 0.16s, border 0.13s;
   border: 1.5px solid #f0f0f7;
-  background: #f9faff;
+  background: var(--card-bg);
   border-radius: 1.1rem;
+  min-height: 88px;
+  box-shadow: var(--card-shadow);
+  position: relative;
 }
 
 .board-list-card:hover,
@@ -74,4 +77,494 @@
   background: #f6f3ff;
   transform: translateY(-2px) scale(1.012);
   cursor: pointer;
+}
+
+.board-list-card-title-row {
+  font-size: 1.12rem;
+  margin-bottom: 6px;
+}
+
+.board-list-card-title {
+  max-width: 75%;
+}
+
+.board-list-card-title-text {
+  color: #222;
+  font-weight: bold;
+  font-family: var(--font-display);
+}
+
+.board-list-card-date {
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+
+.board-list-card-meta {
+  font-size: 0.97rem;
+  min-height: 36px;
+}
+
+.board-list-card-author {
+  color: #222;
+}
+
+.board-list-card-stat {
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.board-list-card-star {
+  color: #ffc107;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+/* ===== 관리자 페이지 공통 (AdmnPage / AdmnBoard) ===== */
+.admin-page-spacer {
+  margin-top: 80px;
+}
+
+.admin-board-container {
+  max-width: 1500px;
+  padding-bottom: 40px;
+}
+
+.admin-board-panel {
+  background: rgba(250, 251, 255, 0.97);
+  min-height: 540px;
+}
+
+.admin-modal-backdrop {
+  background: rgba(22, 22, 37, 0.40);
+  backdrop-filter: blur(2px);
+  z-index: 1050;
+}
+
+.admin-modal-content {
+  border-radius: 1.3rem;
+  box-shadow: 0 6px 32px 0 rgba(80, 55, 255, 0.08);
+}
+
+.admin-modal-close-icon {
+  filter: invert(0.5);
+}
+
+/* ===== 지역/카테고리 선택 위젯 (RegionRadioComp / CategoryCard) ===== */
+.selector-panel {
+  min-width: 240px;
+  max-width: 350px;
+}
+
+.selector-heading {
+  color: #1565c0;
+  font-size: 1.18rem;
+}
+
+.selector-icon-gradient {
+  font-size: 1.3rem;
+  background: linear-gradient(90deg, #42a5f5 10%, #7e57c2 80%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.region-card-btn,
+.category-card-btn {
+  border-radius: 18px;
+  cursor: pointer;
+  padding: 14px 0;
+  outline: none;
+  font-weight: 500;
+  color: #7b8da3;
+  transition: all 0.16s cubic-bezier(.5, 1.7, .76, 1.18);
+}
+
+.region-card-btn {
+  background: #fff;
+  box-shadow: 0 2px 7px 0 rgba(90, 120, 180, 0.08);
+}
+
+.category-card-btn {
+  background: #f7fafd;
+  box-shadow: 0 2px 7px 0 rgba(90, 120, 180, 0.06);
+}
+
+.region-card-active,
+.category-card-active {
+  background: linear-gradient(90deg, #e3f2fd 70%, #ede7f6 100%);
+  color: #1760c6;
+  font-weight: 700;
+  transform: scale(1.07);
+}
+
+.region-card-active {
+  box-shadow: 0 4px 16px 0 rgba(33, 150, 243, 0.12);
+}
+
+.category-card-active {
+  box-shadow: 0 4px 16px 0 rgba(33, 150, 243, 0.10);
+}
+
+/* ===== 랭킹 카드 본문 (MainPageCard / RankCard 공통) ===== */
+.mainpage-card-body {
+  background: rgba(250, 250, 255, 0.96);
+  box-shadow: var(--card-shadow-lg);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.25s cubic-bezier(.19, 1, .22, 1), box-shadow 0.22s;
+  cursor: pointer;
+  z-index: 1; /* 왕관보다 낮음 */
+}
+
+.mainpage-card-image-wrap {
+  position: relative;
+  width: 100%;
+}
+
+.mainpage-card-image {
+  height: 390px;
+  width: 100%;
+  object-fit: cover;
+  filter: brightness(98%);
+  display: block;
+}
+
+.mainpage-card-image-placeholder {
+  height: 390px;
+  background: #f3f3f8;
+}
+
+.rank-card-image {
+  height: 200px;
+  width: 100%;
+  object-fit: cover;
+  filter: brightness(98%);
+  display: block;
+}
+
+.rank-card-image-placeholder {
+  height: 200px;
+  background: #f3f3f8;
+}
+
+.mainpage-card-overlay-badge {
+  position: absolute;
+  bottom: 18px;
+  left: 20px;
+  background: rgba(30, 30, 55, 0.56);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 1.2rem;
+  font-weight: 600;
+  font-size: 1.2rem;
+  letter-spacing: -0.01em;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.07);
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.mainpage-card-overlay-label {
+  color: #e0c3fc;
+  font-weight: 700;
+}
+
+.mainpage-card-title {
+  font-size: 1.09rem;
+  color: #333;
+  font-weight: 500;
+}
+
+.mainpage-card-nickname {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+  max-width: 220px;
+}
+
+.mainpage-card-nickname-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+  max-width: 90px;
+  display: inline-block;
+}
+
+/* ===== 랭킹 리스트 카드 (MainPageCard2) ===== */
+.mainpage-card2-wrap {
+  min-height: 112px;
+}
+
+.mainpage-card2-body {
+  height: 100%;
+  width: 100%;
+  border-radius: 1.3rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  transition: transform 0.22s cubic-bezier(.19, 1, .22, 1), box-shadow 0.18s;
+  cursor: pointer;
+  z-index: 1; /* 뱃지보다 낮게 */
+}
+
+.mainpage-card2-image-wrap {
+  width: 40%;
+  height: 100%;
+}
+
+.mainpage-card2-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-top-left-radius: 1.3rem;
+  border-bottom-left-radius: 1.3rem;
+}
+
+.mainpage-card2-image-placeholder {
+  width: 100%;
+  height: 100%;
+  background: #e9e5fa;
+}
+
+.mainpage-card2-content {
+  width: 60%;
+}
+
+.mainpage-card2-title {
+  color: #6247aa;
+  font-size: 1.09rem;
+  margin-bottom: 6px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mainpage-card2-score {
+  color: #555;
+  font-size: 0.97rem;
+  height: 2.3em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ===== 인기 랭킹 레이아웃 (MainPageCardsLayout) ===== */
+.mainpage-layout-row {
+  min-height: 520px;
+  gap: 36px;
+  width: 100%;
+  margin-top: 48px;
+}
+
+.mainpage-layout-primary {
+  width: 720px;
+  height: 520px;
+  display: flex;
+  align-items: stretch;
+}
+
+.mainpage-layout-primary-motion {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+.mainpage-layout-crown-glow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: none;
+  box-shadow: none;
+}
+
+.mainpage-layout-secondary {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 520px;
+  width: 360px;
+  gap: 18px;
+}
+
+.mainpage-layout-secondary-item {
+  height: calc((100% - 54px) / 4);
+  min-height: 0;
+  display: flex;
+}
+
+/* ===== 인기 카테고리/지역 레이아웃 (MainPageCardsLayout2) ===== */
+.mainpage-layout2-row {
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
+  gap: 24px;
+  overflow-x: auto;
+  padding: 8px 0;
+}
+
+.mainpage-layout2-card {
+  width: 240px;
+  height: 200px;
+  flex-shrink: 0;
+  border-radius: 16px;
+  overflow: hidden;
+  background: var(--card-bg);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.09);
+  display: flex;
+  align-items: stretch;
+}
+
+.mainpage-layout2-badge {
+  background: rgba(30, 30, 55, 0.56);
+  color: #fff;
+  padding: 1.75rem 0 0.2rem 4.75rem;
+  border-radius: 1.2rem;
+  font-weight: 600;
+  font-size: 1.2rem;
+  letter-spacing: -0.01em;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.07);
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: -25px;
+}
+
+.mainpage-layout2-badge span {
+  color: #fff;
+  font-weight: 700;
+}
+
+/* ===== 메인 히어로/섹션 (MainPage) ===== */
+.mainpage-root {
+  min-height: 100vh;
+  background: #F5F6FF;
+  width: 100%;
+  overflow-x: hidden;
+  margin-top: -1px;
+}
+
+.mainpage-hero {
+  width: 100%;
+  min-height: 500px;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.mainpage-hero-content {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  z-index: 2;
+}
+
+.mainpage-hero-panel {
+  text-align: center;
+  position: relative;
+  display: inline-block;
+  padding: 1rem 4.5rem 10rem 4.5rem;
+  background: rgba(255, 255, 255, 0.65);
+  box-shadow: 0 6px 36px rgba(80, 60, 180, 0.08);
+  backdrop-filter: blur(4px);
+  border: 1.5px solid rgba(190, 180, 255, 0.13);
+  z-index: 3;
+  min-width: 320px;
+  max-width: 94vw;
+}
+
+.mainpage-hero-title {
+  font-size: 3.42rem;
+  font-weight: 900;
+  letter-spacing: -0.04em;
+  background: var(--brand-badge-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 0 1px 10px rgba(160, 160, 220, 0.09);
+  margin: 0;
+  font-family: var(--font-display);
+}
+
+.mainpage-hero-divider {
+  height: 3.5px;
+  width: 60px;
+  margin: 0.7rem auto 1.1rem auto;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(90deg, #bdaafc 20%, #92e0f6 90%);
+  opacity: 0.88;
+}
+
+.mainpage-hero-subtext {
+  color: #5B4B9A;
+  font-weight: 500;
+  font-size: 1.16rem;
+  margin: 0.7rem 0 0 0;
+  text-shadow: 0 2px 8px rgba(255, 255, 255, 0.09);
+}
+
+.mainpage-hero-overlay {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 100px;
+  background: linear-gradient(180deg, rgba(245, 245, 255, 0) 0%, rgba(245, 245, 255, 0.84) 100%);
+  z-index: 2;
+}
+
+.mainpage-body-container {
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 1020px;
+  z-index: 2;
+  padding: 0 16px;
+  margin-top: -265px;
+}
+
+.mainpage-section-title {
+  text-align: start;
+  width: 100%;
+  font-family: var(--font-display);
+  color: #a68eff;
+  font-weight: 900;
+  font-size: 2.35rem;
+  margin: 0 0 26px 0;
+  letter-spacing: -0.03em;
+  text-shadow: 0 2px 16px rgba(92, 67, 226, 0.08);
+  transform: translateY(28px);
+}
+
+.mainpage-top5-section {
+  margin-bottom: 32px;
+  margin-top: 5rem;
+}
+
+.mainpage-category-section {
+  margin-top: 8rem;
+}
+
+.mainpage-region-section {
+  margin-top: 6rem;
+}
+
+.mainpage-subsection-title {
+  padding-left: 19rem;
+  text-align: left;
+  font-family: var(--font-display);
+  color: #b7aaff;
+  font-weight: 700;
+  font-size: 1.55rem;
+  letter-spacing: -0.03em;
+  margin-bottom: 1.4rem;
 }

--- a/src/css/sign.css
+++ b/src/css/sign.css
@@ -1,0 +1,169 @@
+/* sign 도메인: 로그인/회원가입/마이페이지 */
+
+/* ===== 로그인/회원가입/정보수정/비밀번호변경 공통 배경 ===== */
+.sign-page-bg {
+  background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
+}
+
+.sign-page-bg-full {
+  width: 100vw;
+  overflow-x: hidden;
+  position: relative;
+}
+
+/* ===== 회원 정보수정 / 비밀번호 변경 공통 카드 ===== */
+.sign-card {
+  max-width: 420px;
+  width: 95%;
+  margin: 40px auto;
+  padding: 40px 34px 32px 34px;
+  background: rgba(255, 255, 255, 0.97);
+  border-radius: 1.5rem;
+  box-shadow: 0 6px 36px 0 rgba(54, 69, 79, 0.13);
+}
+
+.sign-card-title {
+  font-weight: bold;
+  font-size: 2rem;
+  background: #000000;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 30px;
+}
+
+.sign-card-input-box {
+  width: 100%;
+  margin-bottom: 22px;
+}
+
+.sign-card-btn {
+  font-weight: bold;
+  font-size: 1.07rem;
+  letter-spacing: 0.03em;
+  border-radius: 2rem;
+  margin-top: 0;
+}
+
+/* ===== 회원가입 카드 (SignUpPage) ===== */
+.signup-card {
+  max-width: 410px;
+  width: 95%;
+  margin: 3rem auto;
+  border-radius: 1.5rem;
+  box-shadow: 0 6px 32px 0 rgba(54, 69, 79, 0.13);
+  border: none;
+}
+
+.signup-card-title {
+  font-weight: bold;
+  font-size: 2.05rem;
+  background: #000000;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 24px;
+}
+
+.signup-submit-btn {
+  font-weight: bold;
+  font-size: 1.08rem;
+  letter-spacing: 0.03em;
+  border-radius: 2rem;
+  padding: 0.75rem;
+  margin-top: 12px;
+  background: #3f51b5;
+  border: none;
+}
+
+/* ===== 회원 관리 (MemberManagement) ===== */
+.sign-page-spacer {
+  margin-top: 80px;
+}
+
+.member-mgmt-title {
+  margin-bottom: 3.5rem;
+}
+
+/* ===== 마이페이지 (MyPage) ===== */
+.mypage-root {
+  background: linear-gradient(135deg, #eaf4fc 60%, #fff 100%);
+  min-height: 100vh;
+  padding-top: 110px;
+  padding-bottom: 36px;
+}
+
+.mypage-alert {
+  position: fixed;
+  top: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 200px;
+  z-index: var(--z-alert);
+}
+
+.mypage-modal-backdrop {
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.mypage-card {
+  background: #fffdfcf2;
+}
+
+.mypage-avatar {
+  width: 108px;
+  height: 108px;
+  object-fit: cover;
+  background: #f4f6fa;
+  border: 4px solid #e3e8ee;
+}
+
+.mypage-nickname {
+  color: #274071;
+  letter-spacing: 1px;
+}
+
+.mypage-email-value {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  display: block;
+  text-align: right;
+}
+
+.mypage-divider {
+  margin-top: 2rem;
+}
+
+/* ===== 마이페이지 하위 목록 (LikeListPage / CheckMyArt 공통) ===== */
+.mypage-list-page {
+  overflow-x: hidden;
+}
+
+.mypage-list-container {
+  max-width: 850px;
+}
+
+/* ===== 작성 댓글 목록 (ChckMyCom) ===== */
+.mypage-comment-star {
+  font-size: 1.15rem;
+}
+
+.mypage-comment-loading {
+  margin-top: 100px;
+}
+
+.mypage-comment-page {
+  margin-top: 70px;
+}
+
+.mypage-comment-card {
+  max-width: 520px;
+  background: #fafdffcc;
+}
+
+.mypage-comment-header-gap {
+  gap: 1.1rem;
+}
+
+.mypage-comment-count {
+  font-size: 1rem;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ import './css/index.css';
 import './css/common.css';
 import './css/post.css';
 import './css/main.css';
+import './css/sign.css';
+import './css/comment.css';
 import './css/log.css';
 
 import App from './App';

--- a/src/log/components/db/LogManagement.jsx
+++ b/src/log/components/db/LogManagement.jsx
@@ -92,7 +92,7 @@ const LogManagement = ({ onMenuClick }) => {
     ];
 
     return (
-        <div className="container" style={{ paddingTop: '80px' }}>
+        <div className="container log-page-padding">
             {/* Alert 메시지 */}
             {alert.show && (
                 <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">

--- a/src/log/components/db/LogTable.jsx
+++ b/src/log/components/db/LogTable.jsx
@@ -26,7 +26,7 @@ const LogTable = ({
     const renderSortIcon = (key) => {
         if (sortConfig.key !== key) return null;
         return (
-            <span style={{ fontSize: '0.75em', marginLeft: '4px', verticalAlign: 'middle' }}>
+            <span className="log-table-sort-icon">
                 {sortConfig.direction === 'asc' ? '▲' : '▼'}
             </span>
         );
@@ -43,14 +43,15 @@ const LogTable = ({
     return (
         <div>
             <h3 className="mb-3">{title}</h3>
-            <div className="table-responsive" style={{ maxHeight: '500px', overflowY: 'auto' }}>
+            <div className="table-responsive log-table-scroll">
                 <table className={`table table-bordered table-hover align-middle`}>
                     <thead className={`text-center table-${color}`}>
                         <tr>
                             {columns.map(col =>
                                 <th
                                     key={col.key}
-                                    style={{ cursor: col.sortable ? 'pointer' : undefined, width: col.width || undefined }}
+                                    className={col.sortable ? "log-table-sortable-th" : undefined}
+                                    style={{ width: col.width || undefined }}
                                     onClick={col.sortable ? () => handleSort(col.key) : undefined}
                                 >
                                     {col.label}{col.sortable && renderSortIcon(col.key)}
@@ -63,7 +64,7 @@ const LogTable = ({
                             <tr><td colSpan={columns.length} className="text-muted">데이터가 없습니다.</td></tr>
                         ) : (
                             sortedList.flatMap(row => [
-                                <tr key={row.historyId} style={{ cursor: 'pointer' }} onClick={() => setExpandedRowId(expandedRowId === row.historyId ? null : row.historyId)}>
+                                <tr key={row.historyId} className="log-table-row-clickable" onClick={() => setExpandedRowId(expandedRowId === row.historyId ? null : row.historyId)}>
                                     {columns.map(col => (
                                         <td key={col.key}>
                                             {col.render ? col.render(row) : (
@@ -79,12 +80,7 @@ const LogTable = ({
                                         <td colSpan={columns.length} className="text-start bg-light">
                                             <strong>Log Data:</strong>
                                             <pre
-                                                className="mb-0 mt-2"
-                                                style={{
-                                                    whiteSpace: 'pre-wrap',
-                                                    wordBreak: 'break-word',
-                                                    overflowX: 'hidden'
-                                                }}
+                                                className="mb-0 mt-2 log-table-detail-pre"
                                             >
                                                 {details?.[row.historyId] ? JSON.stringify(details[row.historyId], null, 2) : '불러오는 중...'}
                                             </pre>

--- a/src/log/components/deduplication/DeduplicationManagement.jsx
+++ b/src/log/components/deduplication/DeduplicationManagement.jsx
@@ -55,7 +55,7 @@ const DeduplicationManagement = ({ processId, onMenuClick }) => {
   }, [showDetail, showInput]);
 
   return (
-    <div style={{ marginTop: '80px' }}>
+    <div className="log-page-spacer">
       <h2 className="fw-bold mb-4">중복 제거 관리</h2>
 
       {/* 중앙 상단 고정 경고창 */}
@@ -82,11 +82,11 @@ const DeduplicationManagement = ({ processId, onMenuClick }) => {
       <table className="table table-bordered text-center align-middle">
         <thead className="table-light">
           <tr>
-            <th style={{ width: '10%' }}>ID</th>
-            <th className="text-start" style={{ width: '30%' }}>이름</th>
+            <th className="log-col-10">ID</th>
+            <th className="text-start log-col-30">이름</th>
             <th>생성 날짜</th>
             <th>수정 날짜</th>
-            <th style={{ width: '10%' }}>활성화</th>
+            <th className="log-col-10">활성화</th>
           </tr>
         </thead>
         <tbody>
@@ -142,9 +142,8 @@ const DeduplicationManagement = ({ processId, onMenuClick }) => {
       {/* 추가 입력 모달 */}
       {showInput && (
         <div
-          className="modal show d-block"
+          className="modal show d-block log-modal-backdrop-50"
           tabIndex="-1"
-          style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
         >
           <div className="modal-dialog modal-lg" role="document">
             <div className="modal-content">

--- a/src/log/components/deduplication/DeduplicationRow.jsx
+++ b/src/log/components/deduplication/DeduplicationRow.jsx
@@ -45,14 +45,9 @@ const DeduplicationRow = ({ processId, index, data, onChange, onRemove }) => {
         onChange(index, { ...data, [name]: value });
     };
 
-    // 스타일 유틸
-    const inputBoxStyle = { width: 90, textAlign: 'right', display: 'inline-block' };
-    const labelStyle = { minWidth: 28, textAlign: 'center', display: 'inline-block' };
-
     return (
         <div
-            className="border rounded bg-white p-3 mb-3"
-            style={{ boxShadow: '0 2px 8px rgba(0,0,0,0.03)', position: 'relative' }}
+            className="border rounded bg-white p-3 mb-3 dedup-row-card"
         >
             <div className="row align-items-center mb-3">
                 <label className="form-label d-flex mb-1 fw-bold justify-content-center">필드/데이터 조건</label>
@@ -61,8 +56,7 @@ const DeduplicationRow = ({ processId, index, data, onChange, onRemove }) => {
                         <div className="d-flex gap-2 mb-2 align-items-center justify-content-center" key={condIdx}>
                             <select
                                 name="field"
-                                className="form-select"
-                                style={{ maxWidth: 200 }}
+                                className="form-select dedup-field-select"
                                 value={cond.field}
                                 onChange={e => handleConditionChange(condIdx, "field", e.target.value)}
                             >
@@ -74,16 +68,14 @@ const DeduplicationRow = ({ processId, index, data, onChange, onRemove }) => {
                             <input
                                 name="value"
                                 type="text"
-                                className="form-control"
+                                className="form-control dedup-field-select"
                                 placeholder="문자열 입력"
-                                style={{ maxWidth: 200 }}
                                 value={cond.value}
                                 onChange={e => handleConditionChange(condIdx, "value", e.target.value)}
                             />
                             <select
                                 name="matchType"
-                                className="form-select"
-                                style={{ maxWidth: 120 }}
+                                className="form-select dedup-matchtype-select"
                                 value={cond.matchType}
                                 onChange={e => handleConditionChange(condIdx, "matchType", e.target.value)}
                             >
@@ -109,20 +101,20 @@ const DeduplicationRow = ({ processId, index, data, onChange, onRemove }) => {
                 <div className="p-3 border rounded bg-light d-inline-block">
                     <div className="d-flex flex-row justify-content-center gap-3">
                         <div className="d-flex align-items-center gap-1">
-                            <input name="days" type="number" min="0" className="form-control" style={inputBoxStyle} value={data.days} onChange={handleTimeChange} />
-                            <span style={labelStyle}>일</span>
+                            <input name="days" type="number" min="0" className="form-control dedup-time-input" value={data.days} onChange={handleTimeChange} />
+                            <span className="dedup-time-label">일</span>
                         </div>
                         <div className="d-flex align-items-center gap-1">
-                            <input name="hours" type="number" min="0" className="form-control" style={inputBoxStyle} value={data.hours} onChange={handleTimeChange} />
-                            <span style={labelStyle}>시</span>
+                            <input name="hours" type="number" min="0" className="form-control dedup-time-input" value={data.hours} onChange={handleTimeChange} />
+                            <span className="dedup-time-label">시</span>
                         </div>
                         <div className="d-flex align-items-center gap-1">
-                            <input name="minutes" type="number" min="0" className="form-control" style={inputBoxStyle} value={data.minutes} onChange={handleTimeChange} />
-                            <span style={labelStyle}>분</span>
+                            <input name="minutes" type="number" min="0" className="form-control dedup-time-input" value={data.minutes} onChange={handleTimeChange} />
+                            <span className="dedup-time-label">분</span>
                         </div>
                         <div className="d-flex align-items-center gap-1">
-                            <input name="seconds" type="number" min="0" className="form-control" style={inputBoxStyle} value={data.seconds} onChange={handleTimeChange} />
-                            <span style={labelStyle}>초</span>
+                            <input name="seconds" type="number" min="0" className="form-control dedup-time-input" value={data.seconds} onChange={handleTimeChange} />
+                            <span className="dedup-time-label">초</span>
                         </div>
                     </div>
                 </div>

--- a/src/log/components/deduplication/InputDeduplication.jsx
+++ b/src/log/components/deduplication/InputDeduplication.jsx
@@ -54,16 +54,7 @@ const InputDeduplication = ({ processId, onClose,  showOutAlert}) => {
     };
 
     return (
-        <div
-            style={{
-                background: '#fff',
-                borderRadius: 12,
-                padding: '28px 24px 24px 24px',
-                boxShadow: '0 2px 12px rgba(0,0,0,0.09)',
-                maxWidth: 600,
-                margin: '0 auto'
-            }}
-        >
+        <div className="dedup-input-container">
             {/* Modal 안에만 표시되는 alert */}
             {alert.show && (
                 <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">

--- a/src/log/components/filter/ConditionBuilder.jsx
+++ b/src/log/components/filter/ConditionBuilder.jsx
@@ -144,7 +144,7 @@ const ConditionBuilder = ({ onClose, processId, showOutAlert }) => {
     };
 
     return (
-        <div className="container mt-4 text-center" style={{ maxWidth: '400px', margin: '0 auto' }}>
+        <div className="container mt-4 text-center log-condition-container">
             {/* Alert 메시지 */}
             {alert && (
                 <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">
@@ -168,7 +168,7 @@ const ConditionBuilder = ({ onClose, processId, showOutAlert }) => {
 
             <div className="mt-4">
                 <strong>현재 표현식: </strong>
-                <div style={{ marginTop: '10px' }}></div>
+                <div className="log-expression-spacer"></div>
                 <code>{buildExpression()}</code>
             </div>
 
@@ -202,18 +202,18 @@ const ConditionBuilder = ({ onClose, processId, showOutAlert }) => {
                                         return (
                                             <div className="d-flex align-items-center" key={i}>
                                                 <h2 className="me-2">(</h2>
-                                                <select className="form-select me-2" style={{ width: '120px' }}
+                                                <select className="form-select me-2 log-select-field"
                                                     value={nextToken.field}
                                                     onChange={(e) => updateToken(condIndex, 'field', e.target.value)}>
                                                     <option value="">필드 선택</option>
                                                     {fieldList.map((f) => <option key={f} value={f}>{f}</option>)}
                                                 </select>
-                                                <select className="form-select me-2" style={{ width: '80px' }}
+                                                <select className="form-select me-2 log-select-operator"
                                                     value={nextToken.operator}
                                                     onChange={(e) => updateToken(condIndex, 'operator', e.target.value)}>
                                                     {operatorOptions.map((op) => <option key={op} value={op}>{op}</option>)}
                                                 </select>
-                                                <input type="text" className="form-control me-2" style={{ width: '100px' }}
+                                                <input type="text" className="form-control me-2 log-input-value"
                                                     value={nextToken.value}
                                                     onChange={(e) => updateToken(condIndex, 'value', e.target.value)} />
                                                 {groupId !== 0 && (
@@ -231,18 +231,18 @@ const ConditionBuilder = ({ onClose, processId, showOutAlert }) => {
                                 if (t.type === 'condition' && group[i - 1]?.type !== 'left-paren') {
                                     return (
                                         <div className="d-flex align-items-center" key={i}>
-                                            <select className="form-select me-2" style={{ width: '120px' }}
+                                            <select className="form-select me-2 log-select-field"
                                                 value={t.field}
                                                 onChange={(e) => updateToken(tokenIndex, 'field', e.target.value)}>
                                                 <option value="">필드 선택</option>
                                                 {fieldList.map((f) => <option key={f} value={f}>{f}</option>)}
                                             </select>
-                                            <select className="form-select me-2" style={{ width: '80px' }}
+                                            <select className="form-select me-2 log-select-operator"
                                                 value={t.operator}
                                                 onChange={(e) => updateToken(tokenIndex, 'operator', e.target.value)}>
                                                 {operatorOptions.map((op) => <option key={op} value={op}>{op}</option>)}
                                             </select>
-                                            <input type="text" className="form-control me-2" style={{ width: '100px' }}
+                                            <input type="text" className="form-control me-2 log-input-value"
                                                 value={t.value}
                                                 onChange={(e) => updateToken(tokenIndex, 'value', e.target.value)} />
                                             {groupId !== 0 && (

--- a/src/log/components/filter/DetailFilter.jsx
+++ b/src/log/components/filter/DetailFilter.jsx
@@ -164,7 +164,7 @@ const DetailFilter = ({ onClose, processId, filterId, showOutAlert }) => {
     };
 
     return (
-        <div className="container mt-5" style={{ maxWidth: 950 }}>
+        <div className="container mt-5 log-filter-detail-container">
             {/* Alert 메시지 */}
             {alert && (
                 <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">
@@ -179,9 +179,9 @@ const DetailFilter = ({ onClose, processId, filterId, showOutAlert }) => {
 
 
             {/* 현재 표현식 */}
-            <div className="bg-light rounded-4 shadow-sm p-3 mb-4" style={{ fontSize: 17 }}>
+            <div className="bg-light rounded-4 shadow-sm p-3 mb-4 log-expression-box">
                 <strong className="me-2">현재 표현식:</strong>
-                <code className="text-break" style={{ fontSize: 16 }}>
+                <code className="text-break log-expression-code">
                     {buildExpression()}
                 </code>
             </div>
@@ -261,24 +261,22 @@ const DetailFilter = ({ onClose, processId, filterId, showOutAlert }) => {
                                                 if (nextToken?.type === 'condition') {
                                                     const condIndex = tokens.findIndex(tok => tok === nextToken);
                                                     return (
-                                                        <div className="d-flex align-items-center justify-content-center py-2 border-bottom" key={i}
-                                                            style={{ background: '#f8f9fa', borderRadius: 8, marginBottom: 6 }}>
+                                                        <div className="d-flex align-items-center justify-content-center py-2 border-bottom log-condition-row" key={i}>
                                                             <span className="fs-4 fw-bold text-primary me-2">(</span>
-                                                            <select className="form-select me-2" style={{ width: 150 }}
+                                                            <select className="form-select me-2 log-select-field-lg"
                                                                 value={nextToken.field}
                                                                 onChange={(e) => updateToken(condIndex, 'field', e.target.value)}>
                                                                 <option value="">필드 선택</option>
                                                                 {fieldList.map((f) => <option key={f} value={f}>{f}</option>)}
                                                             </select>
-                                                            <select className="form-select me-2" style={{ width: 100 }}
+                                                            <select className="form-select me-2 log-select-operator-lg"
                                                                 value={nextToken.operator}
                                                                 onChange={(e) => updateToken(condIndex, 'operator', e.target.value)}>
                                                                 {operatorOptions.map((op) => <option key={op} value={op}>{op}</option>)}
                                                             </select>
                                                             <input
                                                                 type="text"
-                                                                className="form-control me-2"
-                                                                style={{ width: 130 }}
+                                                                className="form-control me-2 log-input-value-lg"
                                                                 value={nextToken.value}
                                                                 onChange={(e) => updateToken(condIndex, 'value', e.target.value)}
                                                             />
@@ -298,21 +296,19 @@ const DetailFilter = ({ onClose, processId, filterId, showOutAlert }) => {
 
                                             if (t.type === 'condition' && group[i - 1]?.type !== 'left-paren') {
                                                 return (
-                                                    <div className="d-flex align-items-center justify-content-center py-2 border-bottom" key={i}
-                                                        style={{ background: '#f8f9fa', borderRadius: 8, marginBottom: 6 }}>
-                                                        <select className="form-select me-2" style={{ width: 150 }}
+                                                    <div className="d-flex align-items-center justify-content-center py-2 border-bottom log-condition-row" key={i}>
+                                                        <select className="form-select me-2 log-select-field-lg"
                                                             value={t.field}
                                                             onChange={(e) => updateToken(tokenIndex, 'field', e.target.value)}>
                                                             <option value="">필드 선택</option>
                                                             {fieldList.map((f) => <option key={f} value={f}>{f}</option>)}
                                                         </select>
-                                                        <select className="form-select me-2" style={{ width: 100 }}
+                                                        <select className="form-select me-2 log-select-operator-lg"
                                                             value={t.operator}
                                                             onChange={(e) => updateToken(tokenIndex, 'operator', e.target.value)}>
                                                             {operatorOptions.map((op) => <option key={op} value={op}>{op}</option>)}
                                                         </select>
-                                                        <input type="text" className="form-control me-2"
-                                                            style={{ width: 130 }}
+                                                        <input type="text" className="form-control me-2 log-input-value-lg"
                                                             value={t.value}
                                                             onChange={(e) => updateToken(tokenIndex, 'value', e.target.value)} />
                                                         {groupId !== 0 && (
@@ -330,8 +326,7 @@ const DetailFilter = ({ onClose, processId, filterId, showOutAlert }) => {
 
                                             if (t.type === 'right-paren') {
                                                 return (
-                                                    <div className="d-flex align-items-center justify-content-center py-2 border-bottom" key={i}
-                                                        style={{ background: '#f8f9fa', borderRadius: 8, marginBottom: 6 }}>
+                                                    <div className="d-flex align-items-center justify-content-center py-2 border-bottom log-condition-row" key={i}>
                                                         <span className="fs-4 fw-bold text-primary me-2">)</span>
                                                         {groupId !== 0 && (
                                                             <>

--- a/src/log/components/filter/FilterManagement.jsx
+++ b/src/log/components/filter/FilterManagement.jsx
@@ -39,7 +39,7 @@ const FilterManagement = ({ processId, onMenuClick }) => {
     };
 
     return (
-        <div style={{ marginTop: '80px' }}>
+        <div className="log-page-spacer">
             {/* 화면 중앙 위 고정 알림 */}
             {alert && (
                 <div className={`alert alert-${alert.type} fw-semibold mb-0 text-center custom-alert-center`}>
@@ -61,15 +61,15 @@ const FilterManagement = ({ processId, onMenuClick }) => {
                 </button>
             </div>
 
-            <div className="card shadow-sm rounded-4 mb-4" style={{ border: 0 }}>
+            <div className="card shadow-sm rounded-4 mb-4 log-card-noborder">
                 <table className="table table-bordered text-center align-middle mb-0">
                     <thead className="table-light">
                         <tr>
-                            <th style={{ width: '10%' }}>ID</th>
-                            <th className="text-start" style={{ width: '30%' }}>이름</th>
+                            <th className="log-col-10">ID</th>
+                            <th className="text-start log-col-30">이름</th>
                             <th>생성 날짜</th>
                             <th>수정 날짜</th>
-                            <th style={{ width: '10%' }}>활성화</th>
+                            <th className="log-col-10">활성화</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -120,7 +120,7 @@ const FilterManagement = ({ processId, onMenuClick }) => {
             </div>
 
             {builderComp && (
-                <div className="modal show d-block" tabIndex="-1" style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
+                <div className="modal show d-block log-modal-backdrop-50" tabIndex="-1">
                     <div className="modal-dialog modal-lg" role="document">
                         <div className="modal-content rounded-4">
                             <div className="modal-header">

--- a/src/log/components/format/DetailFormat.jsx
+++ b/src/log/components/format/DetailFormat.jsx
@@ -77,14 +77,7 @@ const
         }, []);
 
         return (
-            <div style={{
-                padding: '24px',
-                borderRadius: '12px',
-                maxWidth: '900px',
-                margin: '30px auto',
-                background: '#fff',
-                boxShadow: '0 2px 10px #eee'
-            }}>
+            <div className="log-format-detail-container">
                 <h2 className="mb-4">포맷 상세 화면</h2>
                 <form onSubmit={handleSubmit}>
                     <div className="mb-4">
@@ -93,8 +86,7 @@ const
                     <div>
                         <input
                             type="text"
-                            style={{ width: "415px", transform: "translateY(-28px)" }}
-                            className="form-control-center"
+                            className="form-control-center log-format-detail-name-input"
                             placeholder="format name"
                             value={name}
                             onChange={e => setName(e.target.value)}
@@ -115,8 +107,7 @@ const
                                             onChange={e =>
                                                 handleEntryChange(setDefaultEntry, defaultEntry, index, 'key', e.target.value)
                                             }
-                                            className="form-control me-2"
-                                            style={{ flex: '1' }}
+                                            className="form-control me-2 log-format-flex-1"
                                         />
                                         <input
                                             type="text"
@@ -125,8 +116,7 @@ const
                                             onChange={e =>
                                                 handleEntryChange(setDefaultEntry, defaultEntry, index, 'value', e.target.value)
                                             }
-                                            className="form-control me-2"
-                                            style={{ flex: '2' }}
+                                            className="form-control me-2 log-format-flex-2"
                                         />
                                         <button
                                             type="button"
@@ -155,8 +145,7 @@ const
                                             onChange={e =>
                                                 handleEntryChange(setFormatEntry, formatEntry, index, 'key', e.target.value)
                                             }
-                                            className="form-control me-2"
-                                            style={{ flex: '1' }}
+                                            className="form-control me-2 log-format-flex-1"
                                         />
                                         <span className="mx-1">⬅</span>
                                         <input
@@ -166,8 +155,7 @@ const
                                             onChange={e =>
                                                 handleEntryChange(setFormatEntry, formatEntry, index, 'value', e.target.value)
                                             }
-                                            className="form-control me-2"
-                                            style={{ flex: '2' }}
+                                            className="form-control me-2 log-format-flex-2"
                                         />
                                         <button
                                             type="button"

--- a/src/log/components/format/FormatManagement.jsx
+++ b/src/log/components/format/FormatManagement.jsx
@@ -32,7 +32,7 @@ const FormatManagement = ({ processId, onMenuClick }) => {
     };
 
     return (
-        <div style={{ marginTop: '80px' }}>
+        <div className="log-page-spacer">
             <h2 className="fw-bold mb-4">포맷 관리</h2>
 
             {/* 중앙 상단 고정 경고창 */}
@@ -49,15 +49,15 @@ const FormatManagement = ({ processId, onMenuClick }) => {
                 <button className="btn btn-secondary" onClick={() => onMenuClick('filter')}>필터링 관리 ➡</button>
             </div>
 
-            <div className="card shadow-sm rounded-4 mb-4" style={{ border: 0 }}>
+            <div className="card shadow-sm rounded-4 mb-4 log-card-noborder">
                 <table className="table table-bordered text-center align-middle mb-0">
                     <thead className="table-light">
                         <tr>
-                            <th style={{ width: '10%' }}>ID</th>
-                            <th className="text-start" style={{ width: '25%' }}>이름</th>
+                            <th className="log-col-10">ID</th>
+                            <th className="text-start log-col-25">이름</th>
                             <th>생성 날짜</th>
                             <th>수정 날짜</th>
-                            <th style={{ width: '18%' }}>관리</th>
+                            <th className="log-col-18">관리</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/src/log/components/format/InputFormat.jsx
+++ b/src/log/components/format/InputFormat.jsx
@@ -45,7 +45,7 @@ const InputFormat = ({ onClose, processId, showAlert }) => {
     };
 
     return (
-        <div className="modal show d-block" tabIndex="-1" style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
+        <div className="modal show d-block log-modal-backdrop-50" tabIndex="-1">
             <div className="modal-dialog modal-lg">
                 <div className="modal-content">
                     <div className="modal-header">
@@ -63,8 +63,7 @@ const InputFormat = ({ onClose, processId, showAlert }) => {
                                 <label className="form-label w-100 text-center">포맷 이름</label>
                                 <input
                                     type="text"
-                                    className="form-control"
-                                    style={{ width: "360px", textAlign: "center" }}
+                                    className="form-control log-format-input-name-input"
                                     value={name}
                                     onChange={e => setName(e.target.value)}
                                 />

--- a/src/log/components/monitoring/Kibana.jsx
+++ b/src/log/components/monitoring/Kibana.jsx
@@ -2,21 +2,11 @@ import React from 'react';
 
 const Kibana = () => {
     return (
-        <div style={{
-            width: '80vw',
-            height: '100vh',
-            marginTop: "-75px",
-            padding: 0,
-            overflow: 'hidden',
-        }}>
+        <div className="kibana-container">
             <iframe src="http://14.63.178.160:8085/app/dashboards#/view/cda75653-fe83-4bcf-b630-8f11acae0996?embed=false&_g=(refreshInterval:(pause:!t,value:5000),time:(from:now-3h,to:now))&_a=()&show-top-menu=true&show-query-input=true&show-time-filter=true"
                 height="100%"
                 width="100%"
-                style={{
-                    border: 'none',
-                    width: '80vw',
-                    height: '100vh',
-                }}
+                className="kibana-iframe"
                 allowFullScreen
             >
             </iframe>

--- a/src/log/components/process/EditProcess.jsx
+++ b/src/log/components/process/EditProcess.jsx
@@ -27,7 +27,7 @@ const EditProcess = ({ onClose, processId, _name, showAlert }) => {
 
     return (
 
-        <div className="card mt-4 p-4 mx-auto" style={{ maxWidth: '400px' }}>
+        <div className="card mt-4 p-4 mx-auto log-process-card">
             <h4 className="mb-3">Process 수정</h4>
 
 

--- a/src/log/components/process/InputProcess.jsx
+++ b/src/log/components/process/InputProcess.jsx
@@ -15,7 +15,7 @@ const InputProcess = ({ onClose, showAlert }) => {
     };
 
     return (
-        <div className="card mt-4 p-4 mx-auto" style={{ maxWidth: '400px' }}>
+        <div className="card mt-4 p-4 mx-auto log-process-card">
             <h4 className="mb-3">프로세스 이름</h4>
 
 

--- a/src/log/components/process/ProcessManagement.jsx
+++ b/src/log/components/process/ProcessManagement.jsx
@@ -48,15 +48,14 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
     };
 
     return (
-        <div style={{ marginTop: '80px' }}>
-            <div className="d-flex align-items-center mb-4" style={{ minHeight: 40 }}>
-                <h2 className="fw-bold" style={{ color: "#34a853", paddingBottom: "2px" }}>●</h2>
-                <h2 className="fw-bold" style={{ marginLeft: "7px" }}>프로세스 관리</h2>
+        <div className="log-page-spacer">
+            <div className="d-flex align-items-center mb-4 process-header-row">
+                <h2 className="fw-bold process-status-dot">●</h2>
+                <h2 className="fw-bold process-header-title">프로세스 관리</h2>
             </div>
             <div className="d-flex justify-content-end  mb-3">
                 <button
-                    className="btn btn-success shadow-sm"
-                    style={{ borderRadius: "0.7rem", fontWeight: 600 }}
+                    className="btn btn-success shadow-sm log-btn-rounded"
                     onClick={() => setShowModal(true)}
                 >
                     + 프로세스 추가
@@ -70,15 +69,15 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
                 </div>
             )}
 
-            <div className="card shadow-sm rounded-4 mb-4" style={{ border: 0 }}>
+            <div className="card shadow-sm rounded-4 mb-4 log-card-noborder">
                 <table className="table table-hover table-bordered align-middle text-center mb-0">
                     <thead className="table-light">
                         <tr>
-                            <th style={{ width: '15%' }}>ID</th>
+                            <th className="log-col-15">ID</th>
                             <th className="text-start">이름</th>
                             <th>생성 날짜</th>
                             <th>수정 날짜</th>
-                            <th style={{ width: '15%' }}>수정</th>
+                            <th className="log-col-15">수정</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -108,8 +107,7 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
                                     <td>{process.updatedAt && processDate(process.updatedAt)}</td>
                                     <td>
                                         <button
-                                            className="btn btn-outline-primary btn-sm px-3"
-                                            style={{ borderRadius: '0.7rem', fontWeight: 500 }}
+                                            className="btn btn-outline-primary btn-sm px-3 log-btn-rounded-sm"
                                             onClick={() => setEditComp(process.logProcessId)}
                                         >
                                             수정
@@ -118,7 +116,7 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
                                 </tr>
                                 {editComp === process.logProcessId && (
                                     <tr>
-                                        <td colSpan={5} style={{ background: "#f6f8fa", borderBottomLeftRadius: '0.7rem', borderBottomRightRadius: '0.7rem' }}>
+                                        <td colSpan={5} className="process-edit-row">
                                             <EditProcess
                                                 onClose={handleEditComp}
                                                 processId={process.logProcessId}
@@ -138,18 +136,12 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
             {/* 모달 구조 */}
             {showModal && (
                 <div
-                    className="modal fade show"
+                    className="modal fade show log-modal-backdrop-30"
                     tabIndex="-1"
-                    style={{
-                        display: 'block',
-                        background: 'rgba(0,0,0,0.3)',
-                        zIndex: 1050,
-                    }}
                     onClick={handleCloseModal}
                 >
                     <div
-                        className="modal-dialog modal-dialog-centered"
-                        style={{ maxWidth: 480 }}
+                        className="modal-dialog modal-dialog-centered log-modal-dialog-sm"
                         onClick={e => e.stopPropagation()}
                     >
                         <div className="modal-content rounded-4" >

--- a/src/sign/component/MemberManagement.jsx
+++ b/src/sign/component/MemberManagement.jsx
@@ -30,7 +30,7 @@ const MemberManagement = () => {
     }, []);
 
     return (
-        <div className="container" style={{ marginTop: '80px' }}>
+        <div className="container sign-page-spacer">
             {/* Alert 메시지 */}
             {alert.show && (
                 <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">
@@ -40,7 +40,7 @@ const MemberManagement = () => {
                 </div>
             )}
 
-            <h2 className="fw-bold" style={{ marginBottom: "3.5rem" }}>회원 관리</h2>
+            <h2 className="fw-bold member-mgmt-title">회원 관리</h2>
             <div className="table-responsive">
                 <table className="table table-hover align-middle">
                     <thead className="table-light">

--- a/src/sign/component/PasswordChangePage.jsx
+++ b/src/sign/component/PasswordChangePage.jsx
@@ -2,25 +2,6 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { changePassword } from '../../api/memberApi';
 
-const cardStyle = {
-    maxWidth: "420px",
-    width: "95%",
-    margin: "40px auto",
-    padding: "40px 34px 32px 34px",
-    background: "rgba(255,255,255,0.97)",
-    borderRadius: "1.5rem",
-    boxShadow: "0 6px 36px 0 rgba(54,69,79,0.13)",
-};
-
-const titleGradient = {
-    fontWeight: "bold",
-    fontSize: "2rem",
-    background: "#000000",
-    WebkitBackgroundClip: "text",
-    WebkitTextFillColor: "transparent",
-    marginBottom: "30px"
-};
-
 // 비밀번호 보안 패턴 (8자 이상, 영문/숫자/특수문자)
 const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]).{8,}$/;
 
@@ -81,15 +62,10 @@ const PasswordChangePage = () => {
     };
 
     return (
-        <div style={{
-            minHeight: "100vh",
-            background: "linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)",
-            display: "flex",
-            flexDirection: "column",
-        }}>
+        <div className="min-vh-100 d-flex flex-column sign-page-bg">
             <main className="flex-grow-1 d-flex align-items-center justify-content-center">
-                <div style={cardStyle}>
-                    <div style={titleGradient} className="text-center mb-4">비밀번호 변경</div>
+                <div className="sign-card">
+                    <div className="sign-card-title text-center mb-4">비밀번호 변경</div>
                     {/* Alert */}
                     {alert.show && (
                         <div className={`alert alert-${alert.type} py-2 alert-dismissible fade show`} role="alert">

--- a/src/sign/component/SignInPage.jsx
+++ b/src/sign/component/SignInPage.jsx
@@ -48,16 +48,7 @@ const SignInPage = () => {
     }, []);
 
     return (
-        <div
-            style={{
-                minHeight: "100vh",
-                width: "100vw",
-                overflowX: "hidden",
-                background: "linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)",
-                position: "relative"
-            }}
-            className="min-vh-100 d-flex flex-column"
-        >
+        <div className="min-vh-100 d-flex flex-column sign-page-bg sign-page-bg-full">
             <main className="flex-grow-1 d-flex align-items-center justify-content-center">
                 <div className="col-md-5 col-lg-4">
                     <div className="card shadow-sm">

--- a/src/sign/component/SignUpPage.jsx
+++ b/src/sign/component/SignUpPage.jsx
@@ -24,27 +24,11 @@ const SignUpPage = () => {
     }, []);
 
     return (
-        <div className="min-vh-100 d-flex flex-column" style={{
-            background: "linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)"
-        }}>
+        <div className="min-vh-100 d-flex flex-column sign-page-bg">
             <main className="flex-grow-1 d-flex align-items-center justify-content-center">
-                <div style={{
-                    maxWidth: "410px",
-                    width: "95%",
-                    margin: "3rem auto",
-                    borderRadius: "1.5rem",
-                    boxShadow: "0 6px 32px 0 rgba(54,69,79,0.13)",
-                    border: "none"
-                }} className="card shadow-sm">
+                <div className="card shadow-sm signup-card">
                     <div className="card-body p-4">
-                        <div className="text-center" style={{
-                            fontWeight: "bold",
-                            fontSize: "2.05rem",
-                            background: "#000000",
-                            WebkitBackgroundClip: "text",
-                            WebkitTextFillColor: "transparent",
-                            marginBottom: "24px"
-                        }}>회원가입</div>
+                        <div className="text-center signup-card-title">회원가입</div>
                         {alert.show && (
                             <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">
                                 {alert.message}
@@ -196,17 +180,7 @@ const SignUpPage = () => {
 
                             <div className="d-grid">
                                 <button type="submit"
-                                    className="btn text-white shadow"
-                                    style={{
-                                        fontWeight: "bold",
-                                        fontSize: "1.08rem",
-                                        letterSpacing: "0.03em",
-                                        borderRadius: "2rem",
-                                        padding: "0.75rem",
-                                        marginTop: "12px",
-                                        background: "#3f51b5",
-                                        border: "none"
-                                    }}
+                                    className="btn text-white shadow signup-submit-btn"
                                     disabled={!isFormValid}>
                                     {isSubmitting ? (
                                         <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>

--- a/src/sign/component/SignUpdatePage.jsx
+++ b/src/sign/component/SignUpdatePage.jsx
@@ -2,38 +2,6 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getMyProfile, updateMyProfile } from '../../api/memberApi';
 
-const inputBoxStyle = {
-    width: "100%",
-    marginBottom: "22px",
-};
-
-const cardStyle = {
-    maxWidth: "420px",
-    width: "95%",
-    margin: "40px auto",
-    padding: "40px 34px 32px 34px",
-    background: "rgba(255,255,255,0.97)",
-    borderRadius: "1.5rem",
-    boxShadow: "0 6px 36px 0 rgba(54,69,79,0.13)",
-};
-
-const titleGradient = {
-    fontWeight: "bold",
-    fontSize: "2rem",
-    background: "#000000",
-    WebkitBackgroundClip: "text",
-    WebkitTextFillColor: "transparent",
-    marginBottom: "30px"
-};
-
-const btnStyle = {
-    fontWeight: "bold",
-    fontSize: "1.07rem",
-    letterSpacing: "0.03em",
-    borderRadius: "2rem",
-    marginTop: "18px"
-};
-
 const SignUpdatePage = () => {
     const [formData, setFormData] = useState({
         loginId: '',
@@ -84,15 +52,10 @@ const SignUpdatePage = () => {
     }, []);
 
     return (
-        <div style={{
-            minHeight: "100vh",
-            background: "linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)",
-            display: "flex",
-            flexDirection: "column",
-        }}>
+        <div className="min-vh-100 d-flex flex-column sign-page-bg">
             <main className="flex-grow-1 d-flex align-items-center justify-content-center">
-                <div style={cardStyle}>
-                    <div style={titleGradient} className="text-center mb-4">회원 정보 수정</div>
+                <div className="sign-card">
+                    <div className="sign-card-title text-center mb-4">회원 정보 수정</div>
                     {/* Alert 메시지 */}
                     {alert.show && (
                         <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">
@@ -107,7 +70,7 @@ const SignUpdatePage = () => {
                     )}
                     <form className="needs-validation" noValidate onSubmit={handleSubmit}>
                         {/* 닉네임 */}
-                        <div style={inputBoxStyle}>
+                        <div className="sign-card-input-box">
                             <label htmlFor="nickname" className="form-label fw-semibold">닉네임</label>
                             <input
                                 type="text"
@@ -121,7 +84,7 @@ const SignUpdatePage = () => {
                             <div className="invalid-feedback">닉네임을 입력해주세요.</div>
                         </div>
                         {/* 아이디 */}
-                        <div style={inputBoxStyle}>
+                        <div className="sign-card-input-box">
                             <label htmlFor="loginId" className="form-label fw-semibold">아이디</label>
                             <input
                                 type="text"
@@ -136,7 +99,7 @@ const SignUpdatePage = () => {
                             <div className="invalid-feedback">아이디를 입력해주세요.</div>
                         </div>
                         {/* 이메일 */}
-                        <div style={inputBoxStyle}>
+                        <div className="sign-card-input-box">
                             <label htmlFor="email" className="form-label fw-semibold">
                                 이메일
                             </label>
@@ -154,16 +117,14 @@ const SignUpdatePage = () => {
                         <div className="d-flex gap-2">
                             <button
                                 type="button"
-                                className="btn btn-outline-secondary flex-fill"
-                                style={{ ...btnStyle, marginTop: 0 }}
+                                className="btn btn-outline-secondary flex-fill sign-card-btn"
                                 onClick={() => navigate('/sign/update/password')}
                             >
                                 비밀번호 변경
                             </button>
                             <button
                                 type="submit"
-                                className="btn btn-primary flex-fill"
-                                style={{ ...btnStyle, marginTop: 0 }}>
+                                className="btn btn-primary flex-fill sign-card-btn">
                                 수정 완료
                             </button>
                         </div>


### PR DESCRIPTION
## 관련 이슈
closes #52

## 변경 사항
Phase 3 나머지 화면(board/sign/comment/log)의 인라인 `style={{...}}`를 도메인별 CSS 파일로 일괄 이관. (post 화면은 별도 PR #51에서 처리)

- **board → `main.css`**: MainPage 히어로 섹션/랭킹 카드(MainPageCard·MainPageCard2·RankCard)/레이아웃, AdmnBoard 목록·모달, 지역/카테고리 선택 위젯(RegionRadioComp·CategoryCard)
- **sign → `sign.css` (신설)**: SignIn/SignUp/SignUpdate/PasswordChange 공통 배경·카드, MemberManagement, MyPage 및 하위 화면(ChckMyCom·CheckMyArt·LikeListPage)
- **comment → `comment.css` (신설)**: CommentPage 모달/알림, CommentList, WriteComment
- **log → `log.css`**: Process/Format/Filter/Deduplication Management, LogTable(처리기록), Kibana 모니터링

## 작업 방법
- 정적 인라인 스타일 → 도메인 접두사 케밥케이스 클래스로 추출 (예: `mainpage-hero-title`, `sign-card`, `comment-list-card`, `log-condition-row`)
- 색상/그라디언트/shadow/radius/z-index는 `tokens.css` 변수 우선 참조
- 순위별 색상, 별점 색상 등 **런타임 계산 값만 인라인 유지**
- 동일 값을 갖는 반복 인라인 블록(테이블 열 너비, 모달 배경 등)은 공용 클래스로 통합 (`log-col-10`, `log-modal-backdrop-50` 등)
- 레이아웃 간격은 Bootstrap 유틸리티 우선 사용

## 테스트
- ESLint 전체 실행: 기존 대비 신규 에러 0건 (경고 포함 기존 이슈만 잔존)
- `CI=true npm run build` 및 일반 `npm run build` 모두 성공 확인
- 각 도메인 디렉토리에 `style={{`  잔여 검색 → 런타임 계산 값(순위 배경색, 별점 색상, 동적 컬럼 width)만 남고 정적 값은 모두 제거 확인
- 시각 동일성: 값 변환 없이 기존 인라인 값 그대로 클래스로 이관 (메인/관리자/로그인/마이페이지/댓글/로그관리 화면)