### PR TITLE
🐛 Fix: 푸터 중복 제거 + 하단 흰 여백 수정

### DIFF
--- a/src/board/component/page/MainPage.jsx
+++ b/src/board/component/page/MainPage.jsx
@@ -5,7 +5,6 @@ import { subscribeRankings } from "../../../api/rankingApi";
 
 import MainPageCardsLayout from "./MainPageCardsLayout";
 import MainPageCardsLayout2 from "./MainPageCardsLayout2";
-import Footers from "../../../common/Footers";
 
 
 const MainPage = () => {
@@ -97,8 +96,6 @@ const MainPage = () => {
         </div>
 
       </div>
-
-      <Footers />
     </div>
   );
 };

--- a/src/common/Footers.jsx
+++ b/src/common/Footers.jsx
@@ -1,13 +1,16 @@
 
 //페이지 밑에 들어가는 footers 파일
+const APP_NAME = process.env.REACT_APP_APP_NAME || "TripNow";
+
 const Footers = () => {
+  const year = new Date().getFullYear();
+
   return (
-    <div className="container">
-      <footer className="row row-cols-1 row-cols-sm-2 row-cols-md-5 border-top app-footer">
-
-
-      </footer>
-    </div>
+    <footer className="app-footer border-top">
+      <div className="container text-center text-muted app-footer-copy">
+        © {year} {APP_NAME}. All rights reserved.
+      </div>
+    </footer>
   );
 }
 

--- a/src/components/layout/RootLayout.jsx
+++ b/src/components/layout/RootLayout.jsx
@@ -4,13 +4,13 @@ import GlobalNavigator from "../../common/GlobalNavigator";
 
 const RootLayout = ({ children }) => {
   return (
-    <>
+    <div className="app-shell">
       <GlobalNavigator />
       <Navbar />
       <div style={{ paddingTop: 25 }} />
-      <main>{children}</main>
+      <main className="app-main">{children}</main>
       <Footers />
-    </>
+    </div>
   );
 };
 

--- a/src/css/common.css
+++ b/src/css/common.css
@@ -1,5 +1,16 @@
 /* 공통 레이아웃: Navbar / NavMenu / Footer / 공통 패턴 */
 
+/* ===== 페이지 셸 (sticky footer) ===== */
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-main {
+  flex: 1 0 auto;
+}
+
 /* ===== 상단 고정 알림 (Navbar) ===== */
 .app-alert-fixed {
   position: fixed;
@@ -116,8 +127,12 @@
 
 /* ===== Footer ===== */
 .app-footer {
-  margin: 100px 0 0 0;
-  padding: 64px 0 32px 0;
+  margin: 48px 0 0 0;
+  padding: 24px 0;
+}
+
+.app-footer-copy {
+  font-size: 0.875rem;
 }
 
 /* ===== 공통 페이지 타이틀 ===== */

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,5 +1,6 @@
 body {
   margin: 0;
+  background: var(--page-bg);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -483,7 +483,6 @@
 /* ===== 메인 히어로/섹션 (MainPage) ===== */
 .mainpage-root {
   min-height: 100vh;
-  background: #F5F6FF;
   width: 100%;
   overflow-x: hidden;
   margin-top: -1px;

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -4,6 +4,7 @@
   --brand-badge-gradient: linear-gradient(90deg, #B794F4 40%, #90CDF4 100%);
 
   /* 서피스 */
+  --page-bg: #F5F6FF;
   --card-bg: #fff;
   --card-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.04);
   --card-shadow-lg: 0 8px 32px rgba(60, 60, 100, 0.14);


### PR DESCRIPTION
## 관련 이슈
closes #56

## 변경 사항
- MainPage의 중복 `<Footers />` 제거 (푸터는 RootLayout 한 곳에서만 렌더링)
- 빈 푸터에 카피라이트 콘텐츠 추가, 과도한 margin/padding 축소
- 페이지 배경색을 `.mainpage-root`에서 body 레벨(`--page-bg` 토큰)로 이동
- `RootLayout`에 sticky footer 패턴(`.app-shell` flex column + `.app-main` flex:1) 적용

## 작업 방법
- `tokens.css`에 `--page-bg: #F5F6FF` 토큰 추가, `index.css`의 `body`에 적용
- `main.css`의 `.mainpage-root`에서 중복 배경 선언 제거
- `common.css`에 `.app-shell` / `.app-main` sticky footer 레이아웃 추가, `.app-footer` 여백 축소
- `Footers.jsx`에 연도/앱 이름(`REACT_APP_APP_NAME`) 기반 카피라이트 텍스트 추가
- `MainPage.jsx`의 중복 `Footers` import/렌더링 제거

## 테스트
- 메인 페이지(`/`): 푸터 1개만 노출, 카드 섹션 끝부터 푸터까지 흰 여백 없음 확인
- 로그인 페이지(`/sign/component/SignInPage`): 콘텐츠가 짧아도 푸터가 뷰포트 하단에 붙어 렌더링됨(sticky footer) 확인
- 게시글 목록(`/post/list`): 배경/푸터 정상, 콘솔 에러 없음 확인
- 스크린샷: 세 페이지 모두 Playwright로 캡처하여 변경 전후 비교 완료
