### PR TITLE
🐛 Fix: 랭킹 카드 5개 미만 무한 로딩 + 좁은 화면 반응형 깨짐

### DIFF
--- a/src/board/component/page/MainPage.jsx
+++ b/src/board/component/page/MainPage.jsx
@@ -87,11 +87,11 @@ const MainPage = () => {
       {/* 지역/카테고리별 */}
       <div >
         <div className="mainpage-category-section" >
-          <h4 className="text-left mb-4 mainpage-subsection-title">실시간 인기 카테고리</h4>
+          <h4 className="mainpage-subsection-title">실시간 인기 카테고리</h4>
           <MainPageCardsLayout2 top5Data={top5Category} />
         </div>
         <div className="mainpage-region-section">
-          <h4 className="text-left mb-4 mainpage-subsection-title">실시간 인기 지역</h4>
+          <h4 className="mainpage-subsection-title">실시간 인기 지역</h4>
           <MainPageCardsLayout2 top5Data={top5Region} />
         </div>
 

--- a/src/board/component/page/MainPageCardsLayout.jsx
+++ b/src/board/component/page/MainPageCardsLayout.jsx
@@ -9,12 +9,12 @@ const mainCardHeight = 520;
 
 /**
  * 인기 게시판 카드 레이아웃
- * - 데이터가 5개 미만이면 비행기 로딩 애니메이션 표시
- * - 5개 이상이면 1~5위 카드 정렬
+ * - 데이터가 없으면 로딩 애니메이션 표시
+ * - 1개 이상이면 있는 만큼 1~5위 카드 정렬
  */
 const MainPageCardsLayout = ({ top5Posts }) => {
-    // 데이터가 5개 미만이면 로딩 화면
-    if (!top5Posts || top5Posts.length < 5) {
+    // 데이터가 아직 없으면 로딩 화면
+    if (!top5Posts || top5Posts.length === 0) {
         return <LoadingSpinner text="여행지 인기순위를 불러오는 중..." minHeight={mainCardHeight} />;
     }
 

--- a/src/board/component/page/MainPageCardsLayout2.jsx
+++ b/src/board/component/page/MainPageCardsLayout2.jsx
@@ -5,14 +5,14 @@ import LoadingSpinner from '../../../components/LoadingSpinner';
 const cardHeight = 200;
 
 const MainPageCardsLayout2 = ({ top5Data }) => {
-    // 데이터 없거나 5개 미만이면 로딩 애니메이션
-    if (!top5Data || top5Data.length < 5) {
+    // 데이터가 아직 없으면 로딩 애니메이션
+    if (!top5Data || top5Data.length === 0) {
         return <LoadingSpinner text="순위 데이터를 불러오는 중..." minHeight={cardHeight + 80} />;
     }
 
-    // 데이터 있을 때 카드 렌더링
+    // 데이터 있는 만큼 카드 렌더링
     return (
-        <div className="d-flex justify-content-center align-items-center mainpage-layout2-row">
+        <div className="mainpage-layout2-row">
             {top5Data.map((data, idx) => (
                 <div key={idx}>
                     <div className="mainpage-layout2-card">

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -440,18 +440,18 @@
 
 /* ===== 인기 카테고리/지역 레이아웃 (MainPageCardsLayout2) ===== */
 .mainpage-layout2-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   width: 100%;
   max-width: 1400px;
   margin: 0 auto;
   gap: 24px;
-  overflow-x: auto;
   padding: 8px 0;
 }
 
 .mainpage-layout2-card {
-  width: 240px;
+  width: 100%;
   height: 200px;
-  flex-shrink: 0;
   border-radius: var(--radius-card-md);
   overflow: hidden;
   background: var(--card-bg);
@@ -600,12 +600,12 @@
 }
 
 .mainpage-subsection-title {
-  padding-left: 19rem;
+  max-width: 1400px;
+  margin: 0 auto 1.4rem auto;
   text-align: left;
   font-family: var(--font-display);
   color: #b7aaff;
   font-weight: 700;
   font-size: 1.55rem;
   letter-spacing: -0.03em;
-  margin-bottom: 1.4rem;
 }


### PR DESCRIPTION
## 관련 이슈
closes #58

## 변경 사항
- `MainPageCardsLayout` / `MainPageCardsLayout2`의 로딩 조건을 `length < 5`에서 빈 배열 여부로 변경 (1~4개 데이터일 때 무한 로딩되던 버그 수정)
- `.mainpage-layout2-row`를 flex + `overflow-x: auto`에서 CSS Grid `repeat(auto-fit, minmax(180px, 1fr))`로 교체 → 화면 폭에 따라 열 수 자동 조절, 카드 잘림/가로 스크롤 제거
- `.mainpage-layout2-card` 고정폭(240px) 제거, 그리드 셀에 맞춰 100% 폭
- `.mainpage-subsection-title`의 고정 `padding-left: 19rem` 제거, 카드 행과 동일한 `max-width: 1400px; margin: 0 auto` 컨테이너로 정렬

## 작업 방법
- 로딩 스피너 표시 조건을 `!data || data.length === 0`으로 변경 (5개 미만이어도 있는 만큼 렌더링, `slice(1, 5)`는 원래 배열 길이에 안전)
- 반응형은 미디어쿼리 대신 CSS Grid `auto-fit`으로 처리해 임의 화면 폭에서도 자동 대응

## 테스트
- Playwright로 1600px / 900px / 420px 3개 뷰포트 스크린샷 확인 — 가로 스크롤/잘림 없음, 폭에 따라 5→4→2열로 자연스럽게 재배치
- `EventSource`를 스텁하여 게시글 2개 / 카테고리 1개 / 지역 0개인 SSE 페이로드로 실제 렌더링 확인:
  - 게시글 2개: 1위 카드 + 2위 카드만 정상 렌더링 (더 이상 무한 로딩 아님)
  - 카테고리 1개: 카드 1개만 정상 렌더링
  - 지역 0개(빈 배열): 로딩 스피너 정상 표시 (의도된 동작)
- SSE 랭킹 구독(`subscribeRankings`) 로직은 변경하지 않음, 실시간 연결 정상 동작 확인
