### PR TITLE
🐛 Fix: 게시물 리스트 날짜 NaN-NaN-NaN NaN:NaN 표시 버그 수정

### DIFF
--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -1,6 +1,19 @@
-export const formatDate = (isoString) => {
-  if (!isoString) return "";
-  const date = new Date(isoString.includes("+") ? isoString : isoString + "+09:00");
+export const formatDate = (value) => {
+  if (!value) return "";
+
+  let date;
+  if (Array.isArray(value)) {
+    const [year, month, day, hour = 0, minute = 0, second = 0] = value;
+    date = new Date(year, month - 1, day, hour, minute, second);
+  } else if (typeof value === "string") {
+    const hasTimezone = /[zZ]$|[+-]\d{2}:\d{2}$/.test(value);
+    date = new Date(hasTimezone ? value : `${value}+09:00`);
+  } else {
+    date = new Date(value);
+  }
+
+  if (Number.isNaN(date.getTime())) return "";
+
   return (
     date.getFullYear() + "-" +
     String(date.getMonth() + 1).padStart(2, "0") + "-" +


### PR DESCRIPTION
## 관련 이슈
closes #60

## 변경 사항
- `src/utils/dateUtils.js`의 `formatDate`를 방어적으로 보강

## 작업 방법
- 실제 `/api/v1/search/posts` 응답 확인 결과 `updatedAt`이 CLAUDE.md 진단(배열 직렬화)과 달리 `"2026-07-05T15:25:23.798323Z"` 형태의 UTC ISO 문자열로 내려오는 것을 확인
- 기존 코드는 `"+"` 포함 여부만으로 오프셋 유무를 판단해 `Z` 종료 문자열에 `+09:00`을 그대로 이어붙여 `Invalid Date`가 발생 → `Z`/`±HH:mm` 타임존이 이미 있으면 그대로 파싱하도록 수정
- 배열 형식(`[year, month, day, ...]`) 입력 방어 처리 추가 (다른 엔드포인트에서 발생 가능성 대비)
- 파싱 실패 시 빈 문자열 반환

## 테스트
- 실제 API 응답값(`updatedAt: "2026-07-05T15:25:23.798323Z"`) → `2026-07-06 00:25` 정상 출력 확인
- `null` / 빈 값 → 빈 문자열 반환 확인
- 배열 형식 입력 → 정상 포맷 확인
- 파싱 불가 문자열 → 빈 문자열 반환 (NaN 노출 없음) 확인
