### PR TITLE
💄 Style: 관리자 페이지 알림/날짜/모달 통일 + 공통 컴포넌트 도입

### DIFF
--- a/src/board/component/page/AdmnBoard.jsx
+++ b/src/board/component/page/AdmnBoard.jsx
@@ -5,6 +5,8 @@ import { useNavigate } from "react-router-dom";
 import { Badge } from "react-bootstrap";
 import { toast } from "react-toastify";
 import { CATEGORY_CODE_TO_LABEL, REGION_CODE_TO_LABEL } from "../../../constants/categoryRegion";
+import { formatDate } from "../../../utils/dateUtils";
+import AdminPageHeader from "../../../common/AdminPageHeader";
 
 const Pagination = ({ total, page, onChange, pageSize = 10 }) => {
     const pageCount = Math.ceil(total / pageSize);
@@ -108,11 +110,6 @@ const AdmnBoard = () => {
         대구: "secondary", 인천: "dark", 전남: "secondary"
     };
 
-    const formatDate = (isoString) => {
-        if (!isoString) return "";
-        return isoString.substring(0, 16).replace("T", " ");
-    };
-
     const handleRemove = ({ no }) => {
         setRemoveTarget(no);
         setShowConfirm(true);
@@ -183,7 +180,7 @@ const AdmnBoard = () => {
                 </div>
             )}
             <div className="container admin-board-container">
-                <h2 className="fw-bold">여행지 관리</h2>
+                <AdminPageHeader title="여행지 관리" />
                 <div className="row g-4">
                     <div className="col-12">
                         <div className="panel-bg p-4 rounded-4 h-100 shadow-sm admin-board-panel">

--- a/src/common/AdminPageHeader.jsx
+++ b/src/common/AdminPageHeader.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const AdminPageHeader = ({ title, children }) => (
+    <div className="d-flex justify-content-between align-items-center flex-wrap gap-2 admin-page-header">
+        <h2 className="fw-bold admin-page-header-title">{title}</h2>
+        {children && <div className="d-flex gap-2 admin-page-header-actions">{children}</div>}
+    </div>
+);
+
+AdminPageHeader.propTypes = {
+    title: PropTypes.node.isRequired,
+    children: PropTypes.node,
+};
+
+export default AdminPageHeader;

--- a/src/common/AdminPipelineNav.jsx
+++ b/src/common/AdminPipelineNav.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const STEPS = [
+    { key: 'format', label: '포맷 관리' },
+    { key: 'filter', label: '필터 관리' },
+    { key: 'deduplication', label: '중복제거 관리' },
+];
+
+const AdminPipelineNav = ({ active, onNavigate }) => (
+    <ul className="nav nav-pills admin-pipeline-nav mb-3">
+        {STEPS.map(step => (
+            <li className="nav-item" key={step.key}>
+                <button
+                    type="button"
+                    className={`nav-link admin-pipeline-nav-link${active === step.key ? ' active' : ''}`}
+                    onClick={() => onNavigate(step.key)}
+                >
+                    {step.label}
+                </button>
+            </li>
+        ))}
+    </ul>
+);
+
+AdminPipelineNav.propTypes = {
+    active: PropTypes.oneOf(['format', 'filter', 'deduplication']).isRequired,
+    onNavigate: PropTypes.func.isRequired,
+};
+
+export default AdminPipelineNav;

--- a/src/common/AdmnMenu.jsx
+++ b/src/common/AdmnMenu.jsx
@@ -1,35 +1,41 @@
 // AdmnMenu.jsx
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const AdmnMenu = ({ onMenuClick }) => {
+const MENU_ITEMS = [
+    { key: 'board', label: '여행지 관리' },
+    { key: 'member', label: '회원 관리' },
+    { key: 'process', label: '프로세스 관리' },
+    { key: 'log', label: '로그 DB' },
+    { key: 'monitoring', label: 'Monitoring' },
+];
+
+const AdmnMenu = ({ onMenuClick, activeMenu }) => {
     return (
-        <div className="list-group text-center" >
-            <h4 style={{paddingTop: 20}}>관리자 메뉴</h4>
-            <button className="list-group-item list-group-item-action" onClick={() => onMenuClick('board')}>
-                여행지 관리
-            </button>
-            <button className="list-group-item list-group-item-action" onClick={() => onMenuClick('member')}>
-                회원 관리
-            </button>
-            <button className="list-group-item list-group-item-action" onClick={() => onMenuClick('process')}>
-                프로세스 관리
-            </button>
-            <button className="list-group-item list-group-item-action" onClick={() => onMenuClick('log')}>
-                로그 DB
-            </button>
-            <button className="list-group-item list-group-item-action" onClick={() => onMenuClick('monitoring')}>
-                Monitoring
-            </button>
+        <div className="list-group text-center admin-menu">
+            <h4 className="admin-menu-title">관리자 메뉴</h4>
+            {MENU_ITEMS.map(item => (
+                <button
+                    key={item.key}
+                    className={`list-group-item list-group-item-action admin-menu-item${activeMenu === item.key ? ' active' : ''}`}
+                    onClick={() => onMenuClick(item.key)}
+                >
+                    {item.label}
+                </button>
+            ))}
             {/* <button className="list-group-item list-group-item-action" onClick={() => window.open(process.env.REACT_APP_MATOMO_URL)}>
                 Matomo
             </button>
             <button className="list-group-item list-group-item-action" onClick={() => window.open('http://14.63.178.160:8085')}>
                 Kibana
             </button> */}
-
-
         </div>
     );
+};
+
+AdmnMenu.propTypes = {
+    onMenuClick: PropTypes.func.isRequired,
+    activeMenu: PropTypes.string,
 };
 
 export default AdmnMenu;

--- a/src/common/AdmnPage.jsx
+++ b/src/common/AdmnPage.jsx
@@ -58,7 +58,10 @@ const AdmnPage = () => {
       <div className="row">
         {/* 왼쪽: 메뉴 (props로 onMenuClick 전달) */}
         <div className="col-lg-2 p-0 border-end bg-body-tertiary min-vh-100" >
-          <AdmnMenu onMenuClick={setActiveMenu} />
+          <AdmnMenu
+            onMenuClick={setActiveMenu}
+            activeMenu={['format', 'filter', 'deduplication'].includes(activeMenu) ? 'process' : activeMenu}
+          />
         </div>
 
         {/* 오른쪽: 본문 */}

--- a/src/css/common.css
+++ b/src/css/common.css
@@ -141,3 +141,36 @@
   font-family: var(--font-display);
   font-size: 2rem;
 }
+
+/* ===== 관리자 공통 (AdminPageHeader / AdminPipelineNav / AdmnMenu) ===== */
+.admin-page-header {
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 3px solid transparent;
+  border-image: var(--brand-gradient) 1;
+}
+
+.admin-page-header-title {
+  margin: 0;
+}
+
+.admin-pipeline-nav .admin-pipeline-nav-link {
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  color: var(--page-title-color);
+}
+
+.admin-pipeline-nav .admin-pipeline-nav-link.active {
+  background: var(--brand-gradient);
+  color: #fff;
+}
+
+.admin-menu-title {
+  padding-top: 20px;
+}
+
+.admin-menu-item.active {
+  background: var(--brand-gradient);
+  border-color: transparent;
+  color: #fff;
+}

--- a/src/css/log.css
+++ b/src/css/log.css
@@ -16,22 +16,6 @@
   text-decoration: underline;
 }
 
-/* 중앙 상단 고정 경고창 (로그 관리 화면 공통) */
-.custom-alert-center {
-  position: fixed;
-  top: 64px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: var(--z-form-alert);
-  min-width: 220px;
-  max-width: 380px;
-  border-radius: 0.95rem;
-  box-shadow: 0 3px 12px 0 rgba(0, 0, 0, 0.14);
-  font-size: 1.06rem;
-  padding: 0.7rem 2rem;
-  pointer-events: none;
-}
-
 /* ===== 관리 화면 공통 (Process/Filter/Format/Deduplication/Log Management) ===== */
 .log-page-spacer {
   margin-top: 80px;
@@ -55,20 +39,6 @@
   font-weight: 500;
 }
 
-.log-modal-backdrop-30 {
-  display: block;
-  background: rgba(0, 0, 0, 0.3);
-  z-index: 1050;
-}
-
-.log-modal-backdrop-50 {
-  background-color: rgba(0, 0, 0, 0.5);
-}
-
-.log-modal-dialog-sm {
-  max-width: 480px;
-}
-
 /* 테이블 헤더 열 너비 (Process/Filter/Format/Deduplication 공통) */
 .log-col-10 { width: 10%; }
 .log-col-15 { width: 15%; }
@@ -77,19 +47,6 @@
 .log-col-30 { width: 30%; }
 
 /* ===== 프로세스 관리 (ProcessManagement) ===== */
-.process-header-row {
-  min-height: 40px;
-}
-
-.process-status-dot {
-  color: #34a853;
-  padding-bottom: 2px;
-}
-
-.process-header-title {
-  margin-left: 7px;
-}
-
 .process-edit-row {
   background: #f6f8fa;
   border-bottom-left-radius: var(--radius-btn);

--- a/src/css/sign.css
+++ b/src/css/sign.css
@@ -79,10 +79,6 @@
   margin-top: 80px;
 }
 
-.member-mgmt-title {
-  margin-bottom: 3.5rem;
-}
-
 /* ===== 마이페이지 (MyPage) ===== */
 .mypage-root {
   background: linear-gradient(135deg, #eaf4fc 60%, #fff 100%);

--- a/src/log/components/db/LogManagement.jsx
+++ b/src/log/components/db/LogManagement.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 import { getHistories, getHistory } from '../../../api/log/historyApi';
+import AdminPageHeader from '../../../common/AdminPageHeader';
 import LogTable from './LogTable';
 
 const LogManagement = ({ onMenuClick }) => {
@@ -19,28 +21,25 @@ const LogManagement = ({ onMenuClick }) => {
     const [failFilterSortConfig, setFailFilterSortConfig] = useState({ key: 'historyId', direction: 'desc' });
     const [failDedupSortConfig, setFailDedupSortConfig] = useState({ key: 'historyId', direction: 'desc' });
 
-    // alert 상태
-    const [alert, setAlert] = useState({ show: false, message: '', type: '' });
-
     useEffect(() => {
         const load = async () => {
             try {
                 const { data } = await getHistories({ status: 'SUCCESS', size: 100 });
                 setSuccessList(data.result.content);
             } catch {
-                setAlert({ show: true, message: "성공 기록을 불러오지 못했습니다.", type: "danger" });
+                toast.error("성공 기록을 불러오지 못했습니다.");
             }
             try {
                 const { data } = await getHistories({ status: 'FAIL', stage: 'FILTER', size: 100 });
                 setFailFilterList(data.result.content);
             } catch {
-                setAlert({ show: true, message: "필터 실패 기록을 불러오지 못했습니다.", type: "danger" });
+                toast.error("필터 실패 기록을 불러오지 못했습니다.");
             }
             try {
                 const { data } = await getHistories({ status: 'FAIL', stage: 'DEDUP', size: 100 });
                 setFailDedupList(data.result.content);
             } catch {
-                setAlert({ show: true, message: "중복제거 실패 기록을 불러오지 못했습니다.", type: "danger" });
+                toast.error("중복제거 실패 기록을 불러오지 못했습니다.");
             }
         };
         load();
@@ -93,16 +92,7 @@ const LogManagement = ({ onMenuClick }) => {
 
     return (
         <div className="container log-page-padding">
-            {/* Alert 메시지 */}
-            {alert.show && (
-                <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">
-                    {alert.message}
-                    <button type="button" className="btn-close" aria-label="Close"
-                        onClick={() => setAlert({ ...alert, show: false })}></button>
-                </div>
-            )}
-
-            <h2 className="fw-bold mb-4">처리 기록</h2>
+            <AdminPageHeader title="처리 기록" />
 
             <div className="row">
                 <div className="col-12 mb-4">

--- a/src/log/components/db/LogTable.jsx
+++ b/src/log/components/db/LogTable.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { formatDate } from '../../../utils/dateUtils';
 
 const LogTable = ({
     title, data, expandedRowId, setExpandedRowId,
@@ -31,12 +32,6 @@ const LogTable = ({
             </span>
         );
     };
-
-    const formatDate = (isoString) => {
-        if (!isoString) return "-";
-        return isoString.substring(0, 16).replace("T", " ");
-    };
-
 
     const sortedList = getSortedList();
 

--- a/src/log/components/deduplication/DeduplicationManagement.jsx
+++ b/src/log/components/deduplication/DeduplicationManagement.jsx
@@ -1,18 +1,16 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
+import { Modal } from 'react-bootstrap';
 import InputDeduplication from './InputDeduplication';
 import { getDedupRules } from '../../../api/log/deduplicationApi';
+import { formatDate } from '../../../utils/dateUtils';
+import AdminPageHeader from '../../../common/AdminPageHeader';
+import AdminPipelineNav from '../../../common/AdminPipelineNav';
 import DetailDeduplication from './DetailDeduplication';
 
 const DeduplicationManagement = ({ processId, onMenuClick }) => {
   const [ddpList, setDdpList] = useState([]);
   const [showInput, setShowInput] = useState(false);
   const [showDetail, setShowDetail] = useState(0);
-  const [alert, setAlert] = useState(null);
-
-  const showAlert = useCallback(({ type, message, duration = 2000 }) => {
-    setAlert({ type, message });
-    if (duration > 0) setTimeout(() => setAlert(null), duration);
-  }, []);
 
   const getDeduplicationList = async () => {
     try {
@@ -42,13 +40,6 @@ const DeduplicationManagement = ({ processId, onMenuClick }) => {
     //   });
   };
 
-  // 날짜 포맷
-  const formatDate = (isoString) => {
-    if (!isoString) return "-";
-    return isoString.substring(0, 16).replace("T", " ");
-  };
-
-
   useEffect(() => {
     getDeduplicationList();
     // eslint-disable-next-line
@@ -56,28 +47,11 @@ const DeduplicationManagement = ({ processId, onMenuClick }) => {
 
   return (
     <div className="log-page-spacer">
-      <h2 className="fw-bold mb-4">중복 제거 관리</h2>
+      <AdminPageHeader title="중복 제거 관리">
+        <button className="btn btn-primary" onClick={() => setShowInput(true)}>중복 제거 추가</button>
+      </AdminPageHeader>
 
-      {/* 중앙 상단 고정 경고창 */}
-      {alert && (
-        <div
-          className={`alert alert-${alert.type} fw-semibold py-2 px-3 mb-0 d-inline-block text-center custom-alert-center`}
-        >
-          {alert.message}
-        </div>
-      )}
-
-
-
-      {/* 상단 버튼 영역 */}
-      <div className="d-flex justify-content-end mb-3">
-        <button className="btn btn-primary me-2" onClick={() => setShowInput(true)}>
-          중복 제거 추가
-        </button>
-        <button className="btn btn-secondary" onClick={() => onMenuClick('filter')}>
-          ⬅ 필터 관리
-        </button>
-      </div>
+      <AdminPipelineNav active="deduplication" onNavigate={onMenuClick} />
 
       <table className="table table-bordered text-center align-middle">
         <thead className="table-light">
@@ -128,7 +102,6 @@ const DeduplicationManagement = ({ processId, onMenuClick }) => {
                         processId={processId}
                         id={ddp.dedupRuleId}
                         onClose={handleDetailClose}
-                        showOutAlert={showAlert}
                       />
                     </td>
                   </tr>
@@ -139,28 +112,14 @@ const DeduplicationManagement = ({ processId, onMenuClick }) => {
         </tbody>
       </table>
 
-      {/* 추가 입력 모달 */}
-      {showInput && (
-        <div
-          className="modal show d-block log-modal-backdrop-50"
-          tabIndex="-1"
-        >
-          <div className="modal-dialog modal-lg" role="document">
-            <div className="modal-content">
-              <div className="modal-header">
-                <h5 className="modal-title">중복 제거 추가</h5>
-                <button type="button" className="btn-close" aria-label="Close"
-                  onClick={() => handleInputClose(false)}></button>
-              </div>
-              <div className="modal-body">
-                <InputDeduplication processId={processId} onClose={handleInputClose}
-                  showOutAlert={showAlert}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      <Modal show={showInput} onHide={() => handleInputClose(false)} size="lg" centered>
+        <Modal.Header closeButton>
+          <Modal.Title>중복 제거 추가</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <InputDeduplication processId={processId} onClose={handleInputClose} />
+        </Modal.Body>
+      </Modal>
     </div>
   );
 };

--- a/src/log/components/deduplication/DetailDeduplication.jsx
+++ b/src/log/components/deduplication/DetailDeduplication.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 import { getDedupRule, updateDedupRule, deleteDedupRule } from '../../../api/log/deduplicationApi';
 import DeduplicationRow from './DeduplicationRow';
 
@@ -23,7 +24,7 @@ const toApiRules = (rows) => rows.map(row => ({
     expirationTime: { days: row.days, hours: row.hours, minutes: row.minutes, seconds: row.seconds },
 }));
 
-const DetailDeduplication = ({ processId, id, onClose, showOutAlert }) => {
+const DetailDeduplication = ({ processId, id, onClose }) => {
     const [rows, setRows] = useState([]);
     const [name, setName] = useState('');
     const [active, setActive] = useState(false);
@@ -36,7 +37,7 @@ const DetailDeduplication = ({ processId, id, onClose, showOutAlert }) => {
             setName(result.name);
             setActive(result.isActive);
         } catch {
-            showOutAlert({ message: "view error", type: "danger" });
+            toast.error("중복 제거 정보를 불러오지 못했습니다.");
         }
     };
 
@@ -61,20 +62,20 @@ const DetailDeduplication = ({ processId, id, onClose, showOutAlert }) => {
     const handleSubmit = async () => {
         try {
             await updateDedupRule(id, { name, isActive: active, rules: toApiRules(rows) });
-            showOutAlert({ message: '수정되었습니다.', type: "success" });
+            toast.success('수정되었습니다.');
             setTimeout(() => onClose(true));
         } catch {
-            showOutAlert({ message: '에러 발생', type: 'danger' });
+            toast.error('에러 발생');
         }
     };
 
     const handleRemove = async () => {
         try {
             await deleteDedupRule(id);
-            showOutAlert({ message: '삭제되었습니다.', type: "danger" });
+            toast.success('삭제되었습니다.');
             setTimeout(() => onClose(true));
         } catch {
-            showOutAlert({ message: '에러 발생', type: 'danger' });
+            toast.error('에러 발생');
         }
     };
 
@@ -85,8 +86,6 @@ const DetailDeduplication = ({ processId, id, onClose, showOutAlert }) => {
 
     return (
         <div className="container mt-5">
-            {/* alert 없음 */}
-
             <h3 className="mb-4">중복 제거 설정 수정</h3>
             <div className="mb-3">
                 <label className="form-label">중복 이름</label>

--- a/src/log/components/deduplication/InputDeduplication.jsx
+++ b/src/log/components/deduplication/InputDeduplication.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState } from 'react';
+import { toast } from 'react-toastify';
 import DeduplicationRow from './DeduplicationRow';
 import { createDedupRule } from '../../../api/log/deduplicationApi';
 
@@ -15,15 +16,10 @@ const toApiRules = (rows) => rows.map(row => ({
     expirationTime: { days: row.days, hours: row.hours, minutes: row.minutes, seconds: row.seconds },
 }));
 
-const InputDeduplication = ({ processId, onClose,  showOutAlert}) => {
+const InputDeduplication = ({ processId, onClose }) => {
     const [rows, setRows] = useState([initialRow]);
     const [name, setName] = useState('');
     const [active, setActive] = useState(false);
-    const [alert, setAlert] = useState({ show: false, message: '', type: '' });
-
-    const showAlert = useCallback(({ type, message }) => {
-        setAlert({ show: true, type, message });
-    }, []);
 
     const handleChange = (index, updatedRow) => {
         const newRows = [...rows];
@@ -46,24 +42,15 @@ const InputDeduplication = ({ processId, onClose,  showOutAlert}) => {
     const handleSubmit = async () => {
         try {
             await createDedupRule(processId, { name, isActive: active, rules: toApiRules(rows) });
-            showOutAlert({ message: '중복 제거가 추가되었습니다.', type: "success" });
+            toast.success('중복 제거가 추가되었습니다.');
             onClose();
         } catch {
-            showAlert({ message: '에러 발생', type: "danger" });
+            toast.error('에러 발생');
         }
     };
 
     return (
         <div className="dedup-input-container">
-            {/* Modal 안에만 표시되는 alert */}
-            {alert.show && (
-                <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">
-                    {alert.message}
-                    <button type="button" className="btn-close" aria-label="Close"
-                        onClick={() => setAlert({ ...alert, show: false })}></button>
-                </div>
-            )}
-
             <div className="mb-3">
                 <label className="form-label fw-bold">중복 이름</label>
                 <input

--- a/src/log/components/filter/ConditionBuilder.jsx
+++ b/src/log/components/filter/ConditionBuilder.jsx
@@ -1,24 +1,17 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 import { getActiveFormatRuleFields } from '../../../api/log/formatApi';
 import { createFilterRule } from '../../../api/log/filterApi';
 
 const operatorOptions = ['>', '<', '>=', '<=', '==', '!=', 'Equals'];
 
-const ConditionBuilder = ({ onClose, processId, showOutAlert }) => {
+const ConditionBuilder = ({ onClose, processId }) => {
     const [fieldList, setFieldList] = useState([]);
     const [name, setName] = useState('');
     const [active, setActive] = useState(false);
     const [tokens, setTokens] = useState([
         { type: 'condition', field: '', operator: '>', value: '', groupId: 0 }
     ]);
-
-    // alert 상태
-    const [alert, setAlert] = useState(null);
-
-    const showAlert = useCallback(({ type, message }) => {
-        setAlert({ type, message });
-    }, []);
-
 
     useEffect(() => {
         const load = async () => {
@@ -119,7 +112,7 @@ const ConditionBuilder = ({ onClose, processId, showOutAlert }) => {
 
     const handleSubmit = async (e) => {
         if (!validateParentheses()) {
-            showAlert({ message: "❌ 괄호 짝이 맞지 않습니다.", type: 'danger' });
+            toast.error("❌ 괄호 짝이 맞지 않습니다.");
             return;
         }
 
@@ -128,7 +121,7 @@ const ConditionBuilder = ({ onClose, processId, showOutAlert }) => {
             (token.field === '' || token.operator === '' || token.value === '')
         );
         if (hasInvalid) {
-            showAlert({ message: '❌ 조건에 빈 값이 있습니다. 모든 필드, 연산자, 값을 입력해주세요.', type: 'danger' });
+            toast.error('❌ 조건에 빈 값이 있습니다. 모든 필드, 연산자, 값을 입력해주세요.');
             return;
         }
 
@@ -136,23 +129,15 @@ const ConditionBuilder = ({ onClose, processId, showOutAlert }) => {
 
         try {
             await createFilterRule(processId, { name, conditions, isActive: active });
-            showOutAlert({ message: '필터 추가 성공', type: 'success' });
+            toast.success('필터 추가 성공');
             onClose();
         } catch {
-            showAlert({ message: '에러가 발생했습니다.', type: 'danger' });
+            toast.error('에러가 발생했습니다.');
         }
     };
 
     return (
         <div className="container mt-4 text-center log-condition-container">
-            {/* Alert 메시지 */}
-            {alert && (
-                <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">
-                    {alert.message}
-
-                </div>
-            )}
-
             <h5>필터 추가</h5>
             <div className="mb-3">
                 <label className="form-label">필터 이름</label>

--- a/src/log/components/filter/DetailFilter.jsx
+++ b/src/log/components/filter/DetailFilter.jsx
@@ -1,20 +1,16 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 import { getFilterRule, updateFilterRule, deleteFilterRule } from '../../../api/log/filterApi';
 import { getActiveFormatRuleFields } from '../../../api/log/formatApi';
 import { toApiConditions } from './ConditionBuilder';
 
 const operatorOptions = ['>', '<', '>=', '<=', '==', '!=', 'Equals'];
 
-const DetailFilter = ({ onClose, processId, filterId, showOutAlert }) => {
+const DetailFilter = ({ onClose, processId, filterId }) => {
     const [fieldList, setFieldList] = useState([]);
     const [name, setName] = useState('');
     const [active, setActive] = useState(false);
     const [tokens, setTokens] = useState([]);
-    const [alert, setAlert] = useState(null);
-
-    const showAlert = useCallback(({ type, message }) => {
-        setAlert({ type, message });
-    }, []);
 
     const viewFilter = async () => {
         try {
@@ -24,7 +20,7 @@ const DetailFilter = ({ onClose, processId, filterId, showOutAlert }) => {
             setName(result.name);
             setActive(result.isActive);
         } catch {
-            showAlert({ message: '필터 정보를 불러오지 못했습니다.', type: 'danger' });
+            toast.error('필터 정보를 불러오지 못했습니다.');
         }
     };
 
@@ -40,10 +36,10 @@ const DetailFilter = ({ onClose, processId, filterId, showOutAlert }) => {
     const removeFilter = async () => {
         try {
             await deleteFilterRule(filterId);
-            showOutAlert({ message: '필터가 삭제되었습니다.', type: 'danger' });
+            toast.success('필터가 삭제되었습니다.');
             onClose();
         } catch {
-            showAlert({ message: '필터 삭제에 실패했습니다.', type: 'danger' });
+            toast.error('필터 삭제에 실패했습니다.');
         }
     };
 
@@ -140,7 +136,7 @@ const DetailFilter = ({ onClose, processId, filterId, showOutAlert }) => {
     const handleSubmit = async (e) => {
 
         if (!validateParentheses()) {
-            showAlert({ message: '❌ 괄호 짝이 맞지 않습니다.', type: 'danger' });
+            toast.error('❌ 괄호 짝이 맞지 않습니다.');
             return;
         }
 
@@ -149,29 +145,22 @@ const DetailFilter = ({ onClose, processId, filterId, showOutAlert }) => {
             (token.field === '' || token.operator === '' || token.value === '')
         );
         if (hasInvalid) {
-            showAlert({ message: '❌ 조건에 빈 값이 있습니다. 모든 필드, 연산자, 값을 입력해주세요.', type: 'danger' });
+            toast.error('❌ 조건에 빈 값이 있습니다. 모든 필드, 연산자, 값을 입력해주세요.');
             return;
         }
         const conditions = toApiConditions(tokens);
 
         try {
             await updateFilterRule(filterId, { name, conditions, isActive: active });
-            showOutAlert({ message: '저장되었습니다.', type: 'success' });
+            toast.success('저장되었습니다.');
             onClose();
         } catch {
-            showAlert({ message: '에러가 발생했습니다.', type: 'danger' });
+            toast.error('에러가 발생했습니다.');
         }
     };
 
     return (
         <div className="container mt-5 log-filter-detail-container">
-            {/* Alert 메시지 */}
-            {alert && (
-                <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">
-                    {alert.message}
-                </div>
-            )}
-
             <div className="mb-2">
                 <h4 className="fw-bold text-primary">필터 수정</h4>
                 <hr />

--- a/src/log/components/filter/FilterManagement.jsx
+++ b/src/log/components/filter/FilterManagement.jsx
@@ -1,5 +1,9 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
+import { Modal } from 'react-bootstrap';
 import { getFilterRules } from '../../../api/log/filterApi';
+import { formatDate } from '../../../utils/dateUtils';
+import AdminPageHeader from '../../../common/AdminPageHeader';
+import AdminPipelineNav from '../../../common/AdminPipelineNav';
 import DetailFilter from './DetailFilter';
 import ConditionBuilder from './ConditionBuilder';
 
@@ -7,13 +11,6 @@ const FilterManagement = ({ processId, onMenuClick }) => {
     const [filterList, setFilterList] = useState([]);
     const [detailComp, setDetailComp] = useState(0);
     const [builderComp, setBuilderComp] = useState(false);
-    const [alert, setAlert] = useState(null);
-
-    // 자동 사라지는 경고창
-    const showAlert = useCallback(({ type, message, duration = 1800 }) => {
-        setAlert({ type, message });
-        if (duration > 0) setTimeout(() => setAlert(null), duration);
-    }, []);
 
     const getFilters = async () => {
         try {
@@ -26,40 +23,13 @@ const FilterManagement = ({ processId, onMenuClick }) => {
 
     useEffect(() => { getFilters(); }, [processId, builderComp, detailComp]);
 
-    // 모달 스크롤 방지
-    useEffect(() => {
-        if (builderComp) document.body.style.overflow = 'hidden';
-        else document.body.style.overflow = '';
-        return () => { document.body.style.overflow = ''; };
-    }, [builderComp]);
-
-    const filterDate = (isoString) => {
-        if (!isoString) return "-";
-        return isoString.substring(0, 16).replace("T", " ");
-    };
-
     return (
         <div className="log-page-spacer">
-            {/* 화면 중앙 위 고정 알림 */}
-            {alert && (
-                <div className={`alert alert-${alert.type} fw-semibold mb-0 text-center custom-alert-center`}>
-                    {alert.message}
-                </div>
-            )}
+            <AdminPageHeader title="필터링 관리">
+                <button className="btn btn-primary" onClick={() => setBuilderComp(true)}>필터 추가</button>
+            </AdminPageHeader>
 
-            <h2 className="fw-bold mb-4">필터링 관리</h2>
-
-            <div className="d-flex justify-content-end mb-3">
-                <button className="btn btn-primary me-2" onClick={() => setBuilderComp(true)}>
-                    필터 추가
-                </button>
-                <button className="btn btn-secondary me-2" onClick={() => onMenuClick('format')}>
-                    ⬅ 포맷 관리
-                </button>
-                <button className="btn btn-secondary" onClick={() => onMenuClick('deduplication')}>
-                    중복제거 관리 ➡
-                </button>
-            </div>
+            <AdminPipelineNav active="filter" onNavigate={onMenuClick} />
 
             <div className="card shadow-sm rounded-4 mb-4 log-card-noborder">
                 <table className="table table-bordered text-center align-middle mb-0">
@@ -91,8 +61,8 @@ const FilterManagement = ({ processId, onMenuClick }) => {
                                             {filter.name}
                                         </span>
                                     </td>
-                                    <td>{filterDate(filter.createdAt)}</td>
-                                    <td>{filterDate(filter.updatedAt)}</td>
+                                    <td>{formatDate(filter.createdAt)}</td>
+                                    <td>{formatDate(filter.updatedAt)}</td>
                                     <td>
                                         <button
                                             className={`btn btn-sm ${filter.isActive ? 'btn-success' : 'btn-outline-success'}`}
@@ -108,7 +78,6 @@ const FilterManagement = ({ processId, onMenuClick }) => {
                                                 onClose={() => setDetailComp(0)}
                                                 filterId={filter.filterRuleId}
                                                 processId={processId}
-                                                showOutAlert={showAlert}
                                             />
                                         </td>
                                     </tr>
@@ -119,26 +88,14 @@ const FilterManagement = ({ processId, onMenuClick }) => {
                 </table>
             </div>
 
-            {builderComp && (
-                <div className="modal show d-block log-modal-backdrop-50" tabIndex="-1">
-                    <div className="modal-dialog modal-lg" role="document">
-                        <div className="modal-content rounded-4">
-                            <div className="modal-header">
-                                <h5 className="modal-title">필터 추가</h5>
-                                <button type="button" className="btn-close" aria-label="Close"
-                                    onClick={() => setBuilderComp(false)}></button>
-                            </div>
-                            <div className="modal-body">
-                                <ConditionBuilder
-                                    onClose={() => setBuilderComp(false)}
-                                    processId={processId}
-                                    showOutAlert={showAlert}
-                                />
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            )}
+            <Modal show={builderComp} onHide={() => setBuilderComp(false)} size="lg" centered>
+                <Modal.Header closeButton>
+                    <Modal.Title>필터 추가</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <ConditionBuilder onClose={() => setBuilderComp(false)} processId={processId} />
+                </Modal.Body>
+            </Modal>
         </div>
     );
 };

--- a/src/log/components/format/DetailFormat.jsx
+++ b/src/log/components/format/DetailFormat.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 import { getFormatRule, updateFormatRule, deleteFormatRule } from '../../../api/log/formatApi';
 
 const
-    DetailFormat = ({ onClose, formatId, showAlert }) => {
+    DetailFormat = ({ onClose, formatId }) => {
         const [defaultEntry, setDefaultEntry] = useState([{ key: '', value: '' }]);
         const [formatEntry, setFormatEntry] = useState([{ key: '', value: '' }]);
         const [name, setName] = useState('');
@@ -33,7 +34,7 @@ const
                 setName(result.name);
                 setActive(result.isActive);
             } catch {
-                showAlert("danger", "포맷 정보를 불러오지 못했습니다.");
+                toast.error("포맷 정보를 불러오지 못했습니다.");
             }
         };
 
@@ -41,10 +42,10 @@ const
         const removeFormat = async () => {
             try {
                 await deleteFormatRule(formatId);
-                showAlert("danger", "포맷 삭제 성공!");
+                toast.success("포맷 삭제 성공!");
                 onClose();
             } catch {
-                showAlert("danger", "포맷 삭제 실패");
+                toast.error("포맷 삭제 실패");
             }
         };
 
@@ -64,10 +65,10 @@ const
 
             try {
                 await updateFormatRule(formatId, { name, isActive: active, defaultValues, fieldMappings });
-                showAlert("success", "포맷 수정 성공!");
+                toast.success("포맷 수정 성공!");
                 onClose();
             } catch {
-                showAlert("danger", "포맷 수정 실패");
+                toast.error("포맷 수정 실패");
             }
         };
 

--- a/src/log/components/format/FormatManagement.jsx
+++ b/src/log/components/format/FormatManagement.jsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useState, useCallback } from 'react';
+import { Modal } from 'react-bootstrap';
 import { getFormatRules } from '../../../api/log/formatApi';
+import { formatDate } from '../../../utils/dateUtils';
+import AdminPageHeader from '../../../common/AdminPageHeader';
+import AdminPipelineNav from '../../../common/AdminPipelineNav';
 import InputFormat from './InputFormat';
 import DetailFormat from './DetailFormat';
 
@@ -7,13 +11,6 @@ const FormatManagement = ({ processId, onMenuClick }) => {
     const [formatList, setFormatList] = useState([]);
     const [inputComp, setInputComp] = useState(false);
     const [detailComp, setDetailComp] = useState(0);
-    const [alert, setAlert] = useState(null);
-
-    // 경고창 자동 사라짐
-    const showAlert = useCallback((type, message, duration = 1800) => {
-        setAlert({ type, message });
-        if (duration > 0) setTimeout(() => setAlert(null), duration);
-    }, []);
 
     const getFormats = useCallback(async () => {
         try {
@@ -26,28 +23,13 @@ const FormatManagement = ({ processId, onMenuClick }) => {
 
     useEffect(() => { getFormats(); }, [inputComp, detailComp, getFormats]);
 
-    const formatDate = (isoString) => {
-        if (!isoString) return "-";
-        return isoString.substring(0, 16).replace("T", " ");
-    };
-
     return (
         <div className="log-page-spacer">
-            <h2 className="fw-bold mb-4">포맷 관리</h2>
+            <AdminPageHeader title="포맷 관리">
+                <button className="btn btn-primary" onClick={() => setInputComp(true)}>포맷 추가</button>
+            </AdminPageHeader>
 
-            {/* 중앙 상단 고정 경고창 */}
-            {alert && (
-                <div
-                    className={`alert alert-${alert.type} fw-semibold py-2 px-3 mb-0 d-inline-block text-center custom-alert-center`}
-                >
-                    {alert.message}
-                </div>
-            )}
-
-            <div className="d-flex justify-content-end mb-3">
-                <button className="btn btn-primary me-2" onClick={() => setInputComp(true)}>포맷 추가</button>
-                <button className="btn btn-secondary" onClick={() => onMenuClick('filter')}>필터링 관리 ➡</button>
-            </div>
+            <AdminPipelineNav active="format" onNavigate={onMenuClick} />
 
             <div className="card shadow-sm rounded-4 mb-4 log-card-noborder">
                 <table className="table table-bordered text-center align-middle mb-0">
@@ -93,7 +75,6 @@ const FormatManagement = ({ processId, onMenuClick }) => {
                                             <DetailFormat
                                                 onClose={() => setDetailComp(0)}
                                                 formatId={format.formatRuleId}
-                                                showAlert={showAlert}
                                             />
                                         </td>
                                     </tr>
@@ -104,13 +85,14 @@ const FormatManagement = ({ processId, onMenuClick }) => {
                 </table>
             </div>
 
-            {inputComp && (
-                <InputFormat
-                    onClose={() => setInputComp(false)}
-                    processId={processId}
-                    showAlert={showAlert}
-                />
-            )}
+            <Modal show={inputComp} onHide={() => setInputComp(false)} size="lg" centered>
+                <Modal.Header closeButton>
+                    <Modal.Title>포맷 추가</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <InputFormat onClose={() => setInputComp(false)} processId={processId} />
+                </Modal.Body>
+            </Modal>
         </div>
     );
 };

--- a/src/log/components/format/InputFormat.jsx
+++ b/src/log/components/format/InputFormat.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
+import { toast } from 'react-toastify';
 import { createFormatRule } from '../../../api/log/formatApi';
 
-const InputFormat = ({ onClose, processId, showAlert }) => {
+const InputFormat = ({ onClose, processId }) => {
     const [defaultEntry, setDefaultEntry] = useState([{ key: '', value: '' }]);
     const [formatEntry, setFormatEntry] = useState([{ key: '', value: '' }]);
     const [name, setName] = useState('');
@@ -37,85 +38,67 @@ const InputFormat = ({ onClose, processId, showAlert }) => {
 
         try {
             await createFormatRule(processId, { name, isActive: active, defaultValues, fieldMappings });
-            showAlert("success", "포맷 추가 성공!");
+            toast.success("포맷 추가 성공!");
             onClose();
         } catch {
-            showAlert("danger", "포맷 추가 실패!");
+            toast.error("포맷 추가 실패!");
         }
     };
 
     return (
-        <div className="modal show d-block log-modal-backdrop-50" tabIndex="-1">
-            <div className="modal-dialog modal-lg">
-                <div className="modal-content">
-                    <div className="modal-header">
-                        <h5 className="modal-title">포맷 추가 화면</h5>
-                        <button type="button" className="btn-close" onClick={onClose}></button>
-                    </div>
-                    <div className="modal-body">
-                        {showAlert && (
-                            <div className={`alert alert-${showAlert.type}`} role="alert">
-                                {showAlert.text}
-                            </div>
-                        )}
-                        <form onSubmit={handleSubmit}>
-                            <div className="mb-3 d-flex flex-column align-items-center">
-                                <label className="form-label w-100 text-center">포맷 이름</label>
-                                <input
-                                    type="text"
-                                    className="form-control log-format-input-name-input"
-                                    value={name}
-                                    onChange={e => setName(e.target.value)}
-                                />
-                            </div>
-
-                            <h5>기본 정보</h5>
-                            {defaultEntry.map((entry, index) => (
-                                <div key={`default-${index}`} className="d-flex mb-2">
-                                    <input type="text" className="form-control me-2" placeholder="Key"
-                                        value={entry.key}
-                                        onChange={e => handleEntryChange(setDefaultEntry, defaultEntry, index, 'key', e.target.value)} />
-                                    <input type="text" className="form-control me-2" placeholder="Value"
-                                        value={entry.value}
-                                        onChange={e => handleEntryChange(setDefaultEntry, defaultEntry, index, 'value', e.target.value)} />
-                                    <button type="button" className="btn btn-danger btn-sm"
-                                        onClick={() => removeEntry(setDefaultEntry, defaultEntry, index)}>✕</button>
-                                </div>
-                            ))}
-                            <button type="button" className="btn btn-success btn-sm mb-3"
-                                onClick={() => addEntry(setDefaultEntry, defaultEntry)}>+ 추가</button>
-
-                            <h5>포맷 정보</h5>
-                            {formatEntry.map((entry, index) => (
-                                <div key={`format-${index}`} className="d-flex mb-2">
-                                    <input type="text" className="form-control me-2" placeholder="Key"
-                                        value={entry.key}
-                                        onChange={e => handleEntryChange(setFormatEntry, formatEntry, index, 'key', e.target.value)} />
-                                    ⬅
-                                    <input type="text" className="form-control me-2" placeholder="Value"
-                                        value={entry.value}
-                                        onChange={e => handleEntryChange(setFormatEntry, formatEntry, index, 'value', e.target.value)} />
-                                    <button type="button" className="btn btn-danger btn-sm"
-                                        onClick={() => removeEntry(setFormatEntry, formatEntry, index)}>✕</button>
-                                </div>
-                            ))}
-                            <button type="button" className="btn btn-success btn-sm mb-3"
-                                onClick={() => addEntry(setFormatEntry, formatEntry)}>+ 추가</button>
-
-                            <div className="d-flex justify-content-between mt-4">
-                                <button type="button" className="btn btn-danger" onClick={onClose}>닫기</button>
-                                <button type="submit" className="btn btn-primary">추가 </button>
-                                <button type="button" className={`btn ${active ? 'btn-success' : 'btn-outline-success'}`}
-                                    onClick={() => setActive(prev => !prev)}>
-                                    활성화: {active ? "On" : "Off"}
-                                </button>
-
-                            </div>
-                        </form>
-                    </div>
-                </div>
+        <form onSubmit={handleSubmit}>
+            <div className="mb-3 d-flex flex-column align-items-center">
+                <label className="form-label w-100 text-center">포맷 이름</label>
+                <input
+                    type="text"
+                    className="form-control log-format-input-name-input"
+                    value={name}
+                    onChange={e => setName(e.target.value)}
+                />
             </div>
-        </div>
+
+            <h5>기본 정보</h5>
+            {defaultEntry.map((entry, index) => (
+                <div key={`default-${index}`} className="d-flex mb-2">
+                    <input type="text" className="form-control me-2" placeholder="Key"
+                        value={entry.key}
+                        onChange={e => handleEntryChange(setDefaultEntry, defaultEntry, index, 'key', e.target.value)} />
+                    <input type="text" className="form-control me-2" placeholder="Value"
+                        value={entry.value}
+                        onChange={e => handleEntryChange(setDefaultEntry, defaultEntry, index, 'value', e.target.value)} />
+                    <button type="button" className="btn btn-danger btn-sm"
+                        onClick={() => removeEntry(setDefaultEntry, defaultEntry, index)}>✕</button>
+                </div>
+            ))}
+            <button type="button" className="btn btn-success btn-sm mb-3"
+                onClick={() => addEntry(setDefaultEntry, defaultEntry)}>+ 추가</button>
+
+            <h5>포맷 정보</h5>
+            {formatEntry.map((entry, index) => (
+                <div key={`format-${index}`} className="d-flex mb-2">
+                    <input type="text" className="form-control me-2" placeholder="Key"
+                        value={entry.key}
+                        onChange={e => handleEntryChange(setFormatEntry, formatEntry, index, 'key', e.target.value)} />
+                    ⬅
+                    <input type="text" className="form-control me-2" placeholder="Value"
+                        value={entry.value}
+                        onChange={e => handleEntryChange(setFormatEntry, formatEntry, index, 'value', e.target.value)} />
+                    <button type="button" className="btn btn-danger btn-sm"
+                        onClick={() => removeEntry(setFormatEntry, formatEntry, index)}>✕</button>
+                </div>
+            ))}
+            <button type="button" className="btn btn-success btn-sm mb-3"
+                onClick={() => addEntry(setFormatEntry, formatEntry)}>+ 추가</button>
+
+            <div className="d-flex justify-content-between mt-4">
+                <button type="button" className="btn btn-danger" onClick={onClose}>닫기</button>
+                <button type="submit" className="btn btn-primary">추가 </button>
+                <button type="button" className={`btn ${active ? 'btn-success' : 'btn-outline-success'}`}
+                    onClick={() => setActive(prev => !prev)}>
+                    활성화: {active ? "On" : "Off"}
+                </button>
+            </div>
+        </form>
     );
 };
 

--- a/src/log/components/process/EditProcess.jsx
+++ b/src/log/components/process/EditProcess.jsx
@@ -1,38 +1,33 @@
 import React, { useState } from 'react';
+import { toast } from 'react-toastify';
 import { updateLogProcess, deleteLogProcess } from '../../../api/log/logProcessApi';
 
-const EditProcess = ({ onClose, processId, _name, showAlert }) => {
+const EditProcess = ({ onClose, processId, _name }) => {
     const [name, setName] = useState(_name);
-    // ✅ 추가
 
     const updateProcess = async () => {
         try {
             await updateLogProcess(processId, { name });
-            showAlert("success", "수정 성공!");
+            toast.success("수정 성공!");
             onClose();
         } catch {
-            showAlert("danger", "프로세스 수정 실패!");
+            toast.error("프로세스 수정 실패!");
         }
     };
 
     const removeProcess = async () => {
         try {
             await deleteLogProcess(processId);
-            showAlert("danger", "삭제 성공!");
+            toast.success("삭제 성공!");
             onClose();
         } catch {
-            showAlert("danger", "삭제 실패!");
+            toast.error("삭제 실패!");
         }
     };
 
     return (
-
         <div className="card mt-4 p-4 mx-auto log-process-card">
             <h4 className="mb-3">Process 수정</h4>
-
-
-
-
             <input
                 type='text'
                 className="form-control mb-3"

--- a/src/log/components/process/InputProcess.jsx
+++ b/src/log/components/process/InputProcess.jsx
@@ -1,25 +1,23 @@
 import React, { useState } from 'react';
+import { toast } from 'react-toastify';
 import { createLogProcess } from '../../../api/log/logProcessApi';
 
-const InputProcess = ({ onClose, showAlert }) => {
+const InputProcess = ({ onClose }) => {
     const [name, setName] = useState("");
 
     const addProcess = async () => {
         try {
             await createLogProcess({ name });
-            showAlert("success", "프로세스가 추가되었습니다!");
+            toast.success("프로세스가 추가되었습니다!");
             onClose();
         } catch {
-            showAlert("danger", "프로세스 추가 실패");
+            toast.error("프로세스 추가 실패");
         }
     };
 
     return (
-        <div className="card mt-4 p-4 mx-auto log-process-card">
+        <div>
             <h4 className="mb-3">프로세스 이름</h4>
-
-
-
             <input
                 type='text'
                 className="form-control mb-3"

--- a/src/log/components/process/ProcessManagement.jsx
+++ b/src/log/components/process/ProcessManagement.jsx
@@ -1,5 +1,8 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
+import { Modal } from 'react-bootstrap';
 import { getLogProcesses } from '../../../api/log/logProcessApi';
+import { formatDate } from '../../../utils/dateUtils';
+import AdminPageHeader from '../../../common/AdminPageHeader';
 import InputProcess from './InputProcess';
 import EditProcess from './EditProcess';
 
@@ -8,13 +11,6 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
     const [showModal, setShowModal] = useState(false);
     const [selectedProcessId, setSelectedProcessId] = useState(null);
     const [editComp, setEditComp] = useState(0);
-    const [alert, setAlert] = useState(null);
-
-    // 공통 경고창 함수 (자동 사라짐)
-    const showAlert = useCallback((type, message, duration = 1800) => {
-        setAlert({ type, message });
-        if (duration > 0) setTimeout(() => setAlert(null), duration);
-    }, []);
 
     const getProcesses = async () => {
         try {
@@ -29,45 +25,19 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
         getProcesses();
     }, [showModal, editComp]);
 
-    // 모달 body 스크롤 방지
-    useEffect(() => {
-        if (showModal) document.body.style.overflow = 'hidden';
-        else document.body.style.overflow = '';
-        return () => { document.body.style.overflow = ''; };
-    }, [showModal]);
-
     const handleCloseModal = () => {
         setShowModal(false);
         setSelectedProcessId(null);
     };
     const handleEditComp = () => setEditComp(0);
 
-    const processDate = (isoString) => {
-        if (!isoString) return "-";
-        return isoString.substring(0, 16).replace("T", " ");
-    };
-
     return (
         <div className="log-page-spacer">
-            <div className="d-flex align-items-center mb-4 process-header-row">
-                <h2 className="fw-bold process-status-dot">●</h2>
-                <h2 className="fw-bold process-header-title">프로세스 관리</h2>
-            </div>
-            <div className="d-flex justify-content-end  mb-3">
-                <button
-                    className="btn btn-success shadow-sm log-btn-rounded"
-                    onClick={() => setShowModal(true)}
-                >
+            <AdminPageHeader title="프로세스 관리">
+                <button className="btn btn-success shadow-sm log-btn-rounded" onClick={() => setShowModal(true)}>
                     + 프로세스 추가
                 </button>
-            </div>
-
-            {/* 중앙 상단 고정 경고창 */}
-            {alert && (
-                <div className={`alert alert-${alert.type} fw-semibold py-2 px-3 mb-0 d-inline-block text-center custom-alert-center`}>
-                    {alert.message}
-                </div>
-            )}
+            </AdminPageHeader>
 
             <div className="card shadow-sm rounded-4 mb-4 log-card-noborder">
                 <table className="table table-hover table-bordered align-middle text-center mb-0">
@@ -103,8 +73,8 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
                                             {process.name}
                                         </span>
                                     </td>
-                                    <td>{process.createdAt && processDate(process.createdAt)}</td>
-                                    <td>{process.updatedAt && processDate(process.updatedAt)}</td>
+                                    <td>{process.createdAt && formatDate(process.createdAt)}</td>
+                                    <td>{process.updatedAt && formatDate(process.updatedAt)}</td>
                                     <td>
                                         <button
                                             className="btn btn-outline-primary btn-sm px-3 log-btn-rounded-sm"
@@ -121,7 +91,6 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
                                                 onClose={handleEditComp}
                                                 processId={process.logProcessId}
                                                 _name={process.name}
-                                                showAlert={showAlert}
                                             />
                                         </td>
                                     </tr>
@@ -132,34 +101,14 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
                 </table>
             </div>
 
-
-            {/* 모달 구조 */}
-            {showModal && (
-                <div
-                    className="modal fade show log-modal-backdrop-30"
-                    tabIndex="-1"
-                    onClick={handleCloseModal}
-                >
-                    <div
-                        className="modal-dialog modal-dialog-centered log-modal-dialog-sm"
-                        onClick={e => e.stopPropagation()}
-                    >
-                        <div className="modal-content rounded-4" >
-                            <div className="modal-header" >
-                                <h5 className="modal-title fw-bold">프로세스 추가</h5>
-                                <button type="button" className="btn-close" onClick={handleCloseModal}></button>
-                            </div>
-                            <div className="modal-body">
-                                <InputProcess
-                                    onClose={handleCloseModal}
-                                    processId={selectedProcessId}
-                                    showAlert={showAlert}
-                                />
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            )}
+            <Modal show={showModal} onHide={handleCloseModal} centered>
+                <Modal.Header closeButton>
+                    <Modal.Title className="fw-bold">프로세스 추가</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <InputProcess onClose={handleCloseModal} processId={selectedProcessId} />
+                </Modal.Body>
+            </Modal>
         </div>
     );
 };

--- a/src/sign/component/MemberManagement.jsx
+++ b/src/sign/component/MemberManagement.jsx
@@ -1,28 +1,28 @@
 import React, { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 import { getAdminMembers, updateMemberRole } from '../../api/memberApi';
 import { FaTrash, FaUserShield } from 'react-icons/fa';
+import AdminPageHeader from '../../common/AdminPageHeader';
 
 const MemberManagement = () => {
     const [memberList, setMemberList] = useState([]);
-    const [alert, setAlert] = useState({ show: false, message: '', type: '' }); // alert 상태 추가
 
     const getMemberList = async () => {
         try {
             const { data } = await getAdminMembers();
             setMemberList(data.result.content);
         } catch {
-            setAlert({ show: true, message: "회원 조회 오류", type: "danger" });
+            toast.error("회원 조회 오류");
         }
     };
 
     const delegateAdmin = async ({ memberId }) => {
         try {
             await updateMemberRole(memberId);
-            setAlert({ show: true, message: "관리자 권한이 부여되었습니다.", type: "success" });
+            toast.success("관리자 권한이 부여되었습니다.");
             getMemberList();
         } catch (error) {
-            const msg = error.response?.data || "오류가 발생했습니다.";
-            setAlert({ show: true, message: msg, type: "danger" });
+            toast.error(error.response?.data || "오류가 발생했습니다.");
         }
     };
     useEffect(() => {
@@ -31,16 +31,7 @@ const MemberManagement = () => {
 
     return (
         <div className="container sign-page-spacer">
-            {/* Alert 메시지 */}
-            {alert.show && (
-                <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">
-                    {alert.message}
-                    <button type="button" className="btn-close" aria-label="Close"
-                        onClick={() => setAlert({ ...alert, show: false })}></button>
-                </div>
-            )}
-
-            <h2 className="fw-bold member-mgmt-title">회원 관리</h2>
+            <AdminPageHeader title="회원 관리" />
             <div className="table-responsive">
                 <table className="table table-hover align-middle">
                     <thead className="table-light">


### PR DESCRIPTION
## 관련 이슈
closes #62

## 변경 사항
- 알림을 `react-toastify`로 통일 (화면별 `showAlert`/`showOutAlert` 자체 구현 3종 제거)
- 날짜 포맷을 `utils/dateUtils.js`의 공용 `formatDate`로 통일 (화면별 복붙 정의 제거)
- 손수 만든 `.modal show d-block` 추가 모달(`ConditionBuilder`/`InputDeduplication`/`InputProcess`)을 react-bootstrap `Modal`로 전환, 수동 `body.style.overflow` 제어 제거
- `AdminPageHeader`(타이틀+액션 슬롯), `AdminPipelineNav`(포맷→필터→중복제거 탭 UI) 공통 컴포넌트 신설, 이모지 이동 버튼(⬅➡) 제거
- `AdmnMenu` 활성 메뉴 하이라이트 추가, 관리자 헤더/파이프라인 탭에 브랜드 그라디언트 토큰 적용
- 상세 조회는 기존 인라인 행 확장 패턴 그대로 유지

## 작업 방법
- 알림/날짜는 prop으로 내려주던 `showAlert`/`showOutAlert`/`formatDate`를 각 컴포넌트에서 직접 import하는 방식으로 단순화 (prop drilling 제거)
- Modal 전환 대상 3곳은 부모(Management) 컴포넌트가 `<Modal>`을 소유하고, 자식(Input) 컴포넌트는 폼 콘텐츠만 렌더링하도록 통일
- 사용하지 않게 된 CSS 클래스(`custom-alert-center`, `log-modal-backdrop-30/50`, `log-modal-dialog-sm`, `member-mgmt-title`, `process-header-row/status-dot/title`) 제거

## 테스트
관리자 계정으로 로그인 후 각 화면 CRUD/토글/이동을 실제 브라우저(Playwright)로 확인:
- [x] 여행지 관리: 목록 조회, 헤더 적용
- [x] 회원 관리: 목록 조회, 관리자 위임 토스트
- [x] 프로세스 관리: 추가/수정/삭제 + 성공/실패 토스트, 포맷 화면으로 이동
- [x] 포맷 관리: 목록, 추가 모달(Modal 전환), 파이프라인 탭 이동
- [x] 필터 관리: 목록, 추가 모달(Modal 전환), 파이프라인 탭 이동
- [x] 중복제거 관리: 목록, 추가 모달(Modal 전환), 파이프라인 탭 이동
- [x] 로그 관리(처리 기록): 성공/필터실패/중복제거실패 테이블 조회
- [x] 사이드바 활성 메뉴 하이라이트 (포맷/필터/중복제거 화면에서는 '프로세스 관리'로 하이라이트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
