### PR TITLE
♻️ Refactor: 성별 값 영문 코드화(MALE/FEMALE) 및 genderLabels 라벨 매핑 도입

### DIFF
--- a/src/common/MyPage.jsx
+++ b/src/common/MyPage.jsx
@@ -2,6 +2,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { getMyProfile, deleteMyProfile } from '../api/memberApi';
 import { useEffect, useState } from 'react';
 import { formatDate } from '../utils/dateUtils';
+import { genderLabels } from '../constants/colorMaps';
 import { toast } from 'react-toastify';
 
 const myPageImage = "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png";
@@ -111,7 +112,7 @@ const MyPage = () => {
                     <div className="d-flex align-items-center bg-light rounded-3 px-3 py-2 shadow-sm mb-2">
                       <i className="bi bi-gender-ambiguous text-info me-2" />
                       <span className="text-secondary small fw-semibold me-2">성별</span>
-                      <span className="ms-auto fw-bold">{member.gender || '-'}</span>
+                      <span className="ms-auto fw-bold">{genderLabels[member.gender] || member.gender || '-'}</span>
                     </div>
                   </div>
                   <div className="col-6 col-sm-3">

--- a/src/constants/colorMaps.js
+++ b/src/constants/colorMaps.js
@@ -21,3 +21,9 @@ export const regionColors = {
   인천: "dark",
   전남: "secondary",
 };
+
+export const genderLabels = {
+  MALE: "남",
+  FEMALE: "여",
+  NONE: "선택 안함",
+};

--- a/src/sign/component/MemberManagement.jsx
+++ b/src/sign/component/MemberManagement.jsx
@@ -3,6 +3,7 @@ import { toast } from 'react-toastify';
 import { getAdminMembers, updateMemberRole } from '../../api/memberApi';
 import { FaTrash, FaUserShield } from 'react-icons/fa';
 import AdminPageHeader from '../../common/AdminPageHeader';
+import { genderLabels } from '../../constants/colorMaps';
 
 const MemberManagement = () => {
     const [memberList, setMemberList] = useState([]);
@@ -62,7 +63,7 @@ const MemberManagement = () => {
                                     <td>{member.loginId}</td>
                                     <td>{member.nickname}</td>
                                     <td>{member.email}</td>
-                                    <td>{member.gender}</td>
+                                    <td>{genderLabels[member.gender] || member.gender}</td>
                                     <td>-</td>
                                     <td>{member.roles?.includes("ROLE_ADMIN") ? "관리자" : "회원"}</td>
                                     <td className='text-center'>

--- a/src/sign/component/SignUpPage.jsx
+++ b/src/sign/component/SignUpPage.jsx
@@ -142,8 +142,8 @@ const SignUpPage = () => {
                                         type="radio"
                                         name="gender"
                                         id="genderMale"
-                                        value="남"
-                                        checked={formData.gender === '남'}
+                                        value="MALE"
+                                        checked={formData.gender === 'MALE'}
                                         onChange={handleChange}
                                         required
                                     />
@@ -154,8 +154,8 @@ const SignUpPage = () => {
                                         type="radio"
                                         name="gender"
                                         id="genderFemale"
-                                        value="여"
-                                        checked={formData.gender === '여'}
+                                        value="FEMALE"
+                                        checked={formData.gender === 'FEMALE'}
                                         onChange={handleChange}
                                         required
                                     />


### PR DESCRIPTION
## 관련 이슈
#62 후속 정리 (PR #63 머지 이후 추가 커밋)

## 변경 사항
- `constants/colorMaps.js`에 `genderLabels` 매핑 추가 (MALE/FEMALE/NONE → 남/여/선택 안함)
- 회원가입 성별 라디오 value를 영문 코드(MALE/FEMALE)로 변경
- 회원 관리 / 마이페이지 성별 표시를 `genderLabels` 매핑으로 통일

## 작업 방법
- 화면 표기용 한글 라벨과 API 전송 값(영문 코드)을 분리

## 테스트
- 회원가입 시 성별 전송 값 확인, 회원 관리·마이페이지 성별 한글 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)