### PR TITLE
💄 Style: 관리자 페이지 디자인 폴리싱 — pill 버튼·테이블·사이드바·Detail 통일

### DIFF
--- a/src/common/AdmnMenu.jsx
+++ b/src/common/AdmnMenu.jsx
@@ -1,18 +1,19 @@
 // AdmnMenu.jsx
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FaMapMarkedAlt, FaUsers, FaCogs, FaDatabase, FaChartLine } from 'react-icons/fa';
 
 const MENU_ITEMS = [
-    { key: 'board', label: '여행지 관리' },
-    { key: 'member', label: '회원 관리' },
-    { key: 'process', label: '프로세스 관리' },
-    { key: 'log', label: '로그 DB' },
-    { key: 'monitoring', label: 'Monitoring' },
+    { key: 'board', label: '여행지 관리', icon: <FaMapMarkedAlt /> },
+    { key: 'member', label: '회원 관리', icon: <FaUsers /> },
+    { key: 'process', label: '프로세스 관리', icon: <FaCogs /> },
+    { key: 'log', label: '로그 DB', icon: <FaDatabase /> },
+    { key: 'monitoring', label: 'Monitoring', icon: <FaChartLine /> },
 ];
 
 const AdmnMenu = ({ onMenuClick, activeMenu }) => {
     return (
-        <div className="list-group text-center admin-menu">
+        <div className="list-group admin-menu">
             <h4 className="admin-menu-title">관리자 메뉴</h4>
             {MENU_ITEMS.map(item => (
                 <button
@@ -20,6 +21,7 @@ const AdmnMenu = ({ onMenuClick, activeMenu }) => {
                     className={`list-group-item list-group-item-action admin-menu-item${activeMenu === item.key ? ' active' : ''}`}
                     onClick={() => onMenuClick(item.key)}
                 >
+                    <span className="admin-menu-item-icon">{item.icon}</span>
                     {item.label}
                 </button>
             ))}

--- a/src/common/AdmnPage.jsx
+++ b/src/common/AdmnPage.jsx
@@ -54,10 +54,10 @@ const AdmnPage = () => {
   }, []);
 
   return (
-    <div className="container-fluid" style={{marginTop: "1.1rem"}}>
+    <div className="container-fluid admin-page-root">
       <div className="row">
         {/* 왼쪽: 메뉴 (props로 onMenuClick 전달) */}
-        <div className="col-lg-2 p-0 border-end bg-body-tertiary min-vh-100" >
+        <div className="col-lg-2 p-0 admin-sidebar min-vh-100" >
           <AdmnMenu
             onMenuClick={setActiveMenu}
             activeMenu={['format', 'filter', 'deduplication'].includes(activeMenu) ? 'process' : activeMenu}

--- a/src/css/common.css
+++ b/src/css/common.css
@@ -143,6 +143,10 @@
 }
 
 /* ===== 관리자 공통 (AdminPageHeader / AdminPipelineNav / AdmnMenu) ===== */
+.admin-page-root {
+  margin-top: 1.1rem;
+}
+
 .admin-page-header {
   margin-bottom: 1.5rem;
   padding-bottom: 0.75rem;
@@ -154,23 +158,254 @@
   margin: 0;
 }
 
+.admin-pipeline-nav {
+  gap: 0.4rem;
+}
+
 .admin-pipeline-nav .admin-pipeline-nav-link {
   border-radius: var(--radius-pill);
   font-weight: 600;
   color: var(--page-title-color);
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+}
+
+.admin-pipeline-nav .admin-pipeline-nav-link:hover {
+  background: var(--brand-tint);
 }
 
 .admin-pipeline-nav .admin-pipeline-nav-link.active {
   background: var(--brand-gradient);
   color: #fff;
+  box-shadow: var(--admin-btn-shadow);
+}
+
+/* ===== 관리자 사이드바 (AdmnMenu) ===== */
+.admin-sidebar {
+  background: var(--card-bg);
+  border-right: 1px solid var(--admin-border);
+}
+
+.admin-menu {
+  padding: 0 0.85rem 1rem;
 }
 
 .admin-menu-title {
-  padding-top: 20px;
+  padding: 24px 0 10px;
+  margin-bottom: 0.35rem;
+  font-size: 1.05rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: var(--page-title-color);
+  text-align: center;
 }
 
-.admin-menu-item.active {
+.admin-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  color: var(--admin-muted);
+  padding: 0.7rem 1.1rem;
+  margin-bottom: 0.3rem;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+}
+
+.admin-menu-item:hover {
+  background: var(--brand-tint);
+  color: var(--page-title-color);
+}
+
+.admin-menu-item.active,
+.admin-menu-item.active:hover {
   background: var(--brand-gradient);
   border-color: transparent;
   color: #fff;
+  box-shadow: var(--admin-btn-shadow);
+}
+
+.admin-menu-item-icon {
+  display: inline-flex;
+  font-size: 1rem;
+  opacity: 0.9;
+}
+
+/* ===== 관리자 공통 버튼 (pill) ===== */
+.admin-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  padding: 0.45rem 1.3rem;
+  border: 1.5px solid transparent;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s, filter 0.15s, transform 0.1s;
+}
+
+.admin-btn:active {
+  transform: scale(0.97);
+}
+
+.admin-btn-sm {
+  padding: 0.25rem 0.9rem;
+  font-size: 0.875rem;
+}
+
+.admin-btn-primary {
+  background: var(--brand-gradient);
+  color: #fff;
+  border: none;
+  box-shadow: var(--admin-btn-shadow);
+}
+
+.admin-btn-primary:hover,
+.admin-btn-primary:focus {
+  color: #fff;
+  filter: brightness(1.08);
+  box-shadow: var(--admin-btn-shadow-hover);
+}
+
+.admin-btn-outline {
+  background: var(--card-bg);
+  color: var(--page-title-color);
+  border-color: var(--admin-muted-border);
+}
+
+.admin-btn-outline:hover,
+.admin-btn-outline:focus {
+  background: var(--brand-tint);
+  color: var(--page-title-color);
+  border-color: transparent;
+}
+
+.admin-btn-danger {
+  background: var(--danger-soft-bg);
+  color: var(--danger-strong);
+  border: none;
+}
+
+.admin-btn-danger:hover,
+.admin-btn-danger:focus {
+  background: var(--danger-strong);
+  color: #fff;
+}
+
+.admin-btn-ghost {
+  background: transparent;
+  color: var(--admin-muted);
+  border-color: transparent;
+}
+
+.admin-btn-ghost:hover,
+.admin-btn-ghost:focus {
+  background: var(--brand-tint);
+  color: var(--page-title-color);
+}
+
+.admin-btn-icon {
+  width: 2rem;
+  height: 2rem;
+  min-width: 2rem;
+  padding: 0;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+}
+
+/* ===== 관리자 ON/OFF 토글 ===== */
+.admin-toggle {
+  min-width: 60px;
+  border-radius: var(--radius-pill);
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  border: 1.5px solid transparent;
+  transition: background 0.15s, color 0.15s, filter 0.15s;
+}
+
+.admin-toggle-on {
+  background: var(--brand-gradient);
+  color: #fff;
+  border: none;
+}
+
+.admin-toggle-on:hover,
+.admin-toggle-on:focus {
+  color: #fff;
+  filter: brightness(1.06);
+}
+
+.admin-toggle-off {
+  background: var(--card-bg);
+  color: var(--admin-muted);
+  border-color: var(--admin-muted-border);
+}
+
+.admin-toggle-off:hover,
+.admin-toggle-off:focus {
+  color: var(--admin-muted);
+  background: var(--admin-row-hover);
+}
+
+/* ===== 관리자 공통 테이블 ===== */
+.admin-table-card {
+  background: var(--card-bg);
+  border-radius: var(--radius-card-sm);
+  box-shadow: var(--card-shadow);
+  overflow: hidden;
+  border: none;
+}
+
+.admin-table {
+  margin-bottom: 0;
+}
+
+.admin-table > thead > tr > th {
+  background: var(--brand-tint);
+  color: var(--page-title-color);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  border-bottom: none;
+  padding: 0.85rem 0.75rem;
+}
+
+.admin-table > tbody > tr > td {
+  border-color: var(--admin-border);
+  padding: 0.8rem 0.75rem;
+}
+
+.admin-table > tbody > tr:last-child > td {
+  border-bottom: none;
+}
+
+.admin-table > tbody > tr:not(.admin-table-detail-row):hover > td {
+  background: var(--admin-row-hover);
+}
+
+.admin-table-detail-row > td {
+  background: var(--admin-row-hover);
+}
+
+/* ===== 관리자 Detail/섹션 공통 ===== */
+.admin-detail-title {
+  color: var(--page-title-color);
+  font-weight: 800;
+}
+
+.admin-section-box {
+  border: 1px solid var(--admin-border);
+  border-radius: var(--radius-card-sm);
+  background: var(--card-bg);
+}
+
+.admin-log-table-dot {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 0.5rem;
 }

--- a/src/css/common.css
+++ b/src/css/common.css
@@ -186,7 +186,8 @@
 }
 
 .admin-menu {
-  padding: 0 0.85rem 1rem;
+  /* 고정 Navbar(--nav-height) 아래로 내용 시작 */
+  padding: var(--nav-height) 0.85rem 1rem;
 }
 
 .admin-menu-title {
@@ -242,6 +243,7 @@
   font-weight: 600;
   padding: 0.45rem 1.3rem;
   border: 1.5px solid transparent;
+  white-space: nowrap;
   transition: background 0.15s, color 0.15s, box-shadow 0.15s, filter 0.15s, transform 0.1s;
 }
 
@@ -324,6 +326,7 @@
   font-weight: 700;
   letter-spacing: 0.03em;
   border: 1.5px solid transparent;
+  white-space: nowrap;
   transition: background 0.15s, color 0.15s, filter 0.15s;
 }
 

--- a/src/css/log.css
+++ b/src/css/log.css
@@ -48,7 +48,7 @@
 
 /* ===== 프로세스 관리 (ProcessManagement) ===== */
 .process-edit-row {
-  background: #f6f8fa;
+  background: var(--admin-row-hover);
   border-bottom-left-radius: var(--radius-btn);
   border-bottom-right-radius: var(--radius-btn);
 }
@@ -106,7 +106,7 @@
 }
 
 .log-condition-row {
-  background: #f8f9fa;
+  background: var(--admin-row-hover);
   border-radius: 8px;
   margin-bottom: 6px;
 }
@@ -117,13 +117,12 @@
   border-radius: var(--radius-card-sm);
   max-width: 900px;
   margin: 30px auto;
-  background: #fff;
-  box-shadow: 0 2px 10px #eee;
+  background: var(--card-bg);
+  box-shadow: var(--card-shadow);
 }
 
 .log-format-detail-name-input {
-  width: 415px;
-  transform: translateY(-28px);
+  max-width: 415px;
 }
 
 .log-format-input-name-input {
@@ -167,7 +166,8 @@
 
 /* ===== 중복 제거 (DeduplicationRow / InputDeduplication) ===== */
 .dedup-row-card {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
+  box-shadow: var(--card-shadow);
+  border-color: var(--admin-border) !important;
   position: relative;
 }
 
@@ -192,10 +192,10 @@
 }
 
 .dedup-input-container {
-  background: #fff;
+  background: var(--card-bg);
   border-radius: var(--radius-card-sm);
   padding: 28px 24px 24px 24px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.09);
+  box-shadow: var(--card-shadow);
   max-width: 600px;
   margin: 0 auto;
 }

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -45,4 +45,15 @@
   /* 타이포그래피 */
   --font-display: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Malgun Gothic', sans-serif;
   --page-title-color: #6c45e0;
+
+  /* 관리자 (Admin) */
+  --brand-tint: #EEF0FB;
+  --admin-border: #E4E7F5;
+  --admin-row-hover: #F7F8FE;
+  --admin-muted: #7A819E;
+  --admin-muted-border: #CDD3E6;
+  --danger-soft-bg: #FCE9ED;
+  --danger-strong: #D23B5E;
+  --admin-btn-shadow: 0 2px 10px rgba(40, 53, 147, 0.20);
+  --admin-btn-shadow-hover: 0 4px 16px rgba(40, 53, 147, 0.30);
 }

--- a/src/log/components/db/LogTable.jsx
+++ b/src/log/components/db/LogTable.jsx
@@ -37,10 +37,14 @@ const LogTable = ({
 
     return (
         <div>
-            <h3 className="mb-3">{title}</h3>
-            <div className="table-responsive log-table-scroll">
-                <table className={`table table-bordered table-hover align-middle`}>
-                    <thead className={`text-center table-${color}`}>
+            <h4 className="mb-3 fw-bold">
+                <span className={`admin-log-table-dot bg-${color}`}></span>
+                {title}
+            </h4>
+            <div className="admin-table-card">
+                <div className="table-responsive log-table-scroll">
+                <table className="table admin-table align-middle mb-0">
+                    <thead className="text-center">
                         <tr>
                             {columns.map(col =>
                                 <th
@@ -71,8 +75,8 @@ const LogTable = ({
                                     ))}
                                 </tr>,
                                 expandedRowId === row.historyId && (
-                                    <tr key={`${row.historyId}-expanded`}>
-                                        <td colSpan={columns.length} className="text-start bg-light">
+                                    <tr key={`${row.historyId}-expanded`} className="admin-table-detail-row">
+                                        <td colSpan={columns.length} className="text-start">
                                             <strong>Log Data:</strong>
                                             <pre
                                                 className="mb-0 mt-2 log-table-detail-pre"
@@ -86,6 +90,7 @@ const LogTable = ({
                         )}
                     </tbody>
                 </table>
+                </div>
             </div>
         </div>
     );

--- a/src/log/components/deduplication/DeduplicationManagement.jsx
+++ b/src/log/components/deduplication/DeduplicationManagement.jsx
@@ -48,13 +48,14 @@ const DeduplicationManagement = ({ processId, onMenuClick }) => {
   return (
     <div className="log-page-spacer">
       <AdminPageHeader title="중복 제거 관리">
-        <button className="btn btn-primary" onClick={() => setShowInput(true)}>중복 제거 추가</button>
+        <button className="btn admin-btn admin-btn-primary" onClick={() => setShowInput(true)}>+ 중복 제거 추가</button>
       </AdminPageHeader>
 
       <AdminPipelineNav active="deduplication" onNavigate={onMenuClick} />
 
-      <table className="table table-bordered text-center align-middle">
-        <thead className="table-light">
+      <div className="admin-table-card mb-4">
+      <table className="table admin-table text-center align-middle mb-0">
+        <thead>
           <tr>
             <th className="log-col-10">ID</th>
             <th className="text-start log-col-30">이름</th>
@@ -88,7 +89,7 @@ const DeduplicationManagement = ({ processId, onMenuClick }) => {
                   <td>
 
                     <button
-                      className={`btn btn-sm ${ddp.isActive ? "btn-success" : "btn-outline-secondary"}`}
+                      className={`btn btn-sm admin-toggle ${ddp.isActive ? "admin-toggle-on" : "admin-toggle-off"}`}
                       onClick={() => handleToggleActive(ddp.dedupRuleId, ddp.isActive)}
                     >
                       {ddp.isActive ? "ON" : "OFF"}
@@ -96,8 +97,8 @@ const DeduplicationManagement = ({ processId, onMenuClick }) => {
                   </td>
                 </tr>
                 {showDetail === ddp.dedupRuleId && (
-                  <tr>
-                    <td colSpan="5" className="text-center bg-light">
+                  <tr className="admin-table-detail-row">
+                    <td colSpan="5" className="text-center">
                       <DetailDeduplication
                         processId={processId}
                         id={ddp.dedupRuleId}
@@ -111,6 +112,7 @@ const DeduplicationManagement = ({ processId, onMenuClick }) => {
           )}
         </tbody>
       </table>
+      </div>
 
       <Modal show={showInput} onHide={() => handleInputClose(false)} size="lg" centered>
         <Modal.Header closeButton>

--- a/src/log/components/deduplication/DeduplicationRow.jsx
+++ b/src/log/components/deduplication/DeduplicationRow.jsx
@@ -83,15 +83,16 @@ const DeduplicationRow = ({ processId, index, data, onChange, onRemove }) => {
                                 <option value="Any">Any</option>
                             </select>
                             <button
-                                className="btn btn-outline-danger btn-sm"
+                                className="btn admin-btn-icon admin-btn-danger"
                                 type="button"
+                                title="조건 삭제"
                                 onClick={() => handleRemoveCondition(condIdx)}
                                 disabled={data.conditions.length === 1}
-                            >삭제</button>
+                            >✕</button>
                         </div>
                     ))}
-                    <button className="btn btn-outline-success btn-sm mt-1" type="button" onClick={handleAddCondition}>
-                        +
+                    <button className="btn admin-btn admin-btn-outline admin-btn-sm mt-1" type="button" onClick={handleAddCondition}>
+                        + 조건
                     </button>
                 </div>
             </div>
@@ -121,7 +122,7 @@ const DeduplicationRow = ({ processId, index, data, onChange, onRemove }) => {
             </div>
             {/* 삭제 버튼 */}
             <div className="d-flex justify-content-end">
-                <button className="btn btn-outline-danger mt-3" onClick={() => onRemove(index)} type="button" aria-label="삭제">X</button>
+                <button className="btn admin-btn admin-btn-danger admin-btn-sm mt-3" onClick={() => onRemove(index)} type="button" aria-label="삭제">✕ 규칙 삭제</button>
             </div>
         </div>
     );

--- a/src/log/components/deduplication/DetailDeduplication.jsx
+++ b/src/log/components/deduplication/DetailDeduplication.jsx
@@ -86,7 +86,7 @@ const DetailDeduplication = ({ processId, id, onClose }) => {
 
     return (
         <div className="container mt-5">
-            <h3 className="mb-4">중복 제거 설정 수정</h3>
+            <h4 className="mb-4 admin-detail-title">중복 제거 설정 수정</h4>
             <div className="mb-3">
                 <label className="form-label">중복 이름</label>
                 <input type="text" className="form-control"
@@ -104,18 +104,18 @@ const DetailDeduplication = ({ processId, id, onClose }) => {
                 />
             ))}
 
-            <div className="d-flex justify-content-between mt-3">
-                <button className="btn btn-success" onClick={handleAddRow}>+ 조건 추가</button>
+            <div className="d-flex justify-content-between align-items-center mt-3">
+                <button className="btn admin-btn admin-btn-outline" onClick={handleAddRow}>+ 규칙 추가</button>
                 <button
-                    className={`btn btn-sm ${active ? 'btn-success' : 'btn-outline-success'}`}
+                    className={`btn btn-sm admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
                     onClick={() => setActive(!active)}
                     type="button"
                 >
-                    활성화: {active ? "On" : "Off"}
+                    활성화: {active ? "ON" : "OFF"}
                 </button>
-                <div className="d-flex justify-content-end">
-                    <button className="btn btn-primary" onClick={handleSubmit}>수정</button>
-                    <button className="btn btn-danger" onClick={handleRemove}>삭제</button>
+                <div className="d-flex justify-content-end gap-2">
+                    <button className="btn admin-btn admin-btn-primary" onClick={handleSubmit}>수정</button>
+                    <button className="btn admin-btn admin-btn-danger" onClick={handleRemove}>삭제</button>
                 </div>
             </div>
         </div>

--- a/src/log/components/deduplication/InputDeduplication.jsx
+++ b/src/log/components/deduplication/InputDeduplication.jsx
@@ -64,11 +64,11 @@ const InputDeduplication = ({ processId, onClose }) => {
 
             <div className="mb-3 d-flex justify-content-end">
                 <button
-                    className={`btn btn-sm ${active ? 'btn-success' : 'btn-outline-success'}`}
+                    className={`btn btn-sm admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
                     onClick={() => setActive(!active)}
                     type="button"
                 >
-                    활성화: {active ? "On" : "Off"}
+                    활성화: {active ? "ON" : "OFF"}
                 </button>
             </div>
 
@@ -86,10 +86,10 @@ const InputDeduplication = ({ processId, onClose }) => {
             </div>
 
             <div className="d-flex justify-content-between align-items-center mt-3">
-                <button className="btn btn-success" onClick={handleAddRow}>
-                    + 조건 추가
+                <button className="btn admin-btn admin-btn-outline" onClick={handleAddRow}>
+                    + 규칙 추가
                 </button>
-                <button className="btn btn-primary" onClick={handleSubmit}>
+                <button className="btn admin-btn admin-btn-primary" onClick={handleSubmit}>
                     추가
                 </button>
             </div>

--- a/src/log/components/filter/ConditionBuilder.jsx
+++ b/src/log/components/filter/ConditionBuilder.jsx
@@ -146,9 +146,9 @@ const ConditionBuilder = ({ onClose, processId }) => {
 
             <div className="mt-3">
                 <label>추가:  </label>
-                <button className="btn btn-secondary me-2" onClick={addParenAndConditionWithAnd}>(</button>
-                <button className="btn btn-secondary me-2" onClick={addRightParen}>)</button>
-                <button className="btn btn-success me-2" onClick={addCondition}>조건</button>
+                <button className="btn admin-btn admin-btn-outline admin-btn-sm me-2" onClick={addParenAndConditionWithAnd}>( + 조건</button>
+                <button className="btn admin-btn admin-btn-outline admin-btn-sm me-2" onClick={addRightParen}>)</button>
+                <button className="btn admin-btn admin-btn-outline admin-btn-sm me-2" onClick={addCondition}>조건</button>
             </div>
 
             <div className="mt-4">
@@ -169,7 +169,7 @@ const ConditionBuilder = ({ onClose, processId }) => {
                                     return (
                                         <div className="w-100 text-center mb-2" key={i}>
                                             <button
-                                                className="btn btn-outline-primary"
+                                                className="btn admin-btn admin-btn-outline admin-btn-sm px-4"
                                                 onClick={() =>
                                                     updateToken(tokenIndex, 'value', t.value === '&&' ? '||' : '&&')
                                                 }
@@ -203,9 +203,9 @@ const ConditionBuilder = ({ onClose, processId }) => {
                                                     onChange={(e) => updateToken(condIndex, 'value', e.target.value)} />
                                                 {groupId !== 0 && (
                                                     <>
-                                                        <button className="btn btn-danger btn-sm me-2" onClick={() => deleteGroup(groupId)}>X</button>
-                                                        <button className="btn btn-outline-dark btn-sm me-1" onClick={() => moveGroup(groupId, 'up')}>⬆</button>
-                                                        <button className="btn btn-outline-dark btn-sm" onClick={() => moveGroup(groupId, 'down')}>⬇</button>
+                                                        <button className="btn admin-btn-icon admin-btn-danger me-2" onClick={() => deleteGroup(groupId)} title="삭제">✕</button>
+                                                        <button className="btn admin-btn-icon admin-btn-ghost me-1" onClick={() => moveGroup(groupId, 'up')} title="위로">⬆</button>
+                                                        <button className="btn admin-btn-icon admin-btn-ghost" onClick={() => moveGroup(groupId, 'down')} title="아래로">⬇</button>
                                                     </>
                                                 )}
                                             </div>
@@ -232,9 +232,9 @@ const ConditionBuilder = ({ onClose, processId }) => {
                                                 onChange={(e) => updateToken(tokenIndex, 'value', e.target.value)} />
                                             {groupId !== 0 && (
                                                 <>
-                                                    <button className="btn btn-danger btn-sm me-2" onClick={() => deleteGroup(groupId)}>X</button>
-                                                    <button className="btn btn-outline-dark btn-sm me-1" onClick={() => moveGroup(groupId, 'up')}>⬆</button>
-                                                    <button className="btn btn-outline-dark btn-sm" onClick={() => moveGroup(groupId, 'down')}>⬇</button>
+                                                    <button className="btn admin-btn-icon admin-btn-danger me-2" onClick={() => deleteGroup(groupId)} title="삭제">✕</button>
+                                                    <button className="btn admin-btn-icon admin-btn-ghost me-1" onClick={() => moveGroup(groupId, 'up')} title="위로">⬆</button>
+                                                    <button className="btn admin-btn-icon admin-btn-ghost" onClick={() => moveGroup(groupId, 'down')} title="아래로">⬇</button>
                                                 </>
                                             )}
                                         </div>
@@ -247,9 +247,9 @@ const ConditionBuilder = ({ onClose, processId }) => {
                                             <h2 className="me-2">)</h2>
                                             {groupId !== 0 && (
                                                 <>
-                                                    <button className="btn btn-danger btn-sm me-2" onClick={() => deleteGroup(groupId)}>X</button>
-                                                    <button className="btn btn-outline-dark btn-sm me-1" onClick={() => moveGroup(groupId, 'up')}>⬆</button>
-                                                    <button className="btn btn-outline-dark btn-sm" onClick={() => moveGroup(groupId, 'down')}>⬇</button>
+                                                    <button className="btn admin-btn-icon admin-btn-danger me-2" onClick={() => deleteGroup(groupId)} title="삭제">✕</button>
+                                                    <button className="btn admin-btn-icon admin-btn-ghost me-1" onClick={() => moveGroup(groupId, 'up')} title="위로">⬆</button>
+                                                    <button className="btn admin-btn-icon admin-btn-ghost" onClick={() => moveGroup(groupId, 'down')} title="아래로">⬇</button>
                                                 </>
                                             )}
                                         </div>
@@ -262,15 +262,19 @@ const ConditionBuilder = ({ onClose, processId }) => {
                     </div>
                 );
             })}
-            <button
-                className={`btn btn-sm ${active ? 'btn-success' : 'btn-outline-success'}`}
-                onClick={() => setActive(!active)}
-                type="button"
-            >
-                활성화: {active ? "On" : "Off"}
-            </button>
-            <button className="btn btn-primary me-2" onClick={handleSubmit}>추가</button>
-            <button className="btn btn-danger" onClick={onClose}>닫기</button>
+            <div className="d-flex justify-content-between align-items-center mt-4">
+                <button
+                    className={`btn admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
+                    onClick={() => setActive(!active)}
+                    type="button"
+                >
+                    활성화: {active ? "ON" : "OFF"}
+                </button>
+                <div className="d-flex gap-2">
+                    <button className="btn admin-btn admin-btn-outline" onClick={onClose}>닫기</button>
+                    <button className="btn admin-btn admin-btn-primary" onClick={handleSubmit}>추가</button>
+                </div>
+            </div>
         </div>
     );
 };

--- a/src/log/components/filter/DetailFilter.jsx
+++ b/src/log/components/filter/DetailFilter.jsx
@@ -162,7 +162,7 @@ const DetailFilter = ({ onClose, processId, filterId }) => {
     return (
         <div className="container mt-5 log-filter-detail-container">
             <div className="mb-2">
-                <h4 className="fw-bold text-primary">필터 수정</h4>
+                <h4 className="admin-detail-title">필터 수정</h4>
                 <hr />
             </div>
 
@@ -191,23 +191,23 @@ const DetailFilter = ({ onClose, processId, filterId }) => {
                         <div className="mb-4">
                             <label className="form-label fw-semibold">조건 추가</label>
                             <div className="d-flex gap-2">
-                                <button className="btn btn-outline-secondary" onClick={addParenAndConditionWithAnd}>
+                                <button className="btn admin-btn admin-btn-outline" onClick={addParenAndConditionWithAnd}>
                                     ( + 조건
                                 </button>
-                                <button className="btn btn-outline-secondary" onClick={addRightParen}>)</button>
-                                <button className="btn btn-outline-success" onClick={addCondition}>조건</button>
+                                <button className="btn admin-btn admin-btn-outline" onClick={addRightParen}>)</button>
+                                <button className="btn admin-btn admin-btn-outline" onClick={addCondition}>조건</button>
                             </div>
                         </div>
                         <div className="mb-3">
-                            <button className={`btn ${active ? "btn-success" : "btn-outline-success"} w-100 rounded-pill`}
+                            <button className={`btn admin-toggle ${active ? "admin-toggle-on" : "admin-toggle-off"} w-100`}
                                 onClick={() => setActive(!active)}>
                                 <span className="fw-bold">활성화: {active ? "ON" : "OFF"}</span>
                             </button>
                         </div>
                         <div className="d-flex gap-2">
-                            <button className="btn btn-primary flex-fill rounded-3" onClick={handleSubmit}>수정</button>
-                            <button className="btn btn-danger flex-fill rounded-3" onClick={removeFilter}>삭제</button>
-                            <button className="btn btn-outline-dark flex-fill rounded-3" onClick={onClose}>닫기</button>
+                            <button className="btn admin-btn admin-btn-primary flex-fill" onClick={handleSubmit}>수정</button>
+                            <button className="btn admin-btn admin-btn-danger flex-fill" onClick={removeFilter}>삭제</button>
+                            <button className="btn admin-btn admin-btn-outline flex-fill" onClick={onClose}>닫기</button>
                         </div>
                     </div>
                 </div>
@@ -236,7 +236,7 @@ const DetailFilter = ({ onClose, processId, filterId }) => {
                                                 return (
                                                     <div className="d-flex justify-content-center mb-2" key={i}>
                                                         <button
-                                                            className="btn btn-outline-primary rounded-pill px-4"
+                                                            className="btn admin-btn admin-btn-outline px-4"
                                                             onClick={() => updateToken(tokenIndex, 'value', t.value === '&&' ? '||' : '&&')}
                                                         >
                                                             {t.value === '&&' ? 'AND' : 'OR'}
@@ -271,11 +271,11 @@ const DetailFilter = ({ onClose, processId, filterId }) => {
                                                             />
                                                             {groupId !== 0 && (
                                                                 <>
-                                                                    <button className="btn btn-outline-danger btn-sm me-1" onClick={() => deleteGroup(groupId)} title="삭제">
+                                                                    <button className="btn admin-btn-icon admin-btn-danger me-1" onClick={() => deleteGroup(groupId)} title="삭제">
                                                                         <i className="bi bi-x-lg"></i>
                                                                     </button>
-                                                                    <button className="btn btn-outline-dark btn-sm me-1" onClick={() => moveGroup(groupId, 'up')} title="위로">⬆</button>
-                                                                    <button className="btn btn-outline-dark btn-sm" onClick={() => moveGroup(groupId, 'down')} title="아래로">⬇</button>
+                                                                    <button className="btn admin-btn-icon admin-btn-ghost me-1" onClick={() => moveGroup(groupId, 'up')} title="위로">⬆</button>
+                                                                    <button className="btn admin-btn-icon admin-btn-ghost" onClick={() => moveGroup(groupId, 'down')} title="아래로">⬇</button>
                                                                 </>
                                                             )}
                                                         </div>
@@ -302,11 +302,11 @@ const DetailFilter = ({ onClose, processId, filterId }) => {
                                                             onChange={(e) => updateToken(tokenIndex, 'value', e.target.value)} />
                                                         {groupId !== 0 && (
                                                             <>
-                                                                <button className="btn btn-outline-danger btn-sm me-1" onClick={() => deleteGroup(groupId)} title="삭제">
+                                                                <button className="btn admin-btn-icon admin-btn-danger me-1" onClick={() => deleteGroup(groupId)} title="삭제">
                                                                     <i className="bi bi-x-lg"></i>
                                                                 </button>
-                                                                <button className="btn btn-outline-dark btn-sm me-1" onClick={() => moveGroup(groupId, 'up')} title="위로">⬆</button>
-                                                                <button className="btn btn-outline-dark btn-sm" onClick={() => moveGroup(groupId, 'down')} title="아래로">⬇</button>
+                                                                <button className="btn admin-btn-icon admin-btn-ghost me-1" onClick={() => moveGroup(groupId, 'up')} title="위로">⬆</button>
+                                                                <button className="btn admin-btn-icon admin-btn-ghost" onClick={() => moveGroup(groupId, 'down')} title="아래로">⬇</button>
                                                             </>
                                                         )}
                                                     </div>
@@ -319,11 +319,11 @@ const DetailFilter = ({ onClose, processId, filterId }) => {
                                                         <span className="fs-4 fw-bold text-primary me-2">)</span>
                                                         {groupId !== 0 && (
                                                             <>
-                                                                <button className="btn btn-outline-danger btn-sm me-1" onClick={() => deleteGroup(groupId)} title="삭제">
+                                                                <button className="btn admin-btn-icon admin-btn-danger me-1" onClick={() => deleteGroup(groupId)} title="삭제">
                                                                     <i className="bi bi-x-lg"></i>
                                                                 </button>
-                                                                <button className="btn btn-outline-dark btn-sm me-1" onClick={() => moveGroup(groupId, 'up')} title="위로">⬆</button>
-                                                                <button className="btn btn-outline-dark btn-sm" onClick={() => moveGroup(groupId, 'down')} title="아래로">⬇</button>
+                                                                <button className="btn admin-btn-icon admin-btn-ghost me-1" onClick={() => moveGroup(groupId, 'up')} title="위로">⬆</button>
+                                                                <button className="btn admin-btn-icon admin-btn-ghost" onClick={() => moveGroup(groupId, 'down')} title="아래로">⬇</button>
                                                             </>
                                                         )}
                                                     </div>

--- a/src/log/components/filter/FilterManagement.jsx
+++ b/src/log/components/filter/FilterManagement.jsx
@@ -26,14 +26,14 @@ const FilterManagement = ({ processId, onMenuClick }) => {
     return (
         <div className="log-page-spacer">
             <AdminPageHeader title="필터링 관리">
-                <button className="btn btn-primary" onClick={() => setBuilderComp(true)}>필터 추가</button>
+                <button className="btn admin-btn admin-btn-primary" onClick={() => setBuilderComp(true)}>+ 필터 추가</button>
             </AdminPageHeader>
 
             <AdminPipelineNav active="filter" onNavigate={onMenuClick} />
 
-            <div className="card shadow-sm rounded-4 mb-4 log-card-noborder">
-                <table className="table table-bordered text-center align-middle mb-0">
-                    <thead className="table-light">
+            <div className="admin-table-card mb-4">
+                <table className="table admin-table text-center align-middle mb-0">
+                    <thead>
                         <tr>
                             <th className="log-col-10">ID</th>
                             <th className="text-start log-col-30">이름</th>
@@ -65,15 +65,15 @@ const FilterManagement = ({ processId, onMenuClick }) => {
                                     <td>{formatDate(filter.updatedAt)}</td>
                                     <td>
                                         <button
-                                            className={`btn btn-sm ${filter.isActive ? 'btn-success' : 'btn-outline-success'}`}
+                                            className={`btn btn-sm admin-toggle ${filter.isActive ? 'admin-toggle-on' : 'admin-toggle-off'}`}
                                         >
                                             {filter.isActive ? 'ON' : 'OFF'}
                                         </button>
                                     </td>
                                 </tr>
                                 {detailComp === filter.filterRuleId && (
-                                    <tr>
-                                        <td colSpan="5" className="text-center bg-light">
+                                    <tr className="admin-table-detail-row">
+                                        <td colSpan="5" className="text-center">
                                             <DetailFilter
                                                 onClose={() => setDetailComp(0)}
                                                 filterId={filter.filterRuleId}

--- a/src/log/components/format/DetailFormat.jsx
+++ b/src/log/components/format/DetailFormat.jsx
@@ -79,15 +79,13 @@ const
 
         return (
             <div className="log-format-detail-container">
-                <h2 className="mb-4">포맷 상세 화면</h2>
+                <h4 className="mb-4 admin-detail-title">포맷 상세</h4>
                 <form onSubmit={handleSubmit}>
-                    <div className="mb-4">
-                        <label className="fw-bold mb-2">포맷 이름</label>
-                    </div>
-                    <div>
+                    <div className="mb-4 text-center">
+                        <label className="fw-bold mb-2 d-block">포맷 이름</label>
                         <input
                             type="text"
-                            className="form-control-center log-format-detail-name-input"
+                            className="form-control log-format-detail-name-input mx-auto"
                             placeholder="format name"
                             value={name}
                             onChange={e => setName(e.target.value)}
@@ -97,7 +95,7 @@ const
                     <div className="row">
                         {/* Default Entry */}
                         <div className="col-md-6 mb-3">
-                            <div className="border rounded p-3 h-100">
+                            <div className="admin-section-box p-3 h-100">
                                 <h5 className="mb-3">기본 정보</h5>
                                 {defaultEntry.map((entry, index) => (
                                     <div key={`default-${index}`} className="d-flex align-items-center mb-2">
@@ -121,7 +119,7 @@ const
                                         />
                                         <button
                                             type="button"
-                                            className="btn btn-danger"
+                                            className="btn admin-btn-icon admin-btn-danger"
                                             onClick={() => removeEntry(setDefaultEntry, defaultEntry, index)}
                                         >✕</button>
                                     </div>
@@ -129,13 +127,13 @@ const
                                 <button
                                     type="button"
                                     onClick={() => addEntry(setDefaultEntry, defaultEntry)}
-                                    className="btn btn-outline-success mt-2"
+                                    className="btn admin-btn admin-btn-outline admin-btn-sm mt-2"
                                 >+ 항목 추가</button>
                             </div>
                         </div>
                         {/* Format Entry */}
                         <div className="col-md-6 mb-3">
-                            <div className="border rounded p-3 h-100">
+                            <div className="admin-section-box p-3 h-100">
                                 <h5 className="mb-3">포맷 정보</h5>
                                 {formatEntry.map((entry, index) => (
                                     <div key={`format-${index}`} className="d-flex align-items-center mb-2">
@@ -160,7 +158,7 @@ const
                                         />
                                         <button
                                             type="button"
-                                            className="btn btn-danger"
+                                            className="btn admin-btn-icon admin-btn-danger"
                                             onClick={() => removeEntry(setFormatEntry, formatEntry, index)}
                                         >✕</button>
                                     </div>
@@ -168,7 +166,7 @@ const
                                 <button
                                     type="button"
                                     onClick={() => addEntry(setFormatEntry, formatEntry)}
-                                    className="btn btn-outline-success mt-2"
+                                    className="btn admin-btn admin-btn-outline admin-btn-sm mt-2"
                                 >+ 항목 추가</button>
                             </div>
                         </div>
@@ -177,17 +175,17 @@ const
                     <div className="mt-4 d-flex justify-content-between align-items-center">
                         <div className="d-flex align-items-center">
                             <button
-                                className={`btn btn-sm ${active ? 'btn-success' : 'btn-outline-success'}`}
+                                className={`btn btn-sm admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
                                 onClick={() => setActive(!active)}
                                 type="button"
                             >
-                                활성화: {active ? "On" : "Off"}
+                                활성화: {active ? "ON" : "OFF"}
                             </button>
                         </div>
-                        <div>
-                            <button type="submit" className="btn btn-primary me-2">수정</button>
-                            <button type="button" onClick={removeFormat} className="btn btn-danger me-2">삭제</button>
-                            <button type="button" onClick={onClose} className="btn btn-outline-secondary">닫기</button>
+                        <div className="d-flex gap-2">
+                            <button type="submit" className="btn admin-btn admin-btn-primary">수정</button>
+                            <button type="button" onClick={removeFormat} className="btn admin-btn admin-btn-danger">삭제</button>
+                            <button type="button" onClick={onClose} className="btn admin-btn admin-btn-outline">닫기</button>
                         </div>
                     </div>
                 </form>

--- a/src/log/components/format/FormatManagement.jsx
+++ b/src/log/components/format/FormatManagement.jsx
@@ -26,14 +26,14 @@ const FormatManagement = ({ processId, onMenuClick }) => {
     return (
         <div className="log-page-spacer">
             <AdminPageHeader title="포맷 관리">
-                <button className="btn btn-primary" onClick={() => setInputComp(true)}>포맷 추가</button>
+                <button className="btn admin-btn admin-btn-primary" onClick={() => setInputComp(true)}>+ 포맷 추가</button>
             </AdminPageHeader>
 
             <AdminPipelineNav active="format" onNavigate={onMenuClick} />
 
-            <div className="card shadow-sm rounded-4 mb-4 log-card-noborder">
-                <table className="table table-bordered text-center align-middle mb-0">
-                    <thead className="table-light">
+            <div className="admin-table-card mb-4">
+                <table className="table admin-table text-center align-middle mb-0">
+                    <thead>
                         <tr>
                             <th className="log-col-10">ID</th>
                             <th className="text-start log-col-25">이름</th>
@@ -64,14 +64,14 @@ const FormatManagement = ({ processId, onMenuClick }) => {
                                     <td>{format.createdAt && formatDate(format.createdAt)}</td>
                                     <td>{format.updatedAt && formatDate(format.updatedAt)}</td>
                                     <td>
-                                        <button className={`btn btn-sm ${format.isActive ? 'btn-primary' : 'btn-outline-primary'} me-2`}>
+                                        <button className={`btn btn-sm admin-toggle ${format.isActive ? 'admin-toggle-on' : 'admin-toggle-off'}`}>
                                             {format.isActive ? 'ON' : 'OFF'}
                                         </button>
                                     </td>
                                 </tr>
                                 {detailComp === format.formatRuleId && (
-                                    <tr>
-                                        <td colSpan="5" className="text-center bg-light">
+                                    <tr className="admin-table-detail-row">
+                                        <td colSpan="5" className="text-center">
                                             <DetailFormat
                                                 onClose={() => setDetailComp(0)}
                                                 formatId={format.formatRuleId}

--- a/src/log/components/format/InputFormat.jsx
+++ b/src/log/components/format/InputFormat.jsx
@@ -66,11 +66,11 @@ const InputFormat = ({ onClose, processId }) => {
                     <input type="text" className="form-control me-2" placeholder="Value"
                         value={entry.value}
                         onChange={e => handleEntryChange(setDefaultEntry, defaultEntry, index, 'value', e.target.value)} />
-                    <button type="button" className="btn btn-danger btn-sm"
+                    <button type="button" className="btn admin-btn-icon admin-btn-danger"
                         onClick={() => removeEntry(setDefaultEntry, defaultEntry, index)}>✕</button>
                 </div>
             ))}
-            <button type="button" className="btn btn-success btn-sm mb-3"
+            <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm mb-3"
                 onClick={() => addEntry(setDefaultEntry, defaultEntry)}>+ 추가</button>
 
             <h5>포맷 정보</h5>
@@ -79,24 +79,26 @@ const InputFormat = ({ onClose, processId }) => {
                     <input type="text" className="form-control me-2" placeholder="Key"
                         value={entry.key}
                         onChange={e => handleEntryChange(setFormatEntry, formatEntry, index, 'key', e.target.value)} />
-                    ⬅
+                    <span className="mx-1">⬅</span>
                     <input type="text" className="form-control me-2" placeholder="Value"
                         value={entry.value}
                         onChange={e => handleEntryChange(setFormatEntry, formatEntry, index, 'value', e.target.value)} />
-                    <button type="button" className="btn btn-danger btn-sm"
+                    <button type="button" className="btn admin-btn-icon admin-btn-danger"
                         onClick={() => removeEntry(setFormatEntry, formatEntry, index)}>✕</button>
                 </div>
             ))}
-            <button type="button" className="btn btn-success btn-sm mb-3"
+            <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm mb-3"
                 onClick={() => addEntry(setFormatEntry, formatEntry)}>+ 추가</button>
 
             <div className="d-flex justify-content-between mt-4">
-                <button type="button" className="btn btn-danger" onClick={onClose}>닫기</button>
-                <button type="submit" className="btn btn-primary">추가 </button>
-                <button type="button" className={`btn ${active ? 'btn-success' : 'btn-outline-success'}`}
+                <button type="button" className={`btn admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
                     onClick={() => setActive(prev => !prev)}>
-                    활성화: {active ? "On" : "Off"}
+                    활성화: {active ? "ON" : "OFF"}
                 </button>
+                <div className="d-flex gap-2">
+                    <button type="button" className="btn admin-btn admin-btn-outline" onClick={onClose}>닫기</button>
+                    <button type="submit" className="btn admin-btn admin-btn-primary">추가</button>
+                </div>
             </div>
         </form>
     );

--- a/src/log/components/process/EditProcess.jsx
+++ b/src/log/components/process/EditProcess.jsx
@@ -26,8 +26,8 @@ const EditProcess = ({ onClose, processId, _name }) => {
     };
 
     return (
-        <div className="card mt-4 p-4 mx-auto log-process-card">
-            <h4 className="mb-3">Process 수정</h4>
+        <div className="card mt-4 p-4 mx-auto log-process-card admin-section-box border-0 shadow-sm">
+            <h4 className="mb-3 admin-detail-title">프로세스 수정</h4>
             <input
                 type='text'
                 className="form-control mb-3"
@@ -35,10 +35,10 @@ const EditProcess = ({ onClose, processId, _name }) => {
                 onChange={e => setName(e.target.value)}
                 placeholder="프로세스 이름"
             />
-            <div className="d-flex justify-content-between">
-                <button className="btn btn-primary" onClick={updateProcess}>수정</button>
-                <button className="btn btn-danger" onClick={removeProcess}>삭제</button>
-                <button className="btn btn-outline-secondary" onClick={onClose}>닫기</button>
+            <div className="d-flex justify-content-center gap-2">
+                <button className="btn admin-btn admin-btn-primary" onClick={updateProcess}>수정</button>
+                <button className="btn admin-btn admin-btn-danger" onClick={removeProcess}>삭제</button>
+                <button className="btn admin-btn admin-btn-outline" onClick={onClose}>닫기</button>
             </div>
         </div>
 

--- a/src/log/components/process/InputProcess.jsx
+++ b/src/log/components/process/InputProcess.jsx
@@ -25,15 +25,15 @@ const InputProcess = ({ onClose }) => {
                 value={name}
                 onChange={e => setName(e.target.value)}
             />
-            <div className="d-flex justify-content-between">
+            <div className="d-flex justify-content-end gap-2">
+                <button className="btn admin-btn admin-btn-outline" onClick={onClose}>닫기</button>
                 <button
-                    className="btn btn-primary"
+                    className="btn admin-btn admin-btn-primary"
                     onClick={addProcess}
                     disabled={!name.trim()} // 이름 없으면 비활성화(UX 개선)
                 >
                     추가
                 </button>
-                <button className="btn btn-outline-secondary" onClick={onClose}>닫기</button>
             </div>
         </div>
     );

--- a/src/log/components/process/ProcessManagement.jsx
+++ b/src/log/components/process/ProcessManagement.jsx
@@ -34,14 +34,14 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
     return (
         <div className="log-page-spacer">
             <AdminPageHeader title="프로세스 관리">
-                <button className="btn btn-success shadow-sm log-btn-rounded" onClick={() => setShowModal(true)}>
+                <button className="btn admin-btn admin-btn-primary" onClick={() => setShowModal(true)}>
                     + 프로세스 추가
                 </button>
             </AdminPageHeader>
 
-            <div className="card shadow-sm rounded-4 mb-4 log-card-noborder">
-                <table className="table table-hover table-bordered align-middle text-center mb-0">
-                    <thead className="table-light">
+            <div className="admin-table-card mb-4">
+                <table className="table admin-table align-middle text-center mb-0">
+                    <thead>
                         <tr>
                             <th className="log-col-15">ID</th>
                             <th className="text-start">이름</th>
@@ -77,7 +77,7 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
                                     <td>{process.updatedAt && formatDate(process.updatedAt)}</td>
                                     <td>
                                         <button
-                                            className="btn btn-outline-primary btn-sm px-3 log-btn-rounded-sm"
+                                            className="btn admin-btn admin-btn-outline admin-btn-sm px-3"
                                             onClick={() => setEditComp(process.logProcessId)}
                                         >
                                             수정
@@ -85,7 +85,7 @@ const ProcessManagement = ({ setPID, onMenuClick }) => {
                                     </td>
                                 </tr>
                                 {editComp === process.logProcessId && (
-                                    <tr>
+                                    <tr className="admin-table-detail-row">
                                         <td colSpan={5} className="process-edit-row">
                                             <EditProcess
                                                 onClose={handleEditComp}

--- a/src/sign/component/MemberManagement.jsx
+++ b/src/sign/component/MemberManagement.jsx
@@ -32,9 +32,10 @@ const MemberManagement = () => {
     return (
         <div className="container sign-page-spacer">
             <AdminPageHeader title="회원 관리" />
-            <div className="table-responsive">
-                <table className="table table-hover align-middle">
-                    <thead className="table-light">
+            <div className="admin-table-card">
+                <div className="table-responsive">
+                <table className="table admin-table align-middle mb-0">
+                    <thead>
                         <tr>
                             <th>#</th>
                             <th>ID</th>
@@ -67,7 +68,7 @@ const MemberManagement = () => {
                                     <td>{member.roles?.includes("ROLE_ADMIN") ? "관리자" : "회원"}</td>
                                     <td className='text-center'>
                                         <button
-                                            className="btn btn-sm btn-outline-success"
+                                            className="btn admin-btn-icon admin-btn-outline"
                                             title="관리자 위임"
                                             onClick={() => delegateAdmin({ memberId: member.memberId })}
                                             disabled={member.roles?.includes("ROLE_ADMIN")}
@@ -79,6 +80,7 @@ const MemberManagement = () => {
                             ))}
                     </tbody>
                 </table>
+                </div>
             </div>
 
         </div>


### PR DESCRIPTION
## 관련 이슈
closes #67

## 변경 사항
**1단계 — 공통 디자인 시스템 (tokens.css / common.css / log.css)**
- 관리자 팔레트 토큰 추가: `--brand-tint`, `--admin-border`, `--admin-row-hover`, `--danger-soft-bg`, `--danger-strong` 등
- 공통 버튼 체계 신설 (파이프라인 pill 탭 스타일 기준): `.admin-btn-primary`(브랜드 그라디언트), `.admin-btn-outline`, `.admin-btn-danger`(soft red), `.admin-btn-ghost`, `.admin-btn-icon`(원형 아이콘)
- ON/OFF 토글 통일: `.admin-toggle-on`(그라디언트 pill) / `.admin-toggle-off`(outline)
- 공통 테이블: `.admin-table-card`(라운드 카드) + `.admin-table`(브랜드 틴트 헤더, 행 hover, 가로 구분선만)
- 사이드바: 메뉴 아이콘(react-icons) + pill 항목 + hover 틴트 + 활성 그라디언트, 고정 네비바와의 겹침 해소
- `log.css` 하드코딩 그림자/배경 토큰 수렴, 포맷 이름 입력 `translateY(-28px)` 핵 제거

**2단계 — 화면별 적용 (기능 로직 불변, className만 교체)**
- 회원 관리 / 포맷 / 필터 / 중복제거 / 프로세스 / 로그 DB 전 화면
- 화면마다 제각각이던 버튼 색(primary/success/outline-dark 혼재) 통일
- Detail 컴포넌트 제목(`admin-detail-title`)·섹션 박스 통일, ConditionBuilder를 DetailFilter 수준으로 정리
- 로그 DB 3개 테이블: thead 색상 대신 제목에 상태 색 점(primary/danger/warning)으로 구분

## 작업 방법
- 사용자가 선호한 파이프라인 pill 탭(`--radius-pill` + `--brand-gradient`)을 버튼 공통 스타일로 승격
- 상태 관리·API 호출·Modal/행 확장 패턴은 전부 유지 (`src/api/`, `src/sse/` 무변경 확인)

## 테스트
- `npm run build` 통과
- Playwright(API 목킹)로 전 화면 스크린샷 검증: 회원 관리, 프로세스 관리(+추가 모달), 포맷 관리(+상세), 필터 관리(+상세), 중복제거 관리(+상세), 로그 DB
- 확인 항목: 파이프라인 탭 이동, 행 확장 상세, 추가 Modal 열기/닫기, ON/OFF 토글 표시, 사이드바 활성 하이라이트
- 실 데이터 CRUD 동작은 백엔드 연동 환경에서 확인 필요 (기능 로직 무변경이므로 회귀 위험 낮음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)