### PR TITLE
💄 Style: 포맷/필터/중복제거 상세·추가 폼 레이아웃 통일

### DIFF
--- a/src/css/common.css
+++ b/src/css/common.css
@@ -405,6 +405,22 @@
   background: var(--card-bg);
 }
 
+/* 상세/추가 폼 공통 푸터: 좌측 활성화 토글, 우측 액션 버튼 그룹 */
+.admin-form-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--admin-border);
+}
+
+.admin-form-footer-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .admin-log-table-dot {
   width: 0.65rem;
   height: 0.65rem;

--- a/src/css/log.css
+++ b/src/css/log.css
@@ -59,15 +59,6 @@
 }
 
 /* ===== 필터 조건 빌더 (ConditionBuilder) ===== */
-.log-condition-container {
-  max-width: 400px;
-  margin: 0 auto;
-}
-
-.log-expression-spacer {
-  margin-top: 10px;
-}
-
 .log-select-field {
   width: 120px;
 }
@@ -123,11 +114,6 @@
 
 .log-format-detail-name-input {
   max-width: 415px;
-}
-
-.log-format-input-name-input {
-  width: 360px;
-  text-align: center;
 }
 
 .log-format-flex-1 {

--- a/src/log/components/deduplication/DetailDeduplication.jsx
+++ b/src/log/components/deduplication/DetailDeduplication.jsx
@@ -87,8 +87,8 @@ const DetailDeduplication = ({ processId, id, onClose }) => {
     return (
         <div className="container mt-5">
             <h4 className="mb-4 admin-detail-title">중복 제거 설정 수정</h4>
-            <div className="mb-3">
-                <label className="form-label">중복 이름</label>
+            <div className="mb-4 text-start">
+                <label className="form-label fw-semibold">중복 이름</label>
                 <input type="text" className="form-control"
                     value={name} onChange={e => setName(e.target.value)} />
             </div>
@@ -104,8 +104,11 @@ const DetailDeduplication = ({ processId, id, onClose }) => {
                 />
             ))}
 
-            <div className="d-flex justify-content-between align-items-center mt-3">
-                <button className="btn admin-btn admin-btn-outline" onClick={handleAddRow}>+ 규칙 추가</button>
+            <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm" onClick={handleAddRow}>
+                + 규칙 추가
+            </button>
+
+            <div className="admin-form-footer">
                 <button
                     className={`btn btn-sm admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
                     onClick={() => setActive(!active)}
@@ -113,9 +116,10 @@ const DetailDeduplication = ({ processId, id, onClose }) => {
                 >
                     활성화: {active ? "ON" : "OFF"}
                 </button>
-                <div className="d-flex justify-content-end gap-2">
-                    <button className="btn admin-btn admin-btn-primary" onClick={handleSubmit}>수정</button>
-                    <button className="btn admin-btn admin-btn-danger" onClick={handleRemove}>삭제</button>
+                <div className="admin-form-footer-actions">
+                    <button type="button" className="btn admin-btn admin-btn-primary" onClick={handleSubmit}>수정</button>
+                    <button type="button" className="btn admin-btn admin-btn-danger" onClick={handleRemove}>삭제</button>
+                    <button type="button" className="btn admin-btn admin-btn-outline" onClick={() => onClose(false)}>닫기</button>
                 </div>
             </div>
         </div>

--- a/src/log/components/deduplication/InputDeduplication.jsx
+++ b/src/log/components/deduplication/InputDeduplication.jsx
@@ -51,8 +51,8 @@ const InputDeduplication = ({ processId, onClose }) => {
 
     return (
         <div className="dedup-input-container">
-            <div className="mb-3">
-                <label className="form-label fw-bold">중복 이름</label>
+            <div className="mb-4 text-start">
+                <label className="form-label fw-semibold">중복 이름</label>
                 <input
                     type="text"
                     className="form-control"
@@ -60,16 +60,6 @@ const InputDeduplication = ({ processId, onClose }) => {
                     onChange={e => setName(e.target.value)}
                     autoFocus
                 />
-            </div>
-
-            <div className="mb-3 d-flex justify-content-end">
-                <button
-                    className={`btn btn-sm admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
-                    onClick={() => setActive(!active)}
-                    type="button"
-                >
-                    활성화: {active ? "ON" : "OFF"}
-                </button>
             </div>
 
             <div>
@@ -85,13 +75,22 @@ const InputDeduplication = ({ processId, onClose }) => {
                 ))}
             </div>
 
-            <div className="d-flex justify-content-between align-items-center mt-3">
-                <button className="btn admin-btn admin-btn-outline" onClick={handleAddRow}>
-                    + 규칙 추가
+            <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm" onClick={handleAddRow}>
+                + 규칙 추가
+            </button>
+
+            <div className="admin-form-footer">
+                <button
+                    className={`btn btn-sm admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
+                    onClick={() => setActive(!active)}
+                    type="button"
+                >
+                    활성화: {active ? "ON" : "OFF"}
                 </button>
-                <button className="btn admin-btn admin-btn-primary" onClick={handleSubmit}>
-                    추가
-                </button>
+                <div className="admin-form-footer-actions">
+                    <button type="button" className="btn admin-btn admin-btn-outline" onClick={() => onClose(false)}>닫기</button>
+                    <button type="button" className="btn admin-btn admin-btn-primary" onClick={handleSubmit}>추가</button>
+                </div>
             </div>
         </div>
     );

--- a/src/log/components/filter/ConditionBuilder.jsx
+++ b/src/log/components/filter/ConditionBuilder.jsx
@@ -137,31 +137,36 @@ const ConditionBuilder = ({ onClose, processId }) => {
     };
 
     return (
-        <div className="container mt-4 text-center log-condition-container">
-            <h5>필터 추가</h5>
-            <div className="mb-3">
-                <label className="form-label">필터 이름</label>
-                <input type="text" className="form-control" placeholder="필터 이름" value={name} onChange={e => setName(e.target.value)} />
+        <div className="text-start">
+            <div className="mb-4">
+                <label className="form-label fw-semibold">필터 이름</label>
+                <input type="text" className="form-control" placeholder="filter name" value={name} onChange={e => setName(e.target.value)} />
             </div>
 
-            <div className="mt-3">
-                <label>추가:  </label>
-                <button className="btn admin-btn admin-btn-outline admin-btn-sm me-2" onClick={addParenAndConditionWithAnd}>( + 조건</button>
-                <button className="btn admin-btn admin-btn-outline admin-btn-sm me-2" onClick={addRightParen}>)</button>
-                <button className="btn admin-btn admin-btn-outline admin-btn-sm me-2" onClick={addCondition}>조건</button>
+            <div className="mb-4">
+                <label className="form-label fw-semibold">조건 추가</label>
+                <div className="d-flex gap-2">
+                    <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm" onClick={addParenAndConditionWithAnd}>( + 조건</button>
+                    <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm" onClick={addRightParen}>)</button>
+                    <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm" onClick={addCondition}>조건</button>
+                </div>
             </div>
 
-            <div className="mt-4">
-                <strong>현재 표현식: </strong>
-                <div className="log-expression-spacer"></div>
-                <code>{buildExpression()}</code>
+            <div className="bg-light rounded-4 shadow-sm p-3 mb-4 log-expression-box">
+                <strong className="me-2">현재 표현식:</strong>
+                <code className="text-break log-expression-code">{buildExpression()}</code>
             </div>
 
+            <div className="admin-section-box p-3">
+                <div className="mb-2 d-flex align-items-center">
+                    <i className="bi bi-funnel fs-5 me-2 text-primary"></i>
+                    <span className="fw-semibold">조건 목록</span>
+                </div>
             {getGroups(tokens).map((group, idx) => {
                 const groupId = group[0].groupId;
                 return (
-                    <div className="d-flex justify-content-center mb-3" key={groupId}>
-                        <div className="d-flex flex-column align-items-start">
+                    <div key={groupId}>
+                        <div>
                             {group.map((t, i) => {
                                 const tokenIndex = tokens.findIndex(tok => tok === t);
 
@@ -185,8 +190,8 @@ const ConditionBuilder = ({ onClose, processId }) => {
                                     if (nextToken?.type === 'condition') {
                                         const condIndex = tokens.findIndex(tok => tok === nextToken);
                                         return (
-                                            <div className="d-flex align-items-center" key={i}>
-                                                <h2 className="me-2">(</h2>
+                                            <div className="d-flex align-items-center py-2 border-bottom log-condition-row px-2" key={i}>
+                                                <span className="fs-4 fw-bold text-primary me-2">(</span>
                                                 <select className="form-select me-2 log-select-field"
                                                     value={nextToken.field}
                                                     onChange={(e) => updateToken(condIndex, 'field', e.target.value)}>
@@ -215,7 +220,7 @@ const ConditionBuilder = ({ onClose, processId }) => {
 
                                 if (t.type === 'condition' && group[i - 1]?.type !== 'left-paren') {
                                     return (
-                                        <div className="d-flex align-items-center" key={i}>
+                                        <div className="d-flex align-items-center py-2 border-bottom log-condition-row px-2" key={i}>
                                             <select className="form-select me-2 log-select-field"
                                                 value={t.field}
                                                 onChange={(e) => updateToken(tokenIndex, 'field', e.target.value)}>
@@ -243,8 +248,8 @@ const ConditionBuilder = ({ onClose, processId }) => {
 
                                 if (t.type === 'right-paren') {
                                     return (
-                                        <div className="d-flex align-items-center" key={i}>
-                                            <h2 className="me-2">)</h2>
+                                        <div className="d-flex align-items-center py-2 border-bottom log-condition-row px-2" key={i}>
+                                            <span className="fs-4 fw-bold text-primary me-2">)</span>
                                             {groupId !== 0 && (
                                                 <>
                                                     <button className="btn admin-btn-icon admin-btn-danger me-2" onClick={() => deleteGroup(groupId)} title="삭제">✕</button>
@@ -262,17 +267,19 @@ const ConditionBuilder = ({ onClose, processId }) => {
                     </div>
                 );
             })}
-            <div className="d-flex justify-content-between align-items-center mt-4">
+            </div>
+
+            <div className="admin-form-footer">
                 <button
-                    className={`btn admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
+                    className={`btn btn-sm admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
                     onClick={() => setActive(!active)}
                     type="button"
                 >
                     활성화: {active ? "ON" : "OFF"}
                 </button>
-                <div className="d-flex gap-2">
-                    <button className="btn admin-btn admin-btn-outline" onClick={onClose}>닫기</button>
-                    <button className="btn admin-btn admin-btn-primary" onClick={handleSubmit}>추가</button>
+                <div className="admin-form-footer-actions">
+                    <button type="button" className="btn admin-btn admin-btn-outline" onClick={onClose}>닫기</button>
+                    <button type="button" className="btn admin-btn admin-btn-primary" onClick={handleSubmit}>추가</button>
                 </div>
             </div>
         </div>

--- a/src/log/components/filter/DetailFilter.jsx
+++ b/src/log/components/filter/DetailFilter.jsx
@@ -188,26 +188,15 @@ const DetailFilter = ({ onClose, processId, filterId }) => {
                                 onChange={e => setName(e.target.value)}
                             />
                         </div>
-                        <div className="mb-4">
+                        <div>
                             <label className="form-label fw-semibold">조건 추가</label>
                             <div className="d-flex gap-2">
-                                <button className="btn admin-btn admin-btn-outline" onClick={addParenAndConditionWithAnd}>
+                                <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm" onClick={addParenAndConditionWithAnd}>
                                     ( + 조건
                                 </button>
-                                <button className="btn admin-btn admin-btn-outline" onClick={addRightParen}>)</button>
-                                <button className="btn admin-btn admin-btn-outline" onClick={addCondition}>조건</button>
+                                <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm" onClick={addRightParen}>)</button>
+                                <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm" onClick={addCondition}>조건</button>
                             </div>
-                        </div>
-                        <div className="mb-3">
-                            <button className={`btn admin-toggle ${active ? "admin-toggle-on" : "admin-toggle-off"} w-100`}
-                                onClick={() => setActive(!active)}>
-                                <span className="fw-bold">활성화: {active ? "ON" : "OFF"}</span>
-                            </button>
-                        </div>
-                        <div className="d-flex gap-2">
-                            <button className="btn admin-btn admin-btn-primary flex-fill" onClick={handleSubmit}>수정</button>
-                            <button className="btn admin-btn admin-btn-danger flex-fill" onClick={removeFilter}>삭제</button>
-                            <button className="btn admin-btn admin-btn-outline flex-fill" onClick={onClose}>닫기</button>
                         </div>
                     </div>
                 </div>
@@ -337,6 +326,21 @@ const DetailFilter = ({ onClose, processId, filterId }) => {
                             })}
                         </div>
                     </div>
+                </div>
+            </div>
+
+            <div className="admin-form-footer">
+                <button
+                    className={`btn btn-sm admin-toggle ${active ? "admin-toggle-on" : "admin-toggle-off"}`}
+                    onClick={() => setActive(!active)}
+                    type="button"
+                >
+                    활성화: {active ? "ON" : "OFF"}
+                </button>
+                <div className="admin-form-footer-actions">
+                    <button type="button" className="btn admin-btn admin-btn-primary" onClick={handleSubmit}>수정</button>
+                    <button type="button" className="btn admin-btn admin-btn-danger" onClick={removeFilter}>삭제</button>
+                    <button type="button" className="btn admin-btn admin-btn-outline" onClick={onClose}>닫기</button>
                 </div>
             </div>
         </div>

--- a/src/log/components/format/DetailFormat.jsx
+++ b/src/log/components/format/DetailFormat.jsx
@@ -81,11 +81,11 @@ const
             <div className="log-format-detail-container">
                 <h4 className="mb-4 admin-detail-title">포맷 상세</h4>
                 <form onSubmit={handleSubmit}>
-                    <div className="mb-4 text-center">
-                        <label className="fw-bold mb-2 d-block">포맷 이름</label>
+                    <div className="mb-4 text-start">
+                        <label className="form-label fw-semibold">포맷 이름</label>
                         <input
                             type="text"
-                            className="form-control log-format-detail-name-input mx-auto"
+                            className="form-control log-format-detail-name-input"
                             placeholder="format name"
                             value={name}
                             onChange={e => setName(e.target.value)}
@@ -172,17 +172,15 @@ const
                         </div>
                     </div>
                     {/* 하단 버튼 */}
-                    <div className="mt-4 d-flex justify-content-between align-items-center">
-                        <div className="d-flex align-items-center">
-                            <button
-                                className={`btn btn-sm admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
-                                onClick={() => setActive(!active)}
-                                type="button"
-                            >
-                                활성화: {active ? "ON" : "OFF"}
-                            </button>
-                        </div>
-                        <div className="d-flex gap-2">
+                    <div className="admin-form-footer">
+                        <button
+                            className={`btn btn-sm admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
+                            onClick={() => setActive(!active)}
+                            type="button"
+                        >
+                            활성화: {active ? "ON" : "OFF"}
+                        </button>
+                        <div className="admin-form-footer-actions">
                             <button type="submit" className="btn admin-btn admin-btn-primary">수정</button>
                             <button type="button" onClick={removeFormat} className="btn admin-btn admin-btn-danger">삭제</button>
                             <button type="button" onClick={onClose} className="btn admin-btn admin-btn-outline">닫기</button>

--- a/src/log/components/format/InputFormat.jsx
+++ b/src/log/components/format/InputFormat.jsx
@@ -47,55 +47,65 @@ const InputFormat = ({ onClose, processId }) => {
 
     return (
         <form onSubmit={handleSubmit}>
-            <div className="mb-3 d-flex flex-column align-items-center">
-                <label className="form-label w-100 text-center">포맷 이름</label>
+            <div className="mb-4 text-start">
+                <label className="form-label fw-semibold">포맷 이름</label>
                 <input
                     type="text"
-                    className="form-control log-format-input-name-input"
+                    className="form-control log-format-detail-name-input"
+                    placeholder="format name"
                     value={name}
                     onChange={e => setName(e.target.value)}
                 />
             </div>
 
-            <h5>기본 정보</h5>
-            {defaultEntry.map((entry, index) => (
-                <div key={`default-${index}`} className="d-flex mb-2">
-                    <input type="text" className="form-control me-2" placeholder="Key"
-                        value={entry.key}
-                        onChange={e => handleEntryChange(setDefaultEntry, defaultEntry, index, 'key', e.target.value)} />
-                    <input type="text" className="form-control me-2" placeholder="Value"
-                        value={entry.value}
-                        onChange={e => handleEntryChange(setDefaultEntry, defaultEntry, index, 'value', e.target.value)} />
-                    <button type="button" className="btn admin-btn-icon admin-btn-danger"
-                        onClick={() => removeEntry(setDefaultEntry, defaultEntry, index)}>✕</button>
+            <div className="row">
+                <div className="col-md-6 mb-3">
+                    <div className="admin-section-box p-3 h-100">
+                        <h5 className="mb-3">기본 정보</h5>
+                        {defaultEntry.map((entry, index) => (
+                            <div key={`default-${index}`} className="d-flex align-items-center mb-2">
+                                <input type="text" className="form-control me-2 log-format-flex-1" placeholder="Key"
+                                    value={entry.key}
+                                    onChange={e => handleEntryChange(setDefaultEntry, defaultEntry, index, 'key', e.target.value)} />
+                                <input type="text" className="form-control me-2 log-format-flex-2" placeholder="Value"
+                                    value={entry.value}
+                                    onChange={e => handleEntryChange(setDefaultEntry, defaultEntry, index, 'value', e.target.value)} />
+                                <button type="button" className="btn admin-btn-icon admin-btn-danger"
+                                    onClick={() => removeEntry(setDefaultEntry, defaultEntry, index)}>✕</button>
+                            </div>
+                        ))}
+                        <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm mt-2"
+                            onClick={() => addEntry(setDefaultEntry, defaultEntry)}>+ 항목 추가</button>
+                    </div>
                 </div>
-            ))}
-            <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm mb-3"
-                onClick={() => addEntry(setDefaultEntry, defaultEntry)}>+ 추가</button>
-
-            <h5>포맷 정보</h5>
-            {formatEntry.map((entry, index) => (
-                <div key={`format-${index}`} className="d-flex mb-2">
-                    <input type="text" className="form-control me-2" placeholder="Key"
-                        value={entry.key}
-                        onChange={e => handleEntryChange(setFormatEntry, formatEntry, index, 'key', e.target.value)} />
-                    <span className="mx-1">⬅</span>
-                    <input type="text" className="form-control me-2" placeholder="Value"
-                        value={entry.value}
-                        onChange={e => handleEntryChange(setFormatEntry, formatEntry, index, 'value', e.target.value)} />
-                    <button type="button" className="btn admin-btn-icon admin-btn-danger"
-                        onClick={() => removeEntry(setFormatEntry, formatEntry, index)}>✕</button>
+                <div className="col-md-6 mb-3">
+                    <div className="admin-section-box p-3 h-100">
+                        <h5 className="mb-3">포맷 정보</h5>
+                        {formatEntry.map((entry, index) => (
+                            <div key={`format-${index}`} className="d-flex align-items-center mb-2">
+                                <input type="text" className="form-control me-2 log-format-flex-1" placeholder="Key"
+                                    value={entry.key}
+                                    onChange={e => handleEntryChange(setFormatEntry, formatEntry, index, 'key', e.target.value)} />
+                                <span className="mx-1">⬅</span>
+                                <input type="text" className="form-control me-2 log-format-flex-2" placeholder="Value"
+                                    value={entry.value}
+                                    onChange={e => handleEntryChange(setFormatEntry, formatEntry, index, 'value', e.target.value)} />
+                                <button type="button" className="btn admin-btn-icon admin-btn-danger"
+                                    onClick={() => removeEntry(setFormatEntry, formatEntry, index)}>✕</button>
+                            </div>
+                        ))}
+                        <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm mt-2"
+                            onClick={() => addEntry(setFormatEntry, formatEntry)}>+ 항목 추가</button>
+                    </div>
                 </div>
-            ))}
-            <button type="button" className="btn admin-btn admin-btn-outline admin-btn-sm mb-3"
-                onClick={() => addEntry(setFormatEntry, formatEntry)}>+ 추가</button>
+            </div>
 
-            <div className="d-flex justify-content-between mt-4">
-                <button type="button" className={`btn admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
+            <div className="admin-form-footer">
+                <button type="button" className={`btn btn-sm admin-toggle ${active ? 'admin-toggle-on' : 'admin-toggle-off'}`}
                     onClick={() => setActive(prev => !prev)}>
                     활성화: {active ? "ON" : "OFF"}
                 </button>
-                <div className="d-flex gap-2">
+                <div className="admin-form-footer-actions">
                     <button type="button" className="btn admin-btn admin-btn-outline" onClick={onClose}>닫기</button>
                     <button type="submit" className="btn admin-btn admin-btn-primary">추가</button>
                 </div>

--- a/src/log/components/process/EditProcess.jsx
+++ b/src/log/components/process/EditProcess.jsx
@@ -28,17 +28,20 @@ const EditProcess = ({ onClose, processId, _name }) => {
     return (
         <div className="card mt-4 p-4 mx-auto log-process-card admin-section-box border-0 shadow-sm">
             <h4 className="mb-3 admin-detail-title">프로세스 수정</h4>
+            <label className="form-label fw-semibold">프로세스 이름</label>
             <input
                 type='text'
-                className="form-control mb-3"
+                className="form-control"
                 value={name}
                 onChange={e => setName(e.target.value)}
                 placeholder="프로세스 이름"
             />
-            <div className="d-flex justify-content-center gap-2">
-                <button className="btn admin-btn admin-btn-primary" onClick={updateProcess}>수정</button>
-                <button className="btn admin-btn admin-btn-danger" onClick={removeProcess}>삭제</button>
-                <button className="btn admin-btn admin-btn-outline" onClick={onClose}>닫기</button>
+            <div className="admin-form-footer justify-content-end">
+                <div className="admin-form-footer-actions">
+                    <button type="button" className="btn admin-btn admin-btn-primary" onClick={updateProcess}>수정</button>
+                    <button type="button" className="btn admin-btn admin-btn-danger" onClick={removeProcess}>삭제</button>
+                    <button type="button" className="btn admin-btn admin-btn-outline" onClick={onClose}>닫기</button>
+                </div>
             </div>
         </div>
 

--- a/src/log/components/process/InputProcess.jsx
+++ b/src/log/components/process/InputProcess.jsx
@@ -17,23 +17,26 @@ const InputProcess = ({ onClose }) => {
 
     return (
         <div>
-            <h4 className="mb-3">프로세스 이름</h4>
+            <label className="form-label fw-semibold">프로세스 이름</label>
             <input
                 type='text'
-                className="form-control mb-3"
+                className="form-control"
                 placeholder="프로세스 이름 입력"
                 value={name}
                 onChange={e => setName(e.target.value)}
             />
-            <div className="d-flex justify-content-end gap-2">
-                <button className="btn admin-btn admin-btn-outline" onClick={onClose}>닫기</button>
-                <button
-                    className="btn admin-btn admin-btn-primary"
-                    onClick={addProcess}
-                    disabled={!name.trim()} // 이름 없으면 비활성화(UX 개선)
-                >
-                    추가
-                </button>
+            <div className="admin-form-footer justify-content-end">
+                <div className="admin-form-footer-actions">
+                    <button type="button" className="btn admin-btn admin-btn-outline" onClick={onClose}>닫기</button>
+                    <button
+                        type="button"
+                        className="btn admin-btn admin-btn-primary"
+                        onClick={addProcess}
+                        disabled={!name.trim()} // 이름 없으면 비활성화(UX 개선)
+                    >
+                        추가
+                    </button>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## 관련 이슈
#67 후속 (PR #68 머지 이후 추가 개선)

## 변경 사항
- **공통 폼 푸터(`admin-form-footer`) 도입**: 상단 구분선 + 좌측 활성화 토글 + 우측 액션 버튼 그룹
  - 추가 폼: [닫기][추가] / 상세 폼: [수정][삭제][닫기]
  - 중복제거 상세에 없던 **닫기 버튼 신설**
- **이름 필드 통일**: 전 폼 상단 좌측 정렬 label(fw-semibold) + input (기존: 포맷은 가운데, 필터는 카드 안, 중복제거는 제각각)
- **포맷 추가(InputFormat)**: 상세와 동일한 2열 섹션 박스(기본 정보/포맷 정보) 구조로 재구성
- **필터 추가(ConditionBuilder)**: 필터 수정(DetailFilter)과 동일한 표현식 박스 + 조건 목록 카드 + 조건 행 스타일로 재구성 (기존 좁은 세로 배치 제거)
- **필터 수정(DetailFilter)**: 토글/수정/삭제/닫기를 좌측 카드에서 하단 공통 푸터로 이동
- 프로세스 추가/수정 폼 동일 푸터 패턴 적용, 미사용 CSS(log-condition-container 등) 제거

## 작업 방법
- 기능 로직 불변 — JSX 구조/className과 CSS만 변경, API·상태 관리 무변경

## 테스트
- `npm run build` 통과
- Playwright(API 목킹)로 6종 폼 스크린샷 검증: 포맷 상세/추가, 필터 상세/추가, 중복제거 상세/추가 — 이름 필드·토글·버튼 위치가 전 폼 동일 패턴인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)