### PR TITLE
💄 Style: 로그인/회원가입 배경에 메인 톤 그라디언트 적용

### DIFF
--- a/src/css/sign.css
+++ b/src/css/sign.css
@@ -1,7 +1,11 @@
 /* sign 도메인: 로그인/회원가입/마이페이지 */
 
 /* ===== 로그인/회원가입/정보수정/비밀번호변경 ===== */
-/* 페이지 배경은 body의 --page-bg 상속 (페이지별 자체 배경 금지) */
+/* 메인 히어로 톤 그라디언트 — 끝 색이 --page-bg라 푸터와 색이 이어짐 */
+.sign-page-bg {
+  background: var(--page-hero-gradient);
+}
+
 .sign-page-bg-full {
   width: 100vw;
   overflow-x: hidden;
@@ -69,6 +73,12 @@
   margin-top: 12px;
   background: #3f51b5;
   border: none;
+}
+
+/* Bootstrap .btn:disabled의 투명 배경이 덮어써 흰 버튼+흰 글자가 되는 문제 방지 */
+.signup-submit-btn:disabled {
+  background-color: #3f51b5;
+  opacity: 0.5;
 }
 
 /* ===== 회원 관리 (MemberManagement) ===== */

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -5,6 +5,8 @@
 
   /* 서피스 */
   --page-bg: #F5F6FF;
+  /* 상단 브랜드 연보라 → --page-bg 페이드 (메인 히어로 톤과 통일, 푸터 색 연속) */
+  --page-hero-gradient: linear-gradient(180deg, #DDE4FC 0%, #ECEFFD 45%, #F5F6FF 100%);
   --card-bg: #fff;
   --card-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.04);
   --card-shadow-lg: 0 8px 32px rgba(60, 60, 100, 0.14);

--- a/src/sign/component/SignInPage.jsx
+++ b/src/sign/component/SignInPage.jsx
@@ -48,7 +48,7 @@ const SignInPage = () => {
     }, []);
 
     return (
-        <div className="min-vh-100 d-flex flex-column sign-page-bg-full">
+        <div className="min-vh-100 d-flex flex-column sign-page-bg sign-page-bg-full">
             <main className="flex-grow-1 d-flex align-items-center justify-content-center">
                 <div className="col-md-5 col-lg-4">
                     <div className="card shadow-sm">

--- a/src/sign/component/SignInPage.jsx
+++ b/src/sign/component/SignInPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { login } from '../../api/authApi';
 import { getMyProfile } from '../../api/memberApi';
 import { useNavigate } from 'react-router-dom';
@@ -41,11 +41,6 @@ const SignInPage = () => {
             showAlert(error.response?.data?.message || "에러가 발생했습니다.", "danger");
         }
     };
-
-    useEffect(() => {
-        document.body.classList.add('bg-body-tertiary');
-        return () => document.body.classList.remove('bg-body-tertiary');
-    }, []);
 
     return (
         <div className="min-vh-100 d-flex flex-column sign-page-bg sign-page-bg-full">

--- a/src/sign/component/SignUpPage.jsx
+++ b/src/sign/component/SignUpPage.jsx
@@ -24,7 +24,7 @@ const SignUpPage = () => {
     }, []);
 
     return (
-        <div className="min-vh-100 d-flex flex-column">
+        <div className="min-vh-100 d-flex flex-column sign-page-bg">
             <main className="flex-grow-1 d-flex align-items-center justify-content-center">
                 <div className="card shadow-sm signup-card">
                     <div className="card-body p-4">

--- a/src/sign/component/SignUpPage.jsx
+++ b/src/sign/component/SignUpPage.jsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import useSignUpForm from '../../hooks/useSignUpForm';
 
 const SignUpPage = () => {
@@ -17,11 +16,6 @@ const SignUpPage = () => {
         handleBirthDate,
         handleSubmit,
     } = useSignUpForm();
-
-    useEffect(() => {
-        document.body.classList.add('bg-body-tertiary');
-        return () => document.body.classList.remove('bg-body-tertiary');
-    }, []);
 
     return (
         <div className="min-vh-100 d-flex flex-column sign-page-bg">


### PR DESCRIPTION
## 관련 이슈
closes #70

## 변경 사항
- `tokens.css`에 `--page-hero-gradient` 토큰 추가: 상단 브랜드 연보라(#DDE4FC)에서 `--page-bg`(#F5F6FF)로 페이드되는 세로 그라디언트
- 로그인/회원가입 페이지 루트에 `.sign-page-bg` 적용 (메인 히어로 톤과 통일)
- 회원가입 제출 버튼이 disabled 상태에서 Bootstrap `.btn:disabled`(투명 배경)에 덮여 흰 배경+흰 글자로 안 보이던 버그 수정

## 작업 방법
- 그라디언트 끝 색을 `--page-bg`로 맞춰 #64에서 잡은 푸터 색 연속성을 유지하면서 색감만 부여
- 기능 로직 무변경 (className/CSS만)

## 테스트
- Playwright 스크린샷: 로그인/회원가입 풀페이지 — 상단 연보라 → 하단 --page-bg 페이드, 푸터 경계 색 끊김 없음, disabled 가입 버튼 가시성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)