### PR TITLE
♻️ Refactor: [M1] src/analytics 모듈 도입 + 기존 트래킹 이벤트 이관

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,23 +65,23 @@ src/analytics/
 
 ## 이벤트 카탈로그
 
-### 유저 식별/속성 (`_mtm` 직접 push → `analytics.js`로 이관 대상)
+### 유저 식별/속성 (M1에서 `analytics.js`의 `setUserAttributes` 경유로 이관 완료)
 
-| 데이터 | 시점 | 현재 위치 | 필드 |
+| 데이터 | 시점 | 호출 위치 | 필드 |
 |---|---|---|---|
-| userId (토큰 sub 또는 익명 UUID), age, role | 앱 부팅 1회 | `src/index.js` | userId, age(-1 고정), role |
-| 로그인 유저 속성 | 로그인 성공 | `src/sign/component/SignInPage.jsx` | nickname, gender, age, role — **userId 미갱신 (버그)** |
+| userId (토큰 sub 또는 익명 UUID), age, role | 앱 부팅 1회 | `src/index.js` | userId, age(-1 고정), role — 매직 값은 M3에서 정리 |
+| 로그인 유저 속성 | 로그인 성공 | `src/sign/component/SignInPage.jsx` | nickname, gender, age, role — **userId 미갱신 (버그, M2)** |
 
-### 현재 이벤트 (`window.dataLayer` push — 전부 `events.js`로 이관 대상)
+### 현재 이벤트 (M1에서 `events.js` 트래커 → `_mtm` push로 이관 완료, 이슈 #73)
 
-| 이벤트 | 발화 시점 | 현재 위치 | 페이로드 | 문제 |
+| 이벤트 | 발화 시점 | 트래커 함수 (`src/analytics/events.js`) / 호출 위치 | 페이로드 | 남은 문제 |
 |---|---|---|---|---|
-| `travel_main_view` | 메인 페이지 진입 | `src/board/component/page/MainPage.jsx` | visit_time, referrer | 둘 다 Matomo 기본 수집과 중복 → 제거 |
-| `travel_search_click` | 검색 버튼 클릭 | `src/post/components/PostSearch.jsx` | category, region | 빈 값이 `"없음"` 문자열, keyword 미수집 |
-| `travel_detail_pageview` | 상세 데이터 로드 후 | `src/post/pages/PostDetailPage.jsx` | postId, category, region, title | 찜/댓글 시마다 재발화 (중복 집계) |
-| `travel_detail_exit` | 상세 이탈 (effect cleanup) | `src/post/pages/PostDetailPage.jsx` | postId, staySeconds, title | deps `[no, liked, commentFlag]` → 찜/댓글마다 발화, staySeconds 왜곡 |
-| `travel_favorite_add` / `_remove` | 찜 토글 | `src/post/pages/PostDetailPage.jsx` | postId, category, region, title | postId가 문자열 |
-| `travel_comment_add` / `_remove` | 댓글 등록/삭제 | `src/comment/component/CommentPage.jsx` | **boardId**, category, region, title | boardId→postId 통일 필요, star(별점) 미수집 |
+| `travel_main_view` | 메인 페이지 진입 | `trackMainView` / `src/board/component/page/MainPage.jsx` | (공통 필드만) | — |
+| `travel_search_click` | 검색 버튼 클릭 | `trackSearchClick` / `src/post/components/PostSearch.jsx` | category, region (빈 값 null) | keyword 미수집 (M4) |
+| `travel_detail_pageview` | 상세 데이터 로드 후 | `trackDetailPageview` / `src/post/pages/PostDetailPage.jsx` | postId(number), category, region, title | 찜/댓글 시마다 재발화 — 중복 집계 (M2) |
+| `travel_detail_exit` | 상세 이탈 (effect cleanup) | `trackDetailExit` / `src/post/pages/PostDetailPage.jsx` | postId(number), staySeconds, title | deps `[no, liked, commentFlag]` → 찜/댓글마다 발화, staySeconds 왜곡 (M2) |
+| `travel_favorite_add` / `_remove` | 찜 토글 | `trackFavoriteAdd` / `trackFavoriteRemove` / `src/post/pages/PostDetailPage.jsx` | postId(number), category, region, title | — |
+| `travel_comment_add` / `_remove` | 댓글 등록/삭제 | `trackCommentAdd` / `trackCommentRemove` / `src/comment/component/CommentPage.jsx` | postId(number), category, region, title | star(별점) 미수집 (M4) |
 
 ### 신규 이벤트 (이슈 M4에서 추가)
 
@@ -103,7 +103,9 @@ src/analytics/
 
 ## 작업 이슈 목록 (2026-07-07 진단 결과)
 
-### 이슈 M0 — 데이터 레이어 이원화 확인 (선행 조사, 🐛)
+### 이슈 M0 — 데이터 레이어 이원화 확인 (선행 조사, 🐛) — ✅ 완료 (이슈 #72)
+
+> 결과: 컨테이너는 `_mtm`만 상시 수신 → push 대상 `_mtm` 통일 확정. 컨테이너 ID는 `container_2yv5mH8U.js`로 교체됨. 컨테이너는 아직 태그/트리거 미구성·미게시 상태로, 사용자가 MTM에서 travel_* Custom Event 트리거 + History Change 트리거 구성 후 게시 필요.
 
 **진단**
 - 초기화·로그인은 `window._mtm`, 이벤트 5곳은 `window.dataLayer`에 push. MTM(Matomo Tag Manager)의 기본 데이터 레이어는 `_mtm`이므로, 컨테이너에 커스텀 설정이 없다면 `dataLayer` 이벤트는 Matomo에 도달하지 않을 수 있음.
@@ -112,7 +114,7 @@ src/analytics/
 - Matomo 대시보드(또는 MTM 프리뷰 모드)에서 `travel_*` 이벤트 수신 여부 확인이 1순위. 컨테이너 트리거 설정(History Change 트리거 포함 — SPA 라우트 pageview)도 함께 확인.
 - 확인 결과에 따라 M1에서 push 대상을 한쪽으로 통일. 코드만으로 판단 불가하므로 **작업 시작 전 사용자에게 확인 결과를 물어볼 것**.
 
-### 이슈 M1 — `src/analytics/` 모듈 도입 + 기존 이벤트 이관 (중형, ♻️)
+### 이슈 M1 — `src/analytics/` 모듈 도입 + 기존 이벤트 이관 (중형, ♻️) — ✅ 완료 (이슈 #73)
 
 **진단**
 - `window.dataLayer = window.dataLayer || []; push(...)` 보일러플레이트가 5개 파일에 복붙됨.

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -1,0 +1,82 @@
+import { decodeToken } from "../utils/tokenUtils";
+
+/**
+ * Matomo 데이터 레이어(window._mtm) 접근 유일 창구.
+ * - MTM 컨테이너는 `_mtm`만 push 래핑으로 상시 수신하므로(M0 조사, 이슈 #72)
+ *   모든 push는 이 파일을 통해 `_mtm`으로만 보낸다.
+ * - 컴포넌트는 이 파일을 직접 쓰지 않고 events.js의 트래커 함수만 호출한다.
+ */
+
+const getDataLayer = () => {
+  window._mtm = window._mtm || [];
+  return window._mtm;
+};
+
+/**
+ * 익명 사용자 식별용 UUID를 localStorage에서 조회하고, 없으면 생성해 저장한다.
+ * Matomo 유저 식별 전용 값으로 분석 레이어 밖에서는 사용하지 않는다.
+ */
+export const getOrCreateAnonymousId = () => {
+  let id = localStorage.getItem("anonymousId");
+  if (!id) {
+    id =
+      typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
+            (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
+          );
+    localStorage.setItem("anonymousId", id);
+  }
+  return id;
+};
+
+/**
+ * Matomo에 보낼 userId를 결정한다.
+ * 로그인 상태면 토큰의 sub(또는 loginId), 아니면 익명 UUID.
+ */
+export const getUserIdForMatomo = () => {
+  const token = localStorage.getItem("accessToken");
+  if (token) {
+    const payload = decodeToken(token);
+    if (payload) return payload.sub ?? payload.loginId ?? getOrCreateAnonymousId();
+  }
+  return getOrCreateAnonymousId();
+};
+
+/**
+ * 이벤트를 데이터 레이어에 push한다. 모든 이벤트 발화는 이 함수를 거친다.
+ * 공통 필드(isLoggedIn, userId)를 자동 주입하므로 호출부에서 조립하지 않는다.
+ * 트래킹 실패가 기능을 깨지 않도록 예외는 삼키고 console.error만 남긴다.
+ */
+export const pushEvent = (eventName, payload = {}) => {
+  try {
+    getDataLayer().push({
+      event: eventName,
+      isLoggedIn: !!localStorage.getItem("accessToken"),
+      userId: getUserIdForMatomo(),
+      ...payload,
+    });
+  } catch (e) {
+    console.error("analytics pushEvent 실패:", e);
+  }
+};
+
+/**
+ * 유저 속성(userId, nickname, gender, age, role 등)을 데이터 레이어에 push한다.
+ * 호출 위치: src/index.js(앱 부팅), src/sign/component/SignInPage.jsx(로그인 성공)
+ */
+export const setUserAttributes = (attributes) => {
+  try {
+    getDataLayer().push({ ...attributes });
+  } catch (e) {
+    console.error("analytics setUserAttributes 실패:", e);
+  }
+};
+
+/**
+ * 로그아웃 시 유저 속성을 익명 상태로 되돌린다.
+ * 호출 위치: 미연결 — 이슈 M2에서 Navbar 로그아웃에 연결 예정.
+ */
+export const resetUser = () => {
+  setUserAttributes({ userId: getOrCreateAnonymousId(), nickname: null, gender: null, age: null, role: "user" });
+};

--- a/src/analytics/events.js
+++ b/src/analytics/events.js
@@ -1,0 +1,110 @@
+import { pushEvent } from "./analytics";
+
+/**
+ * 이벤트 카탈로그.
+ * - 이벤트명은 반드시 이 상수로만 사용한다 (문자열 리터럴 금지).
+ * - 트래커 함수는 이벤트당 1개. 페이로드 조립은 전부 이 파일 안에서 하고,
+ *   호출부는 항상 1줄 호출만 한다.
+ * - 공통 필드(isLoggedIn, userId)는 pushEvent가 자동 주입하므로 여기서 넣지 않는다.
+ * - 값이 없으면 null을 보낸다 ("없음" 같은 매직 문자열 금지).
+ */
+export const EVENT_NAMES = {
+  MAIN_VIEW: "travel_main_view",
+  SEARCH_CLICK: "travel_search_click",
+  DETAIL_PAGEVIEW: "travel_detail_pageview",
+  DETAIL_EXIT: "travel_detail_exit",
+  FAVORITE_ADD: "travel_favorite_add",
+  FAVORITE_REMOVE: "travel_favorite_remove",
+  COMMENT_ADD: "travel_comment_add",
+  COMMENT_REMOVE: "travel_comment_remove",
+};
+
+/** 게시글 ID는 항상 number로 보낸다. 캐스팅 불가하면 null. */
+const toPostId = (value) => {
+  if (value === null || value === undefined || value === "") return null;
+  const n = Number(value);
+  return Number.isNaN(n) ? null : n;
+};
+
+/** 빈 문자열/undefined를 null로 통일한다. */
+const orNull = (value) => (value ? value : null);
+
+/** 게시글 계열 이벤트의 공통 페이로드. */
+const buildPostPayload = (post) => ({
+  postId: toPostId(post.postId),
+  category: orNull(post.category),
+  region: orNull(post.region),
+  title: orNull(post.title),
+});
+
+/**
+ * 메인 페이지 진입 시 1회 발화.
+ * 호출 위치: src/board/component/page/MainPage.jsx
+ * 페이로드: 없음 (visit_time·referrer는 Matomo 기본 수집과 중복이라 보내지 않는다)
+ */
+export const trackMainView = () => {
+  pushEvent(EVENT_NAMES.MAIN_VIEW);
+};
+
+/**
+ * 검색 버튼 클릭 시 발화.
+ * 호출 위치: src/post/components/PostSearch.jsx
+ * 페이로드: category(string|null), region(string|null)
+ */
+export const trackSearchClick = ({ category, region }) => {
+  pushEvent(EVENT_NAMES.SEARCH_CLICK, { category: orNull(category), region: orNull(region) });
+};
+
+/**
+ * 게시글 상세 데이터 로드 후 발화.
+ * 호출 위치: src/post/pages/PostDetailPage.jsx
+ * 페이로드: postId(number|null), category, region, title
+ */
+export const trackDetailPageview = (post) => {
+  pushEvent(EVENT_NAMES.DETAIL_PAGEVIEW, buildPostPayload(post));
+};
+
+/**
+ * 게시글 상세 이탈 시 발화 (effect cleanup).
+ * 호출 위치: src/post/pages/PostDetailPage.jsx
+ * 페이로드: postId(number|null), staySeconds(number), title
+ */
+export const trackDetailExit = ({ postId, staySeconds, title }) => {
+  pushEvent(EVENT_NAMES.DETAIL_EXIT, { postId: toPostId(postId), staySeconds, title: orNull(title) });
+};
+
+/**
+ * 찜 추가 성공 시 발화.
+ * 호출 위치: src/post/pages/PostDetailPage.jsx
+ * 페이로드: postId(number|null), category, region, title
+ */
+export const trackFavoriteAdd = (post) => {
+  pushEvent(EVENT_NAMES.FAVORITE_ADD, buildPostPayload(post));
+};
+
+/**
+ * 찜 삭제 성공 시 발화.
+ * 호출 위치: src/post/pages/PostDetailPage.jsx
+ * 페이로드: postId(number|null), category, region, title
+ */
+export const trackFavoriteRemove = (post) => {
+  pushEvent(EVENT_NAMES.FAVORITE_REMOVE, buildPostPayload(post));
+};
+
+/**
+ * 댓글 등록 시 발화.
+ * 호출 위치: src/comment/component/CommentPage.jsx
+ * 페이로드: postId(number|null), category, region, title
+ */
+export const trackCommentAdd = ({ postId, category, region, title }) => {
+  pushEvent(EVENT_NAMES.COMMENT_ADD, buildPostPayload({ postId, category, region, title }));
+};
+
+/**
+ * 댓글 삭제 성공 시 발화.
+ * 호출 위치: src/comment/component/CommentPage.jsx
+ * 페이로드: postId(number|null), category, region, title
+ */
+export const trackCommentRemove = ({ postId, category, region, title }) => {
+  pushEvent(EVENT_NAMES.COMMENT_REMOVE, buildPostPayload({ postId, category, region, title }));
+};

--- a/src/board/component/page/MainPage.jsx
+++ b/src/board/component/page/MainPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import PostSearch from "../../../post/components/PostSearch";
 import tgd3 from '../imgs/tgd3.jpg';
 import { subscribeRankings } from "../../../api/rankingApi";
+import { trackMainView } from "../../../analytics/events";
 
 import MainPageCardsLayout from "./MainPageCardsLayout";
 import MainPageCardsLayout2 from "./MainPageCardsLayout2";
@@ -13,12 +14,7 @@ const MainPage = () => {
   const [top5Category, setTop5Category] = useState([]);
 
   useEffect(() => {
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({
-      event: "travel_main_view",
-      visit_time: new Date().toISOString(),
-      referrer: document.referrer
-    });
+    trackMainView();
 
     const evt = subscribeRankings();
     evt.addEventListener("ranking-update", (e) => {

--- a/src/comment/component/CommentPage.jsx
+++ b/src/comment/component/CommentPage.jsx
@@ -2,6 +2,7 @@ import CommentList from "./CommentList";
 import WriteComment from "./WriteComment";
 import * as commentApi from "../../api/commentApi";
 import { useEffect, useState } from "react";
+import { trackCommentAdd, trackCommentRemove } from "../../analytics/events";
 
 function ConfirmModal({ show, type = "danger", message, onConfirm, onCancel }) {
     if (!show) return null;
@@ -47,8 +48,7 @@ const CommentPage = ({ no, isLoggedIn, ratingAvg, setCommentFlag, category, regi
                     setCommentList(prev => prev.filter((c) => c.commentId !== commentId));
                     const message = "댓글이 삭제되었습니다.";
                     setAlert({ show: true, message, type: "success" });
-                    window.dataLayer = window.dataLayer || [];
-                    window.dataLayer.push({ event: "travel_comment_remove", boardId: no, category, region, title });
+                    trackCommentRemove({ postId: no, category, region, title });
                     setCommentFlag?.(prev => !prev);
                 } catch (err) {
                     const message = err.response?.data?.message || "오류가 발생했습니다.";
@@ -59,8 +59,7 @@ const CommentPage = ({ no, isLoggedIn, ratingAvg, setCommentFlag, category, regi
     };
 
     const addComment = async ({ rating, comment }) => {
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({ event: "travel_comment_add", boardId: no, category, region, title });
+        trackCommentAdd({ postId: no, category, region, title });
         const payload = { postId: parseInt(no), content: comment, star: rating };
         try {
             const { data } = await commentApi.addComment(payload);

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ function insertMatomoScript() {
       _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
       (function() {
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.async=true; g.src='${process.env.REACT_APP_MATOMO_URL || 'http://localhost:9080'}/js/container_5uzHzMcX.js'; s.parentNode.insertBefore(g,s);
+        g.async=true; g.src='${process.env.REACT_APP_MATOMO_URL || 'http://localhost:9080'}/js/container_2yv5mH8U.js'; s.parentNode.insertBefore(g,s);
 
       })();
     `;

--- a/src/index.js
+++ b/src/index.js
@@ -13,17 +13,13 @@ import './css/comment.css';
 import './css/log.css';
 
 import App from './App';
-import { getUserIdForMatomo } from './utils/tokenUtils';
+import { setUserAttributes, getUserIdForMatomo } from './analytics/analytics';
 
 // 3. Matomo Tag Manager 스크립트 삽입 + 데이터레이어에 userId 전달
 function insertMatomoScript() {
   if (!document.getElementById('matomo-container-script')) {
-    // userId 결정
-    const userId = getUserIdForMatomo();
-
     // 데이터레이어에 userId 전달
-    window._mtm = window._mtm || [];
-    window._mtm.push({ userId, age: -1, role: "user" });
+    setUserAttributes({ userId: getUserIdForMatomo(), age: -1, role: "user" });
 
     // Matomo Tag Manager 스크립트 삽입
     const script = document.createElement('script');

--- a/src/post/components/PostSearch.jsx
+++ b/src/post/components/PostSearch.jsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import RegionRadioComp from "../../board/component/page/RegionRadioComp";
 import CategoryCard from "../../board/component/page/CategoryCard";
 import { autoCompleteSearch } from "../../api/postSearchApi";
+import { trackSearchClick } from "../../analytics/events";
 
 const PostSearch = ({ selectedCategory, selectedRegion }) => {
     const [post, setPost] = useState({ category: "", region: "" });
@@ -72,12 +73,7 @@ const PostSearch = ({ selectedCategory, selectedRegion }) => {
         if (post.category) params.append("category", post.category);
         if (post.region) params.append("region", post.region);
         if (keyword) params.append("keyword", keyword);
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({
-            event: "travel_search_click",
-            category: post.category ? post.category : "없음",
-            region: post.region ? post.region : "없음"
-        });
+        trackSearchClick({ category: post.category, region: post.region });
         navigate(`/post/list?${params.toString()}`);
     };
 

--- a/src/post/pages/PostDetailPage.jsx
+++ b/src/post/pages/PostDetailPage.jsx
@@ -7,6 +7,7 @@ import { useSearchParams, useNavigate, useLocation } from "react-router-dom";
 import CommentPage from "../../comment/component/CommentPage";
 import useAlert from "../../hooks/useAlert";
 import PostContent from "../components/PostContent";
+import { trackFavoriteAdd, trackFavoriteRemove, trackDetailPageview, trackDetailExit } from "../../analytics/events";
 
 const PostDetailPage = () => {
   const enterTime = useRef(Date.now());
@@ -36,14 +37,12 @@ const PostDetailPage = () => {
       if (liked) {
         await deleteLike(Number(no));
         setLiked(false);
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({ event: "travel_favorite_remove", postId: no, category: post.category, region: post.region, title: post.title });
+        trackFavoriteRemove(post);
         showAlert("찜 목록에서 삭제되었습니다.", "danger");
       } else {
         await addLike(Number(no));
         setLiked(true);
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({ event: "travel_favorite_add", postId: no, category: post.category, region: post.region, title: post.title });
+        trackFavoriteAdd(post);
         showAlert("찜 목록에 추가되었습니다.", "success");
       }
     } catch {
@@ -79,26 +78,13 @@ const PostDetailPage = () => {
     return () => {
       const leaveTime = Date.now();
       const stayDuration = Math.floor((leaveTime - enterTime.current) / 1000);
-      window.dataLayer = window.dataLayer || [];
-      window.dataLayer.push({
-        event: "travel_detail_exit",
-        postId: no,
-        staySeconds: stayDuration,
-        title: post.title
-      });
+      trackDetailExit({ postId: no, staySeconds: stayDuration, title: post.title });
     };
   }, [no, liked, commentFlag]);
 
   useEffect(() => {
     if (post && post.category && post.region) {
-      window.dataLayer = window.dataLayer || [];
-      window.dataLayer.push({
-        event: "travel_detail_pageview",
-        postId: no,
-        category: post.category,
-        region: post.region,
-        title: post.title
-      });
+      trackDetailPageview(post);
     }
   }, [post, no]);
 

--- a/src/sign/component/SignInPage.jsx
+++ b/src/sign/component/SignInPage.jsx
@@ -4,6 +4,7 @@ import { getMyProfile } from '../../api/memberApi';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { isAdmin } from '../../utils/tokenUtils';
+import { setUserAttributes } from '../../analytics/analytics';
 import useAlert from '../../hooks/useAlert';
 
 const SignInPage = () => {
@@ -28,8 +29,7 @@ const SignInPage = () => {
             const { data: profileRes } = await getMyProfile();
             const member = profileRes.result ?? profileRes;
             localStorage.setItem('nickname', member.nickname);
-            window._mtm = window._mtm || [];
-            window._mtm.push({
+            setUserAttributes({
                 nickname: member.nickname,
                 gender: member.gender,
                 age: member.age,

--- a/src/utils/tokenUtils.js
+++ b/src/utils/tokenUtils.js
@@ -19,26 +19,3 @@ export const isAdmin = (token) => {
   const payload = decodeToken(resolved);
   return payload?.roles?.includes("ROLE_ADMIN") ?? false;
 };
-
-export const getOrCreateAnonymousId = () => {
-  let id = localStorage.getItem("anonymousId");
-  if (!id) {
-    id =
-      typeof crypto !== "undefined" && crypto.randomUUID
-        ? crypto.randomUUID()
-        : ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
-            (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
-          );
-    localStorage.setItem("anonymousId", id);
-  }
-  return id;
-};
-
-export const getUserIdForMatomo = () => {
-  const token = localStorage.getItem("accessToken");
-  if (token) {
-    const payload = decodeToken(token);
-    if (payload) return payload.sub ?? payload.loginId ?? getOrCreateAnonymousId();
-  }
-  return getOrCreateAnonymousId();
-};


### PR DESCRIPTION
## 관련 이슈
closes #73

## 변경 사항
- `src/analytics/analytics.js` 신규 — 데이터 레이어 접근 유일 창구. `pushEvent`(공통 필드 `isLoggedIn`/`userId` 자동 주입, 예외 삼키고 console.error), `setUserAttributes`, `resetUser`(M2에서 로그아웃에 연결 예정)
- `src/analytics/events.js` 신규 — `EVENT_NAMES` 상수 + 트래커 함수 8개(JSDoc: 발화 시점/호출 위치/페이로드)
- 발화 지점 6곳을 트래커 1줄 호출로 교체: MainPage, PostSearch, PostDetailPage(3곳), CommentPage(2곳), SignInPage, index.js
- **push 대상 `window.dataLayer` → `window._mtm` 통일** (M0 #72 결론: 컨테이너는 `_mtm`만 상시 수신)
- 분석 전용 로직(`getUserIdForMatomo`, `getOrCreateAnonymousId`)을 `tokenUtils.js` → `analytics.js`로 이동 (토큰 디코딩은 tokenUtils 유지)
- CLAUDE.md 이벤트 카탈로그 표 갱신
- (선행 커밋) M0 후속으로 컨테이너 파일명 `container_2yv5mH8U.js` 교체 반영

## ⚠️ 이벤트 스키마 변경 (Matomo 대시보드/세그먼트 후속 조치 필요)
| 이벤트 | 변경 |
|---|---|
| 전체 | push 대상 `dataLayer` → `_mtm`, 공통 필드 `isLoggedIn`(boolean)·`userId` 추가 |
| `travel_main_view` | `visit_time`, `referrer` 제거 (Matomo 기본 수집과 중복) |
| `travel_search_click` | 빈 값 `"없음"` → `null` |
| `travel_comment_add/_remove` | `boardId` → `postId` |
| postId 전체 | 문자열 → number 통일, 캐스팅 불가 시 `null` |

## 작업 방법
- 이벤트명은 문자열 리터럴 금지, `EVENT_NAMES` 상수로만 사용
- 페이로드 조립은 전부 `events.js` 내부(`buildPostPayload`, `toPostId`, `orNull`) — 이벤트에 필드 추가 시 events.js 함수 1개만 수정하면 되는 구조
- 발화 타이밍은 기존과 동일하게 보존 (찜/댓글 시 pageview·exit 재발화 버그는 M2 범위)

## 테스트
- `react-scripts build` 통과 (신규 경고 없음)
- Playwright + API 목킹으로 빌드 앱 구동, `window._mtm` 페이로드 캡처 — 8개 이벤트 전부 발화·스키마 확인

<details><summary>페이로드 캡처 (Phase A: 비로그인)</summary>

```json
[
  { "userId": "b5d27d17-e73c-4602-9398-e50c9f8891a5", "age": -1, "role": "user" },
  { "mtm.startTime": 1783368067984, "event": "mtm.Start" },
  { "event": "travel_main_view", "isLoggedIn": false, "userId": "b5d27d17-…" },
  { "event": "travel_search_click", "isLoggedIn": false, "userId": "b5d27d17-…", "category": null, "region": null }
]
```
</details>

<details><summary>페이로드 캡처 (Phase B: 로그인, 상세 페이지 — 발췌)</summary>

```json
[
  { "userId": "tester1", "age": -1, "role": "user" },
  { "event": "travel_detail_pageview", "isLoggedIn": true, "userId": "tester1", "postId": 42, "category": "맛집", "region": "서울", "title": "테스트 글" },
  { "event": "travel_favorite_add", "isLoggedIn": true, "userId": "tester1", "postId": 42, "category": "맛집", "region": "서울", "title": "테스트 글" },
  { "event": "travel_detail_exit", "isLoggedIn": true, "userId": "tester1", "postId": 42, "staySeconds": 0, "title": null },
  { "event": "travel_favorite_remove", "isLoggedIn": true, "userId": "tester1", "postId": 42, "category": "맛집", "region": "서울", "title": "테스트 글" },
  { "event": "travel_comment_add", "isLoggedIn": true, "userId": "tester1", "postId": 42, "category": "맛집", "region": "서울", "title": "테스트 글" },
  { "event": "travel_comment_remove", "isLoggedIn": true, "userId": "tester1", "postId": 42, "category": "맛집", "region": "서울", "title": "테스트 글" },
  { "event": "travel_detail_exit", "isLoggedIn": true, "userId": "tester1", "postId": 42, "staySeconds": 0, "title": "테스트 글" }
]
```
> 찜/댓글 상호작용마다 `travel_detail_pageview`/`travel_detail_exit`가 재발화되는 현상도 캡처에서 재현됨 — 기존 버그로, M2에서 수정 예정 (M1은 발화 타이밍 불변 원칙).
</details>

> ✅ 컨테이너(2yv5mH8U) v1.0.2 재게시 후 E2E 재검증 완료 (2026-07-07): travel_* 이벤트 8종 전부 Matomo(matomo.php) 도달 확인. uid(익명 UUID/토큰 sub)·커스텀 디멘션(postId/category/region/title/userId/isLoggedIn/role) 정상 수신, staySeconds는 dim5+detail_exit eventValue로 매핑됨. 참고: MTM 데이터 레이어 변수는 falsy 값(isLoggedIn=false, staySeconds=0)을 생략하므로 해당 디멘션은 빈 값으로 기록됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)