### PR TITLE
🐛 Fix: Matomo 트래킹 버그 수정 — 상세 pageview/exit 중복 발화·userId 미갱신 (M2)

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: verify
+description: Matomo 트래킹 변경을 프로덕션 빌드 + Playwright로 E2E 검증하고 window._mtm 페이로드를 캡처하는 레시피
+---
+
+# 트래킹 변경 검증 레시피
+
+빌드된 앱을 실제 브라우저로 구동해 `window._mtm` push 내용을 캡처한다. 유닛 테스트/typecheck가 아니라 런타임 관찰이 목적.
+
+## 절차
+
+```bash
+npm run build                      # 프로덕션 빌드 (StrictMode 이중 effect 없음)
+npx serve -s build -l 3999         # SPA fallback 포함 정적 서빙 (백그라운드)
+# 스크래치패드 등 별도 디렉토리에 npm i playwright 후 node <캡처 스크립트>
+```
+
+## 캡처 스크립트 핵심 (Playwright)
+
+- **API 목킹**: `page.route('**/api/**', ...)`로 전부 가로채고 공통 래퍼 `{success, code, message, result}`로 응답.
+- **CORS 주의**: `src/api/client.js`가 `withCredentials: true`라서 와일드카드 `*` 불가. 목 응답에 반드시:
+  `Access-Control-Allow-Origin: http://localhost:3999`, `Access-Control-Allow-Credentials: true`,
+  `Allow-Headers: Authorization, Content-Type`, OPTIONS 프리플라이트 204 처리, 로그인 검증 시 `Access-Control-Expose-Headers: Authorization`.
+- **로그인 상태**: 가짜 JWT(`alg:none`, base64url 헤더.페이로드.x, `sub` = userId)를 `addInitScript`로 localStorage `accessToken`에 주입. 로그인 플로우 검증은 `/api/v1/auth/login` 목이 `Authorization: Bearer <JWT>` 헤더로 응답.
+- **MTM 컨테이너 스텁**: `page.route('**/js/container_*.js')`를 빈 JS로 fulfill → `_mtm`이 순수 배열로 남아 push 내용을 그대로 검사 가능. (localhost:9080에 실제 Matomo가 떠 있으면 스텁 없이는 push가 소비됨)
+- **덤프**: `page.evaluate(() => window._mtm.filter(x => !x['mtm.startTime']))`
+- **`page.goto`는 전체 리로드라 `_mtm`이 초기화됨** — 발화 횟수를 누적 검사하려면 SPA 내비게이션(`page.goBack()`, 링크/버튼 클릭)으로 이동할 것.
+- **getMyLikes 목은 stateful하게** (`state.liked` 토글) — 아니면 찜 두 번째 클릭이 favorite_remove로 발화되지 않음.
+
+## 주요 셀렉터/경로
+
+- 상세: `/post/detail?no=<id>` (목: `/api/v1/search/posts/<id>`), 찜 버튼 `.favorite-btn`, 목록 이동 FAB `.post-detail-fab`
+- 댓글: `#comment` textarea, 별점 `.comment-write-star >> nth=N`, `button:has-text("작성하기")`
+- 로그인: `/sign/component/SignInPage`, `#loginId`/`#password`, 성공 시 `/`로 이동
+- 로그아웃: 네비 토글 `.nav-toggler` → `로그아웃` 링크
+- 참고 스크립트 원본: M2 PR(#76 근처) 본문 및 이전 세션 scratchpad `capture-mtm-m2.js`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,12 +65,13 @@ src/analytics/
 
 ## 이벤트 카탈로그
 
-### 유저 식별/속성 (M1에서 `analytics.js`의 `setUserAttributes` 경유로 이관 완료)
+### 유저 식별/속성 (M1에서 `analytics.js`의 `setUserAttributes` 경유로 이관, M2에서 userId 갱신/리셋 연결 완료)
 
 | 데이터 | 시점 | 호출 위치 | 필드 |
 |---|---|---|---|
 | userId (토큰 sub 또는 익명 UUID), age, role | 앱 부팅 1회 | `src/index.js` | userId, age(-1 고정), role — 매직 값은 M3에서 정리 |
-| 로그인 유저 속성 | 로그인 성공 | `src/sign/component/SignInPage.jsx` | nickname, gender, age, role — **userId 미갱신 (버그, M2)** |
+| 로그인 유저 속성 (`setLoggedInUserAttributes`) | 로그인 성공 | `src/sign/component/SignInPage.jsx` | userId(토큰 식별자로 전환), gender, ageGroup(연령대 구간, 예: "20대"), role — **개인정보 방침(M2 결정): nickname·age 원값 미전송** |
+| 유저 속성 리셋 (`resetUser`) | 로그아웃 | `src/common/Navbar.jsx` | userId(익명 UUID로 복귀), gender/ageGroup null, role "user" |
 
 ### 현재 이벤트 (M1에서 `events.js` 트래커 → `_mtm` push로 이관 완료, 이슈 #73)
 
@@ -78,8 +79,8 @@ src/analytics/
 |---|---|---|---|---|
 | `travel_main_view` | 메인 페이지 진입 | `trackMainView` / `src/board/component/page/MainPage.jsx` | (공통 필드만) | — |
 | `travel_search_click` | 검색 버튼 클릭 | `trackSearchClick` / `src/post/components/PostSearch.jsx` | category, region (빈 값 null) | keyword 미수집 (M4) |
-| `travel_detail_pageview` | 상세 데이터 로드 후 | `trackDetailPageview` / `src/post/pages/PostDetailPage.jsx` | postId(number), category, region, title | 찜/댓글 시마다 재발화 — 중복 집계 (M2) |
-| `travel_detail_exit` | 상세 이탈 (effect cleanup) | `trackDetailExit` / `src/post/pages/PostDetailPage.jsx` | postId(number), staySeconds, title | deps `[no, liked, commentFlag]` → 찜/댓글마다 발화, staySeconds 왜곡 (M2) |
+| `travel_detail_pageview` | 상세 데이터 로드 후 (postId당 1회 가드) | `trackDetailPageview` / `src/post/pages/PostDetailPage.jsx` | postId(number), category, region, title | — (M2에서 중복 발화 수정) |
+| `travel_detail_exit` | 상세 이탈 (effect cleanup + `pagehide` 보완) | `trackDetailExit` / `src/post/pages/PostDetailPage.jsx` | postId(number), staySeconds, title | — (M2에서 과다 발화·staySeconds 왜곡 수정) |
 | `travel_favorite_add` / `_remove` | 찜 토글 | `trackFavoriteAdd` / `trackFavoriteRemove` / `src/post/pages/PostDetailPage.jsx` | postId(number), category, region, title | — |
 | `travel_comment_add` / `_remove` | 댓글 등록/삭제 | `trackCommentAdd` / `trackCommentRemove` / `src/comment/component/CommentPage.jsx` | postId(number), category, region, title | star(별점) 미수집 (M4) |
 
@@ -125,7 +126,9 @@ src/analytics/
 - 이 과정에서 스키마 통일(boardId→postId, Number 캐스팅, null 처리, 중복 필드 제거).
 - `getUserIdForMatomo` 등 분석 전용 로직은 `tokenUtils.js`에서 `analytics.js`로 이동 검토 (토큰 디코딩 자체는 tokenUtils에 유지).
 
-### 이슈 M2 — 트래킹 버그 수정 (소형, 🐛)
+### 이슈 M2 — 트래킹 버그 수정 (소형, 🐛) — ✅ 완료 (이슈 #75)
+
+> 결과: exit 추적을 `no`만 의존하는 별도 effect로 분리(+`pagehide`/`pageshow` 보완), pageview는 ref로 postId당 1회 가드. 로그인 시 `setLoggedInUserAttributes`(userId 포함), 로그아웃 시 `resetUser` 연결. 개인정보 방침 결정: nickname 미전송, age는 `ageGroup` 연령대 구간("20대" 등)으로 변환 전송. Heartbeat Timer는 컨테이너 설정 이슈로 미포함.
 
 **진단**
 - `travel_detail_exit`: `PostDetailPage.jsx` useEffect deps가 `[no, liked, commentFlag]` → 찜 토글/댓글마다 cleanup 실행되어 이탈이 아닌데 발화, `enterTime`도 리셋되어 staySeconds가 "마지막 상호작용 후 경과 시간"이 됨. 체류시간 데이터 신뢰 불가.

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -62,8 +62,8 @@ export const pushEvent = (eventName, payload = {}) => {
 };
 
 /**
- * 유저 속성(userId, nickname, gender, age, role 등)을 데이터 레이어에 push한다.
- * 호출 위치: src/index.js(앱 부팅), src/sign/component/SignInPage.jsx(로그인 성공)
+ * 유저 속성(userId, gender, ageGroup, role 등)을 데이터 레이어에 push한다.
+ * 호출 위치: src/index.js(앱 부팅), 로그인/로그아웃은 아래 setLoggedInUserAttributes/resetUser 경유
  */
 export const setUserAttributes = (attributes) => {
   try {
@@ -74,9 +74,34 @@ export const setUserAttributes = (attributes) => {
 };
 
 /**
+ * 나이 원값을 연령대 구간 문자열로 변환한다. (개인정보 최소화 — 원값은 보내지 않는다)
+ * 예: 27 → "20대". 60 이상은 "60대 이상", 10 미만·비정상 값은 null.
+ */
+const toAgeGroup = (age) => {
+  const n = Number(age);
+  if (!Number.isFinite(n) || n < 10) return null;
+  const decade = Math.floor(n / 10) * 10;
+  return decade >= 60 ? "60대 이상" : `${decade}대`;
+};
+
+/**
+ * 로그인 성공 시 유저 속성을 갱신한다. userId를 익명 UUID → 토큰 식별자로 전환한다.
+ * 개인정보 최소화 방침(M2 결정): nickname은 보내지 않고, age는 연령대 구간(ageGroup)으로 변환한다.
+ * 호출 위치: src/sign/component/SignInPage.jsx (accessToken 저장 이후에 호출해야 userId가 갱신된다)
+ */
+export const setLoggedInUserAttributes = ({ gender, age, role }) => {
+  setUserAttributes({
+    userId: getUserIdForMatomo(),
+    gender: gender || null,
+    ageGroup: toAgeGroup(age),
+    role,
+  });
+};
+
+/**
  * 로그아웃 시 유저 속성을 익명 상태로 되돌린다.
- * 호출 위치: 미연결 — 이슈 M2에서 Navbar 로그아웃에 연결 예정.
+ * 호출 위치: src/common/Navbar.jsx (handleLogout)
  */
 export const resetUser = () => {
-  setUserAttributes({ userId: getOrCreateAnonymousId(), nickname: null, gender: null, age: null, role: "user" });
+  setUserAttributes({ userId: getOrCreateAnonymousId(), gender: null, ageGroup: null, role: "user" });
 };

--- a/src/common/Navbar.jsx
+++ b/src/common/Navbar.jsx
@@ -2,6 +2,7 @@ import { Button } from 'react-bootstrap';
 import { useEffect, useState } from "react";
 import { useNavigate, Link } from 'react-router-dom';
 import { logout } from "../api/authApi";
+import { resetUser } from "../analytics/analytics";
 import UserAuthentication from '../sign/service/UserAuthentication';
 import { toast } from 'react-toastify';
 import useAlert from '../hooks/useAlert';
@@ -21,6 +22,7 @@ const Navbar = () => {
       await logout();
       localStorage.removeItem('accessToken');
       localStorage.removeItem('nickname');
+      resetUser();
       toast.info("로그아웃 되었습니다.");
       handleClose();
       navigate("/");

--- a/src/post/pages/PostDetailPage.jsx
+++ b/src/post/pages/PostDetailPage.jsx
@@ -11,6 +11,8 @@ import { trackFavoriteAdd, trackFavoriteRemove, trackDetailPageview, trackDetail
 
 const PostDetailPage = () => {
   const enterTime = useRef(Date.now());
+  const titleRef = useRef(''); // exit 발화 시점의 최신 제목 (cleanup 클로저의 stale 값 방지)
+  const lastPageviewPostId = useRef(null); // pageview 중복 발화 가드 (postId당 1회)
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const no = searchParams.get('no');
@@ -65,6 +67,7 @@ const PostDetailPage = () => {
     try {
       const { data } = await getPost(no);
       const post = data.result;
+      titleRef.current = post.title;
       setPost({ ...post, images: post.images || [] });
     } catch {
       showAlert("게시글을 불러오지 못했습니다.", "danger");
@@ -74,19 +77,33 @@ const PostDetailPage = () => {
   useEffect(() => {
     loadPost();
     getLike();
-    enterTime.current = Date.now();
-    return () => {
-      const leaveTime = Date.now();
-      const stayDuration = Math.floor((leaveTime - enterTime.current) / 1000);
-      trackDetailExit({ postId: no, staySeconds: stayDuration, title: post.title });
-    };
   }, [no, liked, commentFlag]);
 
+  // 이탈 추적: no에만 의존해 실제 상세 진입/이탈 시에만 발화 (찜/댓글 상호작용에는 반응하지 않음)
   useEffect(() => {
-    if (post && post.category && post.region) {
+    enterTime.current = Date.now();
+    const fireExit = () => {
+      const staySeconds = Math.floor((Date.now() - enterTime.current) / 1000);
+      trackDetailExit({ postId: no, staySeconds, title: titleRef.current });
+    };
+    const handlePagehide = () => fireExit(); // 탭 닫기/외부 이동은 cleanup이 실행되지 않으므로 보완 발화
+    const handlePageshow = () => { enterTime.current = Date.now(); }; // bfcache 복귀 시 체류시간 재시작
+    window.addEventListener('pagehide', handlePagehide);
+    window.addEventListener('pageshow', handlePageshow);
+    return () => {
+      window.removeEventListener('pagehide', handlePagehide);
+      window.removeEventListener('pageshow', handlePageshow);
+      fireExit();
+    };
+  }, [no]);
+
+  // 진입 추적: loadPost 재실행마다 재발화하지 않도록 postId당 1회만 발화
+  useEffect(() => {
+    if (post.postId && lastPageviewPostId.current !== post.postId) {
+      lastPageviewPostId.current = post.postId;
       trackDetailPageview(post);
     }
-  }, [post, no]);
+  }, [post]);
 
   const nickname = localStorage.getItem("nickname");
   const isLoggedIn = !!localStorage.getItem('accessToken');

--- a/src/sign/component/SignInPage.jsx
+++ b/src/sign/component/SignInPage.jsx
@@ -4,7 +4,7 @@ import { getMyProfile } from '../../api/memberApi';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { isAdmin } from '../../utils/tokenUtils';
-import { setUserAttributes } from '../../analytics/analytics';
+import { setLoggedInUserAttributes } from '../../analytics/analytics';
 import useAlert from '../../hooks/useAlert';
 
 const SignInPage = () => {
@@ -29,8 +29,7 @@ const SignInPage = () => {
             const { data: profileRes } = await getMyProfile();
             const member = profileRes.result ?? profileRes;
             localStorage.setItem('nickname', member.nickname);
-            setUserAttributes({
-                nickname: member.nickname,
+            setLoggedInUserAttributes({
                 gender: member.gender,
                 age: member.age,
                 role: isAdmin(accessToken) ? "admin" : "user"


### PR DESCRIPTION
## 관련 이슈
closes #75

## 변경 사항
- **travel_detail_exit 과다 발화 수정** — 이탈 추적을 `no`에만 의존하는 별도 effect로 분리. 찜 토글/댓글 등록·삭제 시 cleanup이 더 이상 실행되지 않아 상호작용마다 발화되던 exit와 enterTime 리셋(staySeconds 왜곡)이 사라짐. 데이터 리로드 effect는 기존 deps `[no, liked, commentFlag]` 그대로 유지(찜/댓글 후 카운트 갱신 — 기능 불변).
- **travel_detail_exit 보완** — SPA cleanup이 못 잡는 탭 닫기/외부 이동은 `pagehide` 리스너로 발화, bfcache 복귀는 `pageshow`에서 enterTime 재시작.
- **travel_detail_pageview 중복 집계 수정** — 마지막 발화 postId를 ref로 기억해 postId당 1회만 발화. loadPost 재실행(찜/댓글)마다 재발화하던 문제 해소. (기존 `category && region` 조건 대신 `postId` 존재로 가드 — category/region이 없는 글도 pageview가 집계됨)
- **userId 미갱신 수정** — 로그인 성공 시 `setLoggedInUserAttributes`가 userId를 익명 UUID → 토큰 sub로 전환. 로그아웃(Navbar) 시 `resetUser`로 익명 상태 복귀.
- **개인정보 최소화 (사용자 결정 사항)** — 로그인 유저 속성에서 nickname 전송 중단, age 원값 대신 연령대 구간 `ageGroup`("20대", "60대 이상", 10세 미만·비정상 값은 null) 전송.
- CLAUDE.md 이벤트 카탈로그 동기화 + 트래킹 검증 레시피를 `.claude/skills/verify/SKILL.md`로 문서화.

## ⚠️ 스키마 변경 (Matomo 대시보드/세그먼트 후속 조치 필요)
| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| 로그인 유저 속성 | nickname, gender, age, role | **userId**, gender, **ageGroup**, role (nickname·age 제거) |
| 로그아웃 | push 없음 | userId(익명 UUID), gender/ageGroup null, role "user" push 추가 |
| detail_pageview/exit 발화량 | 상호작용마다 재발화 | 진입/이탈당 1회 — **집계량이 크게 줄어드는 것이 정상** |
| detail_exit staySeconds | 마지막 상호작용 후 경과 시간 | 실제 체류시간 |

## 작업 방법
- `PostDetailPage.jsx`: exit용 effect(deps `[no]`) 신설, 최신 title은 ref로 전달(클로저 stale 방지), pageview는 `lastPageviewPostId` ref 가드.
- `analytics.js`: `setLoggedInUserAttributes`(userId 자동 포함 + toAgeGroup 구간화) 신설, `resetUser` 갱신. 구간화 로직은 분석 레이어 안에만 존재 — 화면 코드는 원값을 넘기기만 함.

## 테스트 (프로덕션 빌드 + Playwright, API 목킹 후 window._mtm 캡처 — 19/19 통과)
- ✅ 찜 추가/취소 + 댓글 등록 3회 상호작용 동안 detail_pageview 1회, detail_exit 0회 (favorite_add/remove·comment_add는 정상 발화)
- ✅ 목록 이동 시 exit 1회, staySeconds=4 (총 체류 ≈5s 반영 — 상호작용으로 리셋 안 됨):
```json
{"event":"travel_detail_exit","isLoggedIn":true,"userId":"tester1","postId":101,"staySeconds":4,"title":"M2 검증용 글"}
```
- ✅ 뒤로가기 재진입 시 pageview 재발화(방문 단위 집계 유지), pagehide 디스패치 시 exit 발화, pageshow 후 체류시간 재시작
- ✅ 로그인(age 27) push — nickname·age 원값 없음:
```json
{"userId":"tester1","gender":"M","ageGroup":"20대","role":"user"}
```
- ✅ 로그아웃 push: `{"userId":"<익명 UUID>","gender":null,"ageGroup":null,"role":"user"}`
- ✅ 경계값 프로브: age 65 → "60대 이상", age 9 → null

🤖 Generated with [Claude Code](https://claude.com/claude-code)
