### PR TITLE
📦 Chore: [M3] Matomo 하드코딩 제거 + 스크립트 삽입 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 REACT_APP_API_BASE_URL=http://localhost:8000
 REACT_APP_IMAGE_BASE_URL=https://tripnow-bucket.s3.ap-northeast-2.amazonaws.com
 REACT_APP_MATOMO_URL=http://localhost:9080
+# MTM 컨테이너 ID (예: container_2yv5mH8U) — 미설정 시 컨테이너 삽입이 스킵됨
+REACT_APP_MATOMO_CONTAINER_ID=container_2yv5mH8U
 
 # 앱
 REACT_APP_APP_NAME=TripNow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,11 +65,11 @@ src/analytics/
 
 ## 이벤트 카탈로그
 
-### 유저 식별/속성 (M1에서 `analytics.js`의 `setUserAttributes` 경유로 이관, M2에서 userId 갱신/리셋 연결 완료)
+### 유저 식별/속성 (M1에서 `analytics.js`의 `setUserAttributes` 경유로 이관, M2에서 userId 갱신/리셋 연결, M3에서 부팅 push 정리 완료)
 
 | 데이터 | 시점 | 호출 위치 | 필드 |
 |---|---|---|---|
-| userId (토큰 sub 또는 익명 UUID), age, role | 앱 부팅 1회 | `src/index.js` | userId, age(-1 고정), role — 매직 값은 M3에서 정리 |
+| userId (토큰 sub 또는 익명 UUID) — `initAnalytics` 내부 | 앱 부팅 1회 (컨테이너 삽입 직전) | `src/analytics/analytics.js` (호출: `src/index.js`) | userId만 — gender/ageGroup/role은 부팅 시점에 알 수 없어 미전송 (M3에서 age -1·role "user" 매직 값 제거) |
 | 로그인 유저 속성 (`setLoggedInUserAttributes`) | 로그인 성공 | `src/sign/components/SignInPage.jsx` | userId(토큰 식별자로 전환), gender, ageGroup(연령대 구간, 예: "20대"), role — **개인정보 방침(M2 결정): nickname·age 원값 미전송** |
 | 유저 속성 리셋 (`resetUser`) | 로그아웃 | `src/common/Navbar.jsx` | userId(익명 UUID로 복귀), gender/ageGroup null, role "user" |
 
@@ -140,7 +140,9 @@ src/analytics/
 - pageview는 postId 기준 1회 발화 가드(ref로 마지막 발화 postId 기억).
 - 로그인 성공 시 `setUserAttributes`(userId 포함), 로그아웃 시 `resetUser` 호출. nickname·gender·age 원값 전송은 개인정보 관점에서 재검토(연령대 구간화 등) 후 결정.
 
-### 이슈 M3 — 하드코딩 제거 + 스크립트 삽입 정리 (소형, 📦)
+### 이슈 M3 — 하드코딩 제거 + 스크립트 삽입 정리 (소형, 📦) — ✅ 완료 (이슈 #79)
+
+> 결과: 컨테이너 삽입 로직을 `analytics.js`의 `initAnalytics()`로 이동(`index.js`는 1줄 호출), `innerHTML` 주입 → `script.src` 직접 설정으로 전환. `REACT_APP_MATOMO_CONTAINER_ID` env 도입, fallback URL 제거(env 미설정 시 삽입 스킵 + console.error). 부팅 push의 `age: -1`·`role: "user"` 매직 값 제거(userId만 전송).
 
 **진단**
 - `index.js`에 컨테이너 파일명 `container_5uzHzMcX.js`과 fallback `http://localhost:9080` 하드코딩. 스크립트를 `innerHTML` 문자열로 주입(불필요한 간접 실행).
@@ -257,7 +259,7 @@ REACT_APP_IMAGE_BASE_URL=<이미지 베이스 URL>
 
 # Matomo
 REACT_APP_MATOMO_URL=http://localhost:9080
-REACT_APP_MATOMO_CONTAINER_ID=<MTM 컨테이너 ID>   # 예) container_5uzHzMcX (M3에서 도입)
+REACT_APP_MATOMO_CONTAINER_ID=<MTM 컨테이너 ID>   # 예) container_2yv5mH8U — 미설정 시 컨테이너 삽입 스킵 (M3에서 도입, fallback 없음)
 
 # 앱
 REACT_APP_APP_NAME=TripNow

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -105,3 +105,38 @@ export const setLoggedInUserAttributes = ({ gender, age, role }) => {
 export const resetUser = () => {
   setUserAttributes({ userId: getOrCreateAnonymousId(), gender: null, ageGroup: null, role: "user" });
 };
+
+/**
+ * 앱 부팅 시 1회 호출: 유저 식별(userId) push 후 MTM 컨테이너 스크립트를 삽입한다.
+ * 컨테이너 주소는 REACT_APP_MATOMO_URL + REACT_APP_MATOMO_CONTAINER_ID 환경변수로만 결정하며,
+ * 둘 중 하나라도 없으면 삽입을 건너뛰고 console.error만 남긴다 (트래킹 실패가 기능을 깨지 않는다).
+ * gender/ageGroup/role은 부팅 시점에 알 수 없으므로 보내지 않는다 — 로그인 시 setLoggedInUserAttributes가 채운다.
+ * 호출 위치: src/index.js
+ */
+export const initAnalytics = () => {
+  try {
+    if (document.getElementById("matomo-container-script")) return;
+
+    // 컨테이너 로드 전에 큐에 넣어 첫 이벤트부터 userId가 실리게 한다.
+    setUserAttributes({ userId: getUserIdForMatomo() });
+
+    const matomoUrl = process.env.REACT_APP_MATOMO_URL;
+    const containerId = process.env.REACT_APP_MATOMO_CONTAINER_ID;
+    if (!matomoUrl || !containerId) {
+      console.error(
+        "analytics initAnalytics: REACT_APP_MATOMO_URL / REACT_APP_MATOMO_CONTAINER_ID 환경변수가 없어 MTM 컨테이너를 삽입하지 않습니다."
+      );
+      return;
+    }
+
+    getDataLayer().push({ "mtm.startTime": new Date().getTime(), event: "mtm.Start" });
+
+    const script = document.createElement("script");
+    script.id = "matomo-container-script";
+    script.async = true;
+    script.src = `${matomoUrl}/js/${containerId}.js`;
+    document.body.appendChild(script);
+  } catch (e) {
+    console.error("analytics initAnalytics 실패:", e);
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -13,32 +13,9 @@ import './css/comment.css';
 import './css/log.css';
 
 import App from './App';
-import { setUserAttributes, getUserIdForMatomo } from './analytics/analytics';
+import { initAnalytics } from './analytics/analytics';
 
-// 3. Matomo Tag Manager 스크립트 삽입 + 데이터레이어에 userId 전달
-function insertMatomoScript() {
-  if (!document.getElementById('matomo-container-script')) {
-    // 데이터레이어에 userId 전달
-    setUserAttributes({ userId: getUserIdForMatomo(), age: -1, role: "user" });
-
-    // Matomo Tag Manager 스크립트 삽입
-    const script = document.createElement('script');
-    script.id = 'matomo-container-script';
-    script.innerHTML = `
-      _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
-      (function() {
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.async=true; g.src='${process.env.REACT_APP_MATOMO_URL || 'http://localhost:9080'}/js/container_2yv5mH8U.js'; s.parentNode.insertBefore(g,s);
-
-      })();
-    `;
-    document.body.appendChild(script);
-  }
-}
-
-
-// index.js에서 최초 1회만 실행!
-insertMatomoScript();
+initAnalytics();
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## 관련 이슈
closes #79

## 변경 사항
- MTM 컨테이너 삽입 로직을 `src/index.js` → `src/analytics/analytics.js`의 `initAnalytics()`로 이동 (분석 코드 단일 레이어 원칙). `index.js`는 `initAnalytics()` 1줄 호출만 남음.
- `innerHTML` 문자열 주입 제거 — `document.createElement('script')` + `script.src` 직접 설정(async)으로 전환.
- `REACT_APP_MATOMO_CONTAINER_ID` 환경변수 도입 — 컨테이너 파일명 `container_2yv5mH8U.js` 하드코딩 제거, `.env.example` 갱신.
- fallback URL(`http://localhost:9080`) 제거 — `REACT_APP_MATOMO_URL` / `REACT_APP_MATOMO_CONTAINER_ID` 중 하나라도 없으면 컨테이너 삽입을 스킵하고 `console.error`만 남김 (트래킹 실패가 기능을 깨지 않음).
- 부팅 유저 push에서 `age: -1`, `role: "user"` 매직 값 제거 — **userId만 전송**. gender/ageGroup/role은 부팅 시점에 알 수 없으므로 로그인 시 `setLoggedInUserAttributes`가 채움.
- CLAUDE.md 동기화: 유저 식별/속성 표, M3 섹션 완료 표기, 환경변수 예시.

## 작업 방법
- `initAnalytics()`는 (1) `#matomo-container-script` 존재 가드 → (2) userId push (컨테이너 로드 전 큐잉 보장) → (3) `mtm.Start` push → (4) 컨테이너 `<script async src>` 삽입 순서로 동작. 전체를 try/catch로 감싸 실패 시 `console.error`만 남김.
- 기존 발화 순서(userId push → mtm.Start → 컨테이너 로드) 그대로 유지 — 발화 제거 없음.

## 스키마 변경 (분석 담당 후속 조치용)
- 부팅 push에서 `age: -1`, `role: "user"` 필드 제거 → 부팅 push는 `userId` 단일 키. Matomo 쪽에서 age -1 / 부팅 role을 참조하는 세그먼트가 있다면 정리 필요. 로그인 상태 새로고침 시 role이 "user"로 잘못 덮이던 것도 함께 해소됨.

## 테스트
프로덕션 빌드 + `npx serve` + Playwright로 `window._mtm` 캡처 (`.claude/skills/verify` 레시피, 컨테이너 로더는 스텁). **11/11 checks passed**

```
PASS | 컨테이너 스크립트 요소 존재
PASS | src가 env 기반 URL(9080/js/container_2yv5mH8U.js) | http://localhost:9080/js/container_2yv5mH8U.js
PASS | async 로드
PASS | innerHTML 주입 아님(외부 src, 인라인 코드 없음) | ""
PASS | mtm.Start push 존재
PASS | 부팅 유저 push가 mtm.Start보다 먼저 큐잉 | bootIdx=0, startIdx=1
PASS | 부팅 push: 익명 UUID userId | befb3157-cc4f-40cc-a156-2a9900655d01
PASS | 부팅 push: age/role 매직 값 제거 (userId 단일 키) | {"userId":"befb3157-cc4f-40cc-a156-2a9900655d01"}
PASS | 기존 이벤트 발화 유지: travel_main_view 1회
PASS | 로그인 부팅 push: userId = 토큰 sub(tester1) | {"userId":"tester1"}
PASS | 로그인 부팅 push: role "user" 매직 값으로 덮지 않음
```

> env 미설정 케이스(삽입 스킵 + console.error)는 빌드 타임 env 치환이라 별도 빌드가 필요해 E2E에서 제외 — 코드 경로는 단순 가드.

🤖 Generated with [Claude Code](https://claude.com/claude-code)