### PR TITLE
✨ Feat: [M4] 신규 트래킹 이벤트 추가 — 전환 퍼널·검색 품질·랭킹·에러

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,25 +78,24 @@ src/analytics/
 | 이벤트 | 발화 시점 | 트래커 함수 (`src/analytics/events.js`) / 호출 위치 | 페이로드 | 남은 문제 |
 |---|---|---|---|---|
 | `travel_main_view` | 메인 페이지 진입 | `trackMainView` / `src/main/pages/MainPage.jsx` | (공통 필드만) | — |
-| `travel_search_click` | 검색 버튼 클릭 | `trackSearchClick` / `src/post/components/PostSearch.jsx` | category, region (빈 값 null) | keyword 미수집 (M4) |
+| `travel_search_click` | 검색 버튼 클릭 | `trackSearchClick` / `src/post/components/PostSearch.jsx` | category, region, keyword (빈 값 null) | — (M4에서 keyword 추가) |
 | `travel_detail_pageview` | 상세 데이터 로드 후 (postId당 1회 가드) | `trackDetailPageview` / `src/post/pages/PostDetailPage.jsx` | postId(number), category, region, title | — (M2에서 중복 발화 수정) |
 | `travel_detail_exit` | 상세 이탈 (effect cleanup + `pagehide` 보완) | `trackDetailExit` / `src/post/pages/PostDetailPage.jsx` | postId(number), staySeconds, title | — (M2에서 과다 발화·staySeconds 왜곡 수정) |
 | `travel_favorite_add` / `_remove` | 찜 토글 | `trackFavoriteAdd` / `trackFavoriteRemove` / `src/post/pages/PostDetailPage.jsx` | postId(number), category, region, title | — |
-| `travel_comment_add` / `_remove` | 댓글 등록/삭제 | `trackCommentAdd` / `trackCommentRemove` / `src/comment/components/CommentPage.jsx` | postId(number), category, region, title | star(별점) 미수집 (M4) |
+| `travel_comment_add` / `_remove` | 댓글 등록/삭제 | `trackCommentAdd` / `trackCommentRemove` / `src/comment/components/CommentPage.jsx` | postId(number), category, region, title, star(add만, number) | — (M4에서 star 추가) |
 
-### 신규 이벤트 (이슈 M4에서 추가)
+### 신규 이벤트 (M4에서 추가 완료, 이슈 #81)
 
-| 이벤트 | 발화 시점 | 호출 위치(예정) | 페이로드 | 목적 |
+| 이벤트 | 발화 시점 | 트래커 함수 (`src/analytics/events.js`) / 호출 위치 | 페이로드 | 목적 |
 |---|---|---|---|---|
-| `travel_signup_complete` | 회원가입 성공 | `src/sign/components/SignUpPage.jsx` | gender, age | 가입 퍼널 |
-| `travel_login` / `travel_login_fail` | 로그인 성공/실패 | `src/sign/components/SignInPage.jsx` | (성공 시 role) | 로그인 퍼널 |
-| `travel_post_add` / `_update` / `_remove` | 게시글 CRUD 성공 | post 작성/수정 화면 | postId, category, region | 콘텐츠 생산 지표 |
-| `travel_search_click` (확장) | 검색 | `src/post/components/PostSearch.jsx` | + keyword | 검색어 분석 |
-| `travel_search_result` | 검색 결과 로드 | `src/post/pages/PostListPage.jsx` | keyword, category, region, resultCount | **0건 검색 = 콘텐츠 갭** |
-| `travel_list_item_click` | 리스트→상세 클릭 | 리스트 화면 | postId, position(순번), keyword | 검색 CTR |
-| `travel_ranking_click` | 메인 랭킹 카드 클릭 | `MainPageCard` 계열 | rankType(region/category/post), rank, label | 랭킹 기능 효용 검증 |
-| `travel_comment_add` (확장) | 댓글 등록 | `src/comment/components/CommentPage.jsx` | + star | 지역/카테고리 만족도 |
-| `travel_error` | ErrorBoundary·API 실패 | `src/components/ErrorBoundary.jsx` 등 | errorType, message, path | 사용자 체감 장애 |
+| `travel_signup_complete` | 회원가입 성공 | `trackSignupComplete` / `src/hooks/useSignUpForm.js` | gender, ageGroup(연령대 구간 — 개인정보 방침에 따라 age 원값 미전송) | 가입 퍼널 |
+| `travel_login` / `travel_login_fail` | 로그인 성공/실패 | `trackLogin` / `trackLoginFail` / `src/sign/components/SignInPage.jsx` | 성공 시 role("admin"\|"user"), 실패 시 공통 필드만 | 로그인 퍼널 |
+| `travel_post_add` | 게시글 작성 성공 | `trackPostAdd` / `src/post/pages/PostWritePage.jsx` | postId(생성 응답에서 확보, 없으면 null), category, region (코드값) | 콘텐츠 생산 지표 |
+| `travel_post_update` / `_remove` | 게시글 수정/삭제 성공 | `trackPostUpdate` / `trackPostRemove` / `src/post/pages/PostEditPage.jsx` | postId, category, region (코드값) | 콘텐츠 생산 지표 |
+| `travel_search_result` | 검색 결과 로드 성공 (정렬/페이지 이동 포함 매 로드) | `trackSearchResult` / `src/post/pages/PostListPage.jsx` | keyword, category, region, resultCount(totalElements, 없으면 페이지 건수) | **0건 검색 = 콘텐츠 갭** |
+| `travel_list_item_click` | 검색 결과 카드 → 상세 클릭 | `trackListItemClick` / `src/post/pages/PostListPage.jsx` (`PostListCard`의 `onCardClick` prop 경유) | postId, position(페이지 내 순번 1~), keyword | 검색 CTR |
+| `travel_ranking_click` | 메인 랭킹 카드 클릭 | `trackRankingClick` / `src/main/components/MainPageCard/MainPageCard.jsx` | rankType("post"\|"region"\|"category"), rank(1~5), label(post는 제목, 그 외 코드값), postId(post일 때만) | 랭킹 기능 효용 검증 |
+| `travel_error` | 렌더 크래시 / 목록 로드 실패(에러 화면 노출) | `trackError` / `src/components/ErrorBoundary.jsx`(render) · `src/post/pages/PostListPage.jsx`(api) | errorType("render"\|"api"), message, path | 사용자 체감 장애 |
 
 > 공통 필드(`isLoggedIn`, `userId`)는 `pushEvent`가 모든 이벤트에 자동 주입하므로 표에서 생략.
 
@@ -152,11 +151,9 @@ src/analytics/
 - `REACT_APP_MATOMO_CONTAINER_ID` 환경변수 추가(.env.example 갱신), fallback URL 제거 또는 env 필수화.
 - `innerHTML` 대신 index.js에서 동일 로직 직접 실행. 삽입 로직 자체를 `analytics.js`의 `initAnalytics()`로 이동.
 
-### 이슈 M4 — 신규 이벤트 추가 (중형, ✨)
+### 이슈 M4 — 신규 이벤트 추가 (중형, ✨) — ✅ 완료 (이슈 #81)
 
-- 위 "신규 이벤트" 표 참조. 전환·생산 퍼널(가입/로그인/게시글 CRUD) → 검색 품질(keyword, resultCount, list click) → 랭킹 클릭 → 에러/기타 순으로 우선순위.
-- Web Vitals(패키지 이미 의존성에 있음, 미사용)를 Matomo 이벤트로 보내는 것은 선택 항목 — 별도 이슈로 분리 가능.
-- 이벤트마다 카탈로그 표 갱신 필수.
+> 결과: 신규 이벤트 10종 추가(위 "신규 이벤트" 표) + 기존 2종 확장(search_click keyword, comment_add star). 개인정보 방침에 따라 signup은 age 원값 대신 ageGroup 전송. `travel_error`는 ErrorBoundary(render)와 PostListPage 목록 로드 실패(api) 2곳 연결 — `src/api/` 수정 금지 원칙 때문에 axios 인터셉터 방식은 쓰지 않음. Web Vitals → Matomo 전송은 별도 이슈로 분리(미착수). MTM 컨테이너에 신규 travel_* Custom Event 트리거 등록·게시는 사용자 대시보드 작업으로 남음.
 
 ### 작업 순서
 

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -76,8 +76,9 @@ export const setUserAttributes = (attributes) => {
 /**
  * 나이 원값을 연령대 구간 문자열로 변환한다. (개인정보 최소화 — 원값은 보내지 않는다)
  * 예: 27 → "20대". 60 이상은 "60대 이상", 10 미만·비정상 값은 null.
+ * events.js의 trackSignupComplete도 같은 방침을 쓰므로 export한다.
  */
-const toAgeGroup = (age) => {
+export const toAgeGroup = (age) => {
   const n = Number(age);
   if (!Number.isFinite(n) || n < 10) return null;
   const decade = Math.floor(n / 10) * 10;

--- a/src/analytics/events.js
+++ b/src/analytics/events.js
@@ -1,4 +1,4 @@
-import { pushEvent } from "./analytics";
+import { pushEvent, toAgeGroup } from "./analytics";
 
 /**
  * 이벤트 카탈로그.
@@ -17,6 +17,16 @@ export const EVENT_NAMES = {
   FAVORITE_REMOVE: "travel_favorite_remove",
   COMMENT_ADD: "travel_comment_add",
   COMMENT_REMOVE: "travel_comment_remove",
+  SIGNUP_COMPLETE: "travel_signup_complete",
+  LOGIN: "travel_login",
+  LOGIN_FAIL: "travel_login_fail",
+  POST_ADD: "travel_post_add",
+  POST_UPDATE: "travel_post_update",
+  POST_REMOVE: "travel_post_remove",
+  SEARCH_RESULT: "travel_search_result",
+  LIST_ITEM_CLICK: "travel_list_item_click",
+  RANKING_CLICK: "travel_ranking_click",
+  ERROR: "travel_error",
 };
 
 /** 게시글 ID는 항상 number로 보낸다. 캐스팅 불가하면 null. */
@@ -49,10 +59,14 @@ export const trackMainView = () => {
 /**
  * 검색 버튼 클릭 시 발화.
  * 호출 위치: src/post/components/PostSearch.jsx
- * 페이로드: category(string|null), region(string|null)
+ * 페이로드: category(string|null), region(string|null), keyword(string|null)
  */
-export const trackSearchClick = ({ category, region }) => {
-  pushEvent(EVENT_NAMES.SEARCH_CLICK, { category: orNull(category), region: orNull(region) });
+export const trackSearchClick = ({ category, region, keyword }) => {
+  pushEvent(EVENT_NAMES.SEARCH_CLICK, {
+    category: orNull(category),
+    region: orNull(region),
+    keyword: orNull(keyword),
+  });
 };
 
 /**
@@ -94,10 +108,13 @@ export const trackFavoriteRemove = (post) => {
 /**
  * 댓글 등록 시 발화.
  * 호출 위치: src/comment/components/CommentPage.jsx
- * 페이로드: postId(number|null), category, region, title
+ * 페이로드: postId(number|null), category, region, title, star(number|null — 별점 1~5)
  */
-export const trackCommentAdd = ({ postId, category, region, title }) => {
-  pushEvent(EVENT_NAMES.COMMENT_ADD, buildPostPayload({ postId, category, region, title }));
+export const trackCommentAdd = ({ postId, category, region, title, star }) => {
+  pushEvent(EVENT_NAMES.COMMENT_ADD, {
+    ...buildPostPayload({ postId, category, region, title }),
+    star: Number.isFinite(Number(star)) && star !== null && star !== "" ? Number(star) : null,
+  });
 };
 
 /**
@@ -107,4 +124,144 @@ export const trackCommentAdd = ({ postId, category, region, title }) => {
  */
 export const trackCommentRemove = ({ postId, category, region, title }) => {
   pushEvent(EVENT_NAMES.COMMENT_REMOVE, buildPostPayload({ postId, category, region, title }));
+};
+
+/** 생년월일(yyyy-MM-dd)로 만 나이를 계산한다. 파싱 불가하면 null. */
+const toAgeFromBirthDate = (birthDate) => {
+  if (!birthDate) return null;
+  const birth = new Date(birthDate);
+  if (Number.isNaN(birth.getTime())) return null;
+  const now = new Date();
+  let age = now.getFullYear() - birth.getFullYear();
+  const beforeBirthday =
+    now.getMonth() < birth.getMonth() ||
+    (now.getMonth() === birth.getMonth() && now.getDate() < birth.getDate());
+  return beforeBirthday ? age - 1 : age;
+};
+
+/**
+ * 회원가입 성공 시 발화. (가입 퍼널)
+ * 개인정보 최소화 방침(M2 결정): 나이 원값은 보내지 않고 연령대 구간(ageGroup)으로 변환한다.
+ * 호출 위치: src/hooks/useSignUpForm.js
+ * 페이로드: gender(string|null), ageGroup(string|null — 예: "20대")
+ */
+export const trackSignupComplete = ({ gender, birthDate }) => {
+  pushEvent(EVENT_NAMES.SIGNUP_COMPLETE, {
+    gender: orNull(gender),
+    ageGroup: toAgeGroup(toAgeFromBirthDate(birthDate)),
+  });
+};
+
+/**
+ * 로그인 성공 시 발화. (로그인 퍼널)
+ * 호출 위치: src/sign/components/SignInPage.jsx
+ * 페이로드: role("admin"|"user")
+ */
+export const trackLogin = ({ role }) => {
+  pushEvent(EVENT_NAMES.LOGIN, { role: orNull(role) });
+};
+
+/**
+ * 로그인 실패 시 발화. (로그인 퍼널 — 실패 원인은 보안상 페이로드에 싣지 않는다)
+ * 호출 위치: src/sign/components/SignInPage.jsx
+ * 페이로드: 없음 (공통 필드만)
+ */
+export const trackLoginFail = () => {
+  pushEvent(EVENT_NAMES.LOGIN_FAIL);
+};
+
+/**
+ * 게시글 작성 성공 시 발화. (콘텐츠 생산 지표)
+ * 호출 위치: src/post/pages/PostWritePage.jsx
+ * 페이로드: postId(number|null — 생성 응답에서 확보), category, region (코드값)
+ */
+export const trackPostAdd = ({ postId, category, region }) => {
+  pushEvent(EVENT_NAMES.POST_ADD, {
+    postId: toPostId(postId),
+    category: orNull(category),
+    region: orNull(region),
+  });
+};
+
+/**
+ * 게시글 수정 성공 시 발화. (콘텐츠 생산 지표)
+ * 호출 위치: src/post/pages/PostEditPage.jsx
+ * 페이로드: postId(number|null), category, region (코드값)
+ */
+export const trackPostUpdate = ({ postId, category, region }) => {
+  pushEvent(EVENT_NAMES.POST_UPDATE, {
+    postId: toPostId(postId),
+    category: orNull(category),
+    region: orNull(region),
+  });
+};
+
+/**
+ * 게시글 삭제 성공 시 발화. (콘텐츠 생산 지표)
+ * 호출 위치: src/post/pages/PostEditPage.jsx
+ * 페이로드: postId(number|null), category, region (코드값)
+ */
+export const trackPostRemove = ({ postId, category, region }) => {
+  pushEvent(EVENT_NAMES.POST_REMOVE, {
+    postId: toPostId(postId),
+    category: orNull(category),
+    region: orNull(region),
+  });
+};
+
+/**
+ * 검색 결과 로드 성공 시 발화. resultCount 0 = 콘텐츠 갭 신호.
+ * 정렬/페이지 이동도 결과 로드이므로 매 로드마다 발화된다.
+ * 호출 위치: src/post/pages/PostListPage.jsx
+ * 페이로드: keyword, category, region, resultCount(number — 전체 건수, 서버가 안 주면 현재 페이지 건수)
+ */
+export const trackSearchResult = ({ keyword, category, region, resultCount }) => {
+  pushEvent(EVENT_NAMES.SEARCH_RESULT, {
+    keyword: orNull(keyword),
+    category: orNull(category),
+    region: orNull(region),
+    resultCount: Number.isFinite(Number(resultCount)) ? Number(resultCount) : null,
+  });
+};
+
+/**
+ * 검색 결과 리스트에서 게시글 카드 클릭 시 발화. (검색 CTR)
+ * 호출 위치: src/post/pages/PostListPage.jsx
+ * 페이로드: postId(number|null), position(number — 현재 페이지 내 순번, 1부터), keyword
+ */
+export const trackListItemClick = ({ postId, position, keyword }) => {
+  pushEvent(EVENT_NAMES.LIST_ITEM_CLICK, {
+    postId: toPostId(postId),
+    position,
+    keyword: orNull(keyword),
+  });
+};
+
+/**
+ * 메인 랭킹 카드 클릭 시 발화. (랭킹 기능 효용 검증)
+ * 호출 위치: src/main/components/MainPageCard/MainPageCard.jsx
+ * 페이로드: rankType("post"|"region"|"category"), rank(number|null — 1~5),
+ *           label(string|null — post는 제목, region/category는 코드값), postId(number|null — post일 때만)
+ */
+export const trackRankingClick = ({ rankType, rank, label, postId }) => {
+  pushEvent(EVENT_NAMES.RANKING_CLICK, {
+    rankType,
+    rank: Number.isFinite(Number(rank)) && rank !== null && rank !== undefined ? Number(rank) : null,
+    label: orNull(label),
+    postId: toPostId(postId),
+  });
+};
+
+/**
+ * 사용자 체감 장애 발생 시 발화.
+ * - 렌더 크래시: src/components/ErrorBoundary.jsx (errorType "render")
+ * - 목록 로드 실패(에러 화면 노출): src/post/pages/PostListPage.jsx (errorType "api")
+ * 페이로드: errorType("render"|"api"), message(string|null), path(string — window.location.pathname)
+ */
+export const trackError = ({ errorType, message, path }) => {
+  pushEvent(EVENT_NAMES.ERROR, {
+    errorType: orNull(errorType),
+    message: orNull(message),
+    path: orNull(path),
+  });
 };

--- a/src/comment/components/CommentPage.jsx
+++ b/src/comment/components/CommentPage.jsx
@@ -59,7 +59,7 @@ const CommentPage = ({ postId, isLoggedIn, ratingAvg, setCommentFlag, category, 
     };
 
     const addComment = async ({ rating, comment }) => {
-        trackCommentAdd({ postId, category, region, title });
+        trackCommentAdd({ postId, category, region, title, star: rating });
         const payload = { postId: parseInt(postId), content: comment, star: rating };
         try {
             const { data } = await commentApi.addComment(payload);

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,4 +1,5 @@
 import { Component } from 'react';
+import { trackError } from '../analytics/events';
 
 class ErrorBoundary extends Component {
     constructor(props) {
@@ -12,6 +13,7 @@ class ErrorBoundary extends Component {
 
     componentDidCatch(error, info) {
         console.error('ErrorBoundary caught:', error, info);
+        trackError({ errorType: 'render', message: error?.message, path: window.location.pathname });
     }
 
     render() {

--- a/src/hooks/useSignUpForm.js
+++ b/src/hooks/useSignUpForm.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { checkNickname, checkLoginId, checkEmail, signUp } from '../api/memberApi';
+import { trackSignupComplete } from '../analytics/events';
 
 const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+~\-=\[\]{};':"\\|,.<>\/?]).{8,}$/;
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -107,6 +108,7 @@ const useSignUpForm = () => {
         try {
             const { passwordConfirm: _, ...rest } = formData;
             await signUp({ ...rest, birthDate });
+            trackSignupComplete({ gender: formData.gender, birthDate });
             toast.success("회원가입이 완료되었습니다! 🎉");
             navigate("/");
         } catch (error) {

--- a/src/main/components/MainPageCard/MainPageCard.jsx
+++ b/src/main/components/MainPageCard/MainPageCard.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import CountUp from 'react-countup';
 import { CATEGORY_CODE_TO_LABEL, REGION_CODE_TO_LABEL } from '../../../constants/categoryRegion';
 import { CATEGORY_REGION_IMAGES } from './categoryRegionImages';
+import { trackRankingClick } from '../../../analytics/events';
 
 // 1~5위 색상 예시 (secondary variant 순위 뱃지)
 const rankColors = ["#ffd700", "#C0C0C0", "#cd7f32", "#90caf9", "#b39ddb"];
@@ -47,8 +48,10 @@ const MainPageCard = ({ variant = 'primary', rank, postId, score, data, type }) 
 
   const handleClick = () => {
     if (variant === 'category') {
+      trackRankingClick({ rankType: type, rank, label: data });
       navigate(`/post/list/?${type}=${data}`);
     } else {
+      trackRankingClick({ rankType: 'post', rank, label: post.title, postId: post.postId });
       navigate(`/post/detail/?postId=${post.postId}`);
     }
   };

--- a/src/post/components/PostListCard.jsx
+++ b/src/post/components/PostListCard.jsx
@@ -4,12 +4,13 @@ import { categoryColors, regionColors } from "../../constants/colorMaps";
 import { CATEGORY_CODE_TO_LABEL, REGION_CODE_TO_LABEL } from "../../constants/categoryRegion";
 import { formatDate } from "../../utils/dateUtils";
 
-const PostListCard = ({ post, navigateTo, navigateState }) => {
+const PostListCard = ({ post, navigateTo, navigateState, onCardClick }) => {
   const navigate = useNavigate();
   const categoryLabel = CATEGORY_CODE_TO_LABEL[post.category] ?? post.category;
   const regionLabel = REGION_CODE_TO_LABEL[post.region] ?? post.region;
 
   const handleClick = () => {
+    onCardClick?.();
     const to = navigateTo ?? `/post/detail?postId=${post.postId}`;
     navigate(to, navigateState ? { state: navigateState } : undefined);
   };

--- a/src/post/components/PostSearch.jsx
+++ b/src/post/components/PostSearch.jsx
@@ -73,7 +73,7 @@ const PostSearch = ({ selectedCategory, selectedRegion }) => {
         if (post.category) params.append("category", post.category);
         if (post.region) params.append("region", post.region);
         if (keyword) params.append("keyword", keyword);
-        trackSearchClick({ category: post.category, region: post.region });
+        trackSearchClick({ category: post.category, region: post.region, keyword });
         navigate(`/post/list?${params.toString()}`);
     };
 

--- a/src/post/pages/PostEditPage.jsx
+++ b/src/post/pages/PostEditPage.jsx
@@ -8,6 +8,7 @@ import {
     CATEGORY_LABEL_TO_CODE, CATEGORY_CODE_TO_LABEL,
     REGION_LABEL_TO_CODE, REGION_CODE_TO_LABEL,
 } from '../../constants/categoryRegion';
+import { trackPostUpdate, trackPostRemove } from '../../analytics/events';
 
 const IMAGE_BASE_URL = process.env.REACT_APP_IMAGE_BASE_URL || '';
 
@@ -70,6 +71,11 @@ const PostEditPage = () => {
     const removePost = async () => {
         try {
             await deletePost(postId);
+            trackPostRemove({
+                postId,
+                category: CATEGORY_LABEL_TO_CODE[post.category] ?? post.category,
+                region: REGION_LABEL_TO_CODE[post.region] ?? post.region,
+            });
             showAlert("삭제 성공", "success");
             setTimeout(() => navigate('/post/list'), 500);
         } catch {
@@ -124,12 +130,15 @@ const PostEditPage = () => {
             const uploadedImageKeys = await Promise.all(newImageFiles.map(uploadImageToS3));
             // 이미지 정렬 순서는 배열 순서 자체로 전달 (기존 이미지 → 신규 이미지 순)
             const images = [...existingImages.map((img) => img.imageKey), ...uploadedImageKeys];
+            const category = CATEGORY_LABEL_TO_CODE[post.category] ?? post.category;
+            const region = REGION_LABEL_TO_CODE[post.region] ?? post.region;
             await updatePost(postId, {
                 ...post,
-                category: CATEGORY_LABEL_TO_CODE[post.category] ?? post.category,
-                region: REGION_LABEL_TO_CODE[post.region] ?? post.region,
+                category,
+                region,
                 images,
             });
+            trackPostUpdate({ postId, category, region });
             showAlert("글 수정이 완료되었습니다.", "success");
             setTimeout(() => navigate('/post/list'), 500);
         } catch {

--- a/src/post/pages/PostListPage.jsx
+++ b/src/post/pages/PostListPage.jsx
@@ -5,6 +5,7 @@ import PostSearch from "../components/PostSearch";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import PostListCard from "../components/PostListCard";
 import useAlert from "../../hooks/useAlert";
+import { trackSearchResult, trackListItemClick, trackError } from "../../analytics/events";
 
 const PostListPage = () => {
   const [posts, setPosts] = useState([]);
@@ -58,8 +59,13 @@ const PostListPage = () => {
       setPosts(result.content ?? []);
       setPagination({ totalPages: result.totalPages ?? 0, isFirst: result.isFirst ?? true, isLast: result.isLast ?? true });
       setRetryCount(0);
+      trackSearchResult({
+        keyword, category, region,
+        resultCount: result.totalElements ?? (result.content?.length ?? 0),
+      });
     } catch (e) {
       setError(e);
+      trackError({ errorType: "api", message: e.message, path: window.location.pathname });
     } finally {
       setLoading(false);
     }
@@ -153,12 +159,13 @@ const PostListPage = () => {
           </div>
         ) : (
           <div className="d-flex flex-column gap-4">
-            {posts.map((post) => (
+            {posts.map((post, idx) => (
               <PostListCard
                 key={post.postId}
                 post={post}
                 navigateTo={`/post/detail?postId=${post.postId}`}
                 navigateState={{ from: location.search }}
+                onCardClick={() => trackListItemClick({ postId: post.postId, position: idx + 1, keyword })}
               />
             ))}
           </div>

--- a/src/post/pages/PostWritePage.jsx
+++ b/src/post/pages/PostWritePage.jsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import useAlert from '../../hooks/useAlert';
 import PostForm from '../components/PostForm';
 import { CATEGORY_LABEL_TO_CODE, REGION_LABEL_TO_CODE } from '../../constants/categoryRegion';
+import { trackPostAdd } from '../../analytics/events';
 
 const buildSafeFileName = (originalName) => {
     const ext = originalName.includes('.') ? originalName.split('.').pop().toLowerCase() : 'jpg';
@@ -81,12 +82,17 @@ const PostWritePage = () => {
         setUploading(true);
         try {
             const uploadedImageKeys = await Promise.all(images.map(uploadImageToS3));
-            await createPost({
+            const category = CATEGORY_LABEL_TO_CODE[post.category] ?? post.category;
+            const region = REGION_LABEL_TO_CODE[post.region] ?? post.region;
+            const { data } = await createPost({
                 ...post,
-                category: CATEGORY_LABEL_TO_CODE[post.category] ?? post.category,
-                region: REGION_LABEL_TO_CODE[post.region] ?? post.region,
+                category,
+                region,
                 images: uploadedImageKeys,
             });
+            // 생성 응답 result가 { postId } 객체든 id 원시값이든 모두 수용 (없으면 null 전송)
+            const result = data?.result;
+            trackPostAdd({ postId: typeof result === 'object' ? result?.postId : result, category, region });
             showAlert("글 작성이 완료되었습니다.", "success");
             setTimeout(() => navigate('/post/list'), 500);
         } catch {

--- a/src/sign/components/SignInPage.jsx
+++ b/src/sign/components/SignInPage.jsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { isAdmin } from '../../utils/tokenUtils';
 import { setLoggedInUserAttributes } from '../../analytics/analytics';
+import { trackLogin, trackLoginFail } from '../../analytics/events';
 import useAlert from '../../hooks/useAlert';
 
 const SignInPage = () => {
@@ -29,14 +30,17 @@ const SignInPage = () => {
             const { data: profileRes } = await getMyProfile();
             const member = profileRes.result ?? profileRes;
             localStorage.setItem('nickname', member.nickname);
+            const role = isAdmin(accessToken) ? "admin" : "user";
             setLoggedInUserAttributes({
                 gender: member.gender,
                 age: member.age,
-                role: isAdmin(accessToken) ? "admin" : "user"
+                role
             });
+            trackLogin({ role });
             toast.success(`${member.nickname}님 환영합니다.`);
             navigate("/");
         } catch (error) {
+            trackLoginFail();
             showAlert(error.response?.data?.message || "에러가 발생했습니다.", "danger");
         }
     };


### PR DESCRIPTION
## 관련 이슈
closes #81

## 변경 사항
- `src/analytics/events.js`에 신규 트래커 10종 추가 (모두 JSDoc·`EVENT_NAMES` 상수 사용)
  - `travel_signup_complete` — 회원가입 성공 (`useSignUpForm`) : gender, **ageGroup** (개인정보 방침(M2)에 따라 age 원값 미전송, 생년월일→연령대 변환)
  - `travel_login` / `travel_login_fail` — 로그인 성공/실패 (`SignInPage`) : 성공 시 role
  - `travel_post_add` / `_update` / `_remove` — 게시글 CRUD 성공 (`PostWritePage`/`PostEditPage`) : postId, category, region(코드값)
  - `travel_search_result` — 검색 결과 로드 (`PostListPage`) : keyword, category, region, resultCount (0건 = 콘텐츠 갭)
  - `travel_list_item_click` — 검색 리스트→상세 클릭 (`PostListPage`) : postId, position(페이지 내 순번), keyword
  - `travel_ranking_click` — 메인 랭킹 카드 클릭 (`MainPageCard`) : rankType(post/region/category), rank, label, postId(post일 때)
  - `travel_error` — ErrorBoundary 렌더 크래시(render) + 목록 로드 실패 에러 화면(api) : errorType, message, path
- 기존 이벤트 확장 (스키마 추가만, 발화 시점 불변)
  - `travel_search_click` + **keyword**
  - `travel_comment_add` + **star**(별점)
- `analytics.js`: `toAgeGroup` export 전환 (signup 트래커 재사용)
- `PostListCard`: 옵션 `onCardClick` prop 추가 — 검색 리스트(`PostListPage`)에서만 CTR 트래커 연결, 찜/내글 목록은 미발화
- CLAUDE.md 이벤트 카탈로그 표 갱신 (신규 이벤트 표 → 구현 완료 상태로 전환)

## 작업 방법
- 아키텍처 규칙 준수: 페이로드 조립은 전부 `events.js`, 호출부는 1줄. `window._mtm` 접근은 `src/analytics/`만.
- `travel_error`의 API 실패 수집은 `src/api/` 수정 금지 원칙 때문에 axios 인터셉터 대신 화면 catch(에러 화면이 노출되는 `PostListPage`)에 연결.
- `travel_post_add`의 postId는 생성 응답 `result`가 객체든 원시값이든 수용, 확보 실패 시 null.
- 게시글 CRUD의 category/region은 API 요청과 동일한 코드값을 페이로드에 사용.

## 테스트
프로덕션 빌드 + Playwright(E2E, API 전체 목킹)로 `window._mtm` push 캡처 — 아래 전문.

```
===== S1 회원가입 → travel_signup_complete =====
{"event":"travel_signup_complete","isLoggedIn":false,"userId":"3505638b-…","gender":"MALE","ageGroup":"20대"}

===== S2-a 로그인 실패 → travel_login_fail =====
{"event":"travel_login_fail","isLoggedIn":false,"userId":"3505638b-…"}

===== S2-b 로그인 성공 → 유저 속성 push + travel_login =====
{"userId":"tester99","gender":"MALE","ageGroup":"20대","role":"user"}
{"event":"travel_login","isLoggedIn":true,"userId":"tester99","role":"user"}

===== S3-a 검색 클릭 + 결과 로드 =====
{"event":"travel_search_click","isLoggedIn":true,"userId":"tester99","category":null,"region":null,"keyword":"바다"}
{"event":"travel_search_result","isLoggedIn":true,"userId":"tester99","keyword":"바다","category":null,"region":null,"resultCount":3}

===== S3-b 리스트 1번 카드 클릭 =====
{"event":"travel_list_item_click","isLoggedIn":true,"userId":"tester99","postId":11,"position":1,"keyword":"바다"}
{"event":"travel_detail_pageview","isLoggedIn":true,"userId":"tester99","postId":11,"category":"FOOD","region":"SEOUL","title":"테스트 글 11"}  ← 기존 이벤트 발화 불변 확인

===== S4 댓글 등록(별 3) =====
{"event":"travel_comment_add","isLoggedIn":true,"userId":"tester99","postId":11,"category":"FOOD","region":"SEOUL","title":"테스트 글 11","star":3}

===== S5-a 카테고리 랭킹 1위 카드 클릭 =====
{"event":"travel_ranking_click","isLoggedIn":true,"userId":"tester99","rankType":"category","rank":1,"label":"FOOD","postId":null}

===== S5-b 게시글 랭킹 2위 카드 클릭 =====
{"event":"travel_ranking_click","isLoggedIn":true,"userId":"tester99","rankType":"post","rank":2,"label":"테스트 글 22","postId":22}

===== S6 게시글 작성 성공 =====
{"event":"travel_post_add","isLoggedIn":true,"userId":"tester99","postId":42,"category":"FOOD","region":"SEOUL"}

===== S7-a 게시글 수정 성공 =====
{"event":"travel_post_update","isLoggedIn":true,"userId":"tester99","postId":42,"category":"FOOD","region":"SEOUL"}

===== S7-b 게시글 삭제 성공 =====
{"event":"travel_post_remove","isLoggedIn":true,"userId":"tester99","postId":42,"category":"FOOD","region":"SEOUL"}

===== S8 목록 로드 실패 =====
{"event":"travel_error","isLoggedIn":true,"userId":"tester99","errorType":"api","message":"Request failed with status code 500","path":"/post/list"}
```

- `travel_error(render)`(ErrorBoundary)는 E2E로 렌더 크래시를 강제할 수 없어 캡처 제외 — `componentDidCatch` 1줄 호출로 코드 경로는 단순.
- 프로덕션 빌드 컴파일 정상 (+747B gzip), 경고는 전부 기존 것.

## Matomo 측 후속 조치 (분석 담당)
- MTM 컨테이너에 신규 Custom Event 트리거 등록 + 게시 필요: `travel_signup_complete`, `travel_login`, `travel_login_fail`, `travel_post_add`, `travel_post_update`, `travel_post_remove`, `travel_search_result`, `travel_list_item_click`, `travel_ranking_click`, `travel_error`
- 기존 이벤트 스키마 확장(대시보드/세그먼트 영향): `travel_search_click`에 `keyword`, `travel_comment_add`에 `star` 추가
- Web Vitals → Matomo 전송은 별도 이슈로 분리 (미착수)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
