### PR TITLE
✨ Feat: 관리자 여행지 관리 탭 개편 — 관리자 게시글/댓글 API 연동

### DIFF
--- a/src/admin/AdminPostManagement.jsx
+++ b/src/admin/AdminPostManagement.jsx
@@ -1,14 +1,27 @@
 import React, { useEffect, useState } from "react";
-import { getPostListBySearch } from "../api/postSearchApi";
-import { deletePost } from "../api/postApi";
+import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
 import { Badge } from "react-bootstrap";
 import { toast } from "react-toastify";
+import {
+    getAdminPosts, getAdminPost, deleteAdminPost, restoreAdminPost, permanentDeleteAdminPost,
+    getAdminComments, deleteAdminComment, restoreAdminComment,
+} from "../api/adminPostApi";
 import { CATEGORY_CODE_TO_LABEL, REGION_CODE_TO_LABEL } from "../constants/categoryRegion";
+import { categoryColors, regionColors } from "../constants/colorMaps";
 import { formatDate } from "../utils/dateUtils";
 import AdminPageHeader from "./AdminPageHeader";
 
-const Pagination = ({ total, page, onChange, pageSize = 10 }) => {
+const PAGE_SIZE = 10;
+const IMAGE_BASE_URL = process.env.REACT_APP_IMAGE_BASE_URL || "";
+
+const DELETED_FILTERS = [
+    { key: "all", label: "전체", deleted: undefined },
+    { key: "active", label: "활성", deleted: false },
+    { key: "deleted", label: "삭제됨", deleted: true },
+];
+
+const Pagination = ({ total, page, onChange, pageSize = PAGE_SIZE }) => {
     const pageCount = Math.ceil(total / pageSize);
     if (pageCount <= 1) return null;
     const pages = Array.from({ length: pageCount }, (_, idx) => idx);
@@ -31,170 +44,433 @@ const Pagination = ({ total, page, onChange, pageSize = 10 }) => {
     );
 };
 
-const PostList = ({ title, posts, loading, error, categoryColors, regionColors, formatDate, onRemove, onClickCard }) => (
-    <div className="mb-4">
-        <h5 className="fw-bold mb-3">{title}</h5>
-        {loading ? (
-            <div className="text-center py-5 fs-5">
-                <div className="spinner-border text-primary me-2" role="status"></div>로딩 중...
-            </div>
-        ) : error ? (
-            <div className="text-danger text-center py-5">에러 발생: {error.message}</div>
-        ) : posts.length === 0 ? (
-            <div className="text-center text-secondary py-5 fs-5">게시글이 없습니다. 검색해주세요.</div>
-        ) : (
-            <div className="d-flex flex-column gap-4">
-                {posts.map((post) => (
-                    <div
-                        key={post.postId}
-                        className="p-3 rounded-3 border admin-post-card"
-                        tabIndex={0}
-                        onClick={() => onClickCard(post)}
-                        onKeyDown={e => { if (e.key === "Enter" || e.key === " ") onClickCard(post); }}
-                    >
-                        <div className="d-flex justify-content-between align-items-start fw-bold admin-post-card-title-row">
-                            <div className="text-truncate admin-post-card-title">
-                                <span className="admin-post-card-title-text" title={post.title}>
-                                    {post.title}
-                                </span>
-                            </div>
-                            <span className="text-secondary ms-2 admin-post-card-date">
-                                {formatDate(post.updatedAt)}
-                            </span>
-                        </div>
-                        <div className="d-flex align-items-center flex-wrap gap-2 justify-content-between admin-post-card-meta">
-                            <div>
-                                <Badge bg={categoryColors[CATEGORY_CODE_TO_LABEL[post.category] ?? post.category]} className="me-1">{CATEGORY_CODE_TO_LABEL[post.category] ?? post.category}</Badge>
-                                <Badge bg={regionColors[REGION_CODE_TO_LABEL[post.region] ?? post.region]} className="me-2">{REGION_CODE_TO_LABEL[post.region] ?? post.region}</Badge>
-                                <span className="admin-post-card-author">by {post.memberNickname}</span>
-                            </div>
-                            <div className="d-flex align-items-center">
-                                <span className="badge text-dark d-flex align-items-center admin-post-card-stat">
-                                    <i className="bi bi-eye me-1" />{post.viewCount || 0}
-                                </span>
-                                <span className="badge admin-post-card-star">
-                                    <i className="bi bi-star-fill me-1" />{post.starAvg ? post.starAvg.toFixed(1) : 0}
-                                </span>
-                                {onRemove &&
-                                    <button className="btn btn-sm btn-outline-danger"
-                                        onClick={e => { e.stopPropagation(); onRemove({ postId: post.postId }); }}>
-                                        삭제
-                                    </button>
-                                }
-                            </div>
-                        </div>
-                    </div>
-                ))}
-            </div>
-        )}
-    </div>
+Pagination.propTypes = {
+    total: PropTypes.number.isRequired,
+    page: PropTypes.number.isRequired,
+    onChange: PropTypes.func.isRequired,
+    pageSize: PropTypes.number,
+};
+
+const StatusBadge = ({ isDeleted }) => (
+    isDeleted ? <Badge bg="danger">삭제됨</Badge> : <Badge bg="success">활성</Badge>
 );
 
+StatusBadge.propTypes = {
+    isDeleted: PropTypes.bool,
+};
+
 const AdminPostManagement = () => {
-    const [esPosts, setEsPosts] = useState([]);
-    const [esLoading, setEsLoading] = useState(false);
-    const [esError, setEsError] = useState(null);
-    const [showConfirm, setShowConfirm] = useState(false);
-    const [removeTarget, setRemoveTarget] = useState(null);
+    const navigate = useNavigate();
 
-    const ES_PAGE_SIZE = 10;
-    const [esPage, setEsPage] = useState(0);
-    const [esDocCount, setEsDocCount] = useState(0);
+    const [posts, setPosts] = useState([]);
+    const [totalElements, setTotalElements] = useState(0);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [filterKey, setFilterKey] = useState("all");
+    const [page, setPage] = useState(0);
 
-    const categoryColors = {
-        축제: "danger", 공연: "primary", 행사: "success", 체험: "warning",
-        쇼핑: "info", 자연: "success", 역사: "secondary", 가족: "dark", 음식: "warning",
-    };
-    const regionColors = {
-        서울: "primary", 부산: "info", 제주: "success", 강원: "danger", 경기: "info", 기타: "warning",
-        대구: "secondary", 인천: "dark", 전남: "secondary"
-    };
+    // { type: 'delete' | 'permanent', post }
+    const [confirm, setConfirm] = useState(null);
+    // { loading, data }
+    const [detail, setDetail] = useState(null);
+    // { post, page, list, totalElements, loading }
+    const [comments, setComments] = useState(null);
 
-    const handleRemove = ({ postId }) => {
-        setRemoveTarget(postId);
-        setShowConfirm(true);
-    };
-
-    const removePost = async () => {
+    const loadPosts = async (filterArg, pageArg) => {
+        setLoading(true);
+        setError(null);
         try {
-            await deletePost(removeTarget);
-            toast.success("삭제에 성공했습니다.");
-            getEsPosts();
-        } catch {
-            toast.error("삭제에 실패했습니다.");
-        } finally {
-            setShowConfirm(false);
-            setRemoveTarget(null);
-        }
-    };
-
-    const getEsPosts = async (page = 0) => {
-        setEsLoading(true);
-        try {
-            const { data } = await getPostListBySearch({ category: "", region: "", keyword: "", sort: "id", direction: "asc", page });
-            setEsPosts(data.result.content);
-            setEsDocCount(data.result.totalElements);
+            const { deleted } = DELETED_FILTERS.find((f) => f.key === filterArg);
+            const { data } = await getAdminPosts({ deleted, page: pageArg, size: PAGE_SIZE });
+            const { content, totalElements: total } = data.result;
+            if (content.length === 0 && pageArg > 0) {
+                // 삭제/복구로 마지막 페이지가 비면 이전 페이지로 이동 (effect가 재조회)
+                setPage(pageArg - 1);
+                return;
+            }
+            setPosts(content);
+            setTotalElements(total);
         } catch (e) {
-            setEsError(e);
+            setError(e);
         } finally {
-            setEsLoading(false);
+            setLoading(false);
         }
     };
 
     useEffect(() => {
-        getEsPosts(0);
-    }, []);
+        loadPosts(filterKey, page);
+    }, [filterKey, page]);
 
-    const navigate = useNavigate();
-    const handleGoDetail = (post) => navigate(`/post/detail?postId=${post.postId}`);
-
-    const handleEsPageChange = (newPage) => {
-        setEsPage(newPage);
-        getEsPosts(newPage);
+    const handleFilterChange = (key) => {
+        setFilterKey(key);
+        setPage(0);
     };
+
+    const openDetail = async (postId) => {
+        setDetail({ loading: true, data: null });
+        try {
+            const { data } = await getAdminPost(postId);
+            setDetail({ loading: false, data: data.result });
+        } catch {
+            toast.error("게시글 상세 조회에 실패했습니다.");
+            setDetail(null);
+        }
+    };
+
+    const restorePost = async (postId) => {
+        try {
+            await restoreAdminPost(postId);
+            toast.success("게시글을 복구했습니다.");
+            loadPosts(filterKey, page);
+        } catch {
+            toast.error("게시글 복구에 실패했습니다.");
+        }
+    };
+
+    const runConfirmAction = async () => {
+        const { type, post } = confirm;
+        try {
+            if (type === "permanent") {
+                await permanentDeleteAdminPost(post.postId);
+                toast.success("게시글을 영구 삭제했습니다.");
+            } else {
+                await deleteAdminPost(post.postId);
+                toast.success("게시글을 삭제했습니다.");
+            }
+            loadPosts(filterKey, page);
+        } catch {
+            toast.error(type === "permanent" ? "영구 삭제에 실패했습니다." : "삭제에 실패했습니다.");
+        } finally {
+            setConfirm(null);
+        }
+    };
+
+    const loadComments = async (post, pageArg) => {
+        setComments((prev) => ({
+            post,
+            page: pageArg,
+            list: prev?.post?.postId === post.postId ? prev.list : [],
+            totalElements: prev?.post?.postId === post.postId ? prev.totalElements : 0,
+            loading: true,
+        }));
+        try {
+            const { data } = await getAdminComments({ postId: post.postId, page: pageArg, size: PAGE_SIZE });
+            setComments({
+                post,
+                page: pageArg,
+                list: data.result.content,
+                totalElements: data.result.totalElements,
+                loading: false,
+            });
+        } catch {
+            toast.error("댓글 조회에 실패했습니다.");
+            setComments(null);
+        }
+    };
+
+    const removeComment = async (commentId) => {
+        try {
+            await deleteAdminComment(commentId);
+            toast.success("댓글을 삭제했습니다.");
+            loadComments(comments.post, comments.page);
+        } catch {
+            toast.error("댓글 삭제에 실패했습니다.");
+        }
+    };
+
+    const restoreComment = async (commentId) => {
+        try {
+            await restoreAdminComment(commentId);
+            toast.success("댓글을 복구했습니다.");
+            loadComments(comments.post, comments.page);
+        } catch {
+            toast.error("댓글 복구에 실패했습니다.");
+        }
+    };
+
+    const renderConfirmModal = () => {
+        const isPermanent = confirm.type === "permanent";
+        return (
+            <div className="modal show fade d-block admin-modal-backdrop" tabIndex={-1}>
+                <div className="modal-dialog modal-dialog-centered">
+                    <div className="modal-content admin-modal-content">
+                        <div className="modal-header border-0">
+                            <h5 className="modal-title text-danger fw-semibold">
+                                <i className="bi bi-trash3 me-2"></i>{isPermanent ? "게시글 영구 삭제" : "게시글 삭제"}
+                            </h5>
+                            <button type="button" className="btn-close admin-modal-close-icon" aria-label="닫기"
+                                onClick={() => setConfirm(null)} />
+                        </div>
+                        <div className="modal-body text-center">
+                            <p className="fs-6 mb-1 text-secondary text-truncate" title={confirm.post.title}>{confirm.post.title}</p>
+                            {isPermanent ? (
+                                <p className="fs-5 mb-3 text-dark">
+                                    DB와 이미지(S3)에서 완전히 제거되며 <span className="fw-bold text-danger">복구할 수 없습니다</span>.<br />
+                                    정말 <span className="fw-bold text-danger">영구 삭제</span>하시겠습니까?
+                                </p>
+                            ) : (
+                                <p className="fs-5 mb-3 text-dark">정말 <span className="fw-bold text-danger">삭제</span>하시겠습니까?</p>
+                            )}
+                            <div className="d-flex justify-content-center gap-3 mt-4">
+                                <button className="btn admin-btn admin-btn-outline px-4" onClick={() => setConfirm(null)}>취소</button>
+                                <button className="btn admin-btn admin-btn-danger px-4" onClick={runConfirmAction}>
+                                    <i className="bi bi-trash3 me-1"></i> {isPermanent ? "영구 삭제" : "삭제"}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    };
+
+    const renderDetailModal = () => {
+        const post = detail.data;
+        return (
+            <div className="modal show fade d-block admin-modal-backdrop" tabIndex={-1}>
+                <div className="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+                    <div className="modal-content admin-modal-content">
+                        <div className="modal-header border-0">
+                            <h5 className="modal-title admin-detail-title d-flex align-items-center gap-2">
+                                <i className="bi bi-file-text me-1"></i>게시글 상세
+                                {post && <StatusBadge isDeleted={post.isDeleted} />}
+                            </h5>
+                            <button type="button" className="btn-close admin-modal-close-icon" aria-label="닫기"
+                                onClick={() => setDetail(null)} />
+                        </div>
+                        <div className="modal-body">
+                            {detail.loading || !post ? (
+                                <div className="text-center py-5 fs-5">
+                                    <div className="spinner-border text-primary me-2" role="status"></div>로딩 중...
+                                </div>
+                            ) : (
+                                <>
+                                    <div className="d-flex align-items-center flex-wrap gap-2 mb-2">
+                                        <Badge bg={categoryColors[CATEGORY_CODE_TO_LABEL[post.category]] ?? "secondary"}>
+                                            {CATEGORY_CODE_TO_LABEL[post.category] ?? post.category}
+                                        </Badge>
+                                        <Badge bg={regionColors[REGION_CODE_TO_LABEL[post.region]] ?? "secondary"}>
+                                            {REGION_CODE_TO_LABEL[post.region] ?? post.region}
+                                        </Badge>
+                                        <span className="fw-bold fs-5">{post.title}</span>
+                                    </div>
+                                    <div className="text-secondary small mb-3">
+                                        <div><i className="bi bi-geo-alt me-1"></i>{post.travelPlace}{post.address ? ` · ${post.address}` : ""}</div>
+                                        <div>
+                                            작성자 ID {post.memberId} · 작성 {formatDate(post.createdAt)}
+                                            {post.updatedAt && ` · 수정 ${formatDate(post.updatedAt)}`}
+                                            {post.isDeleted && post.deletedAt && ` · 삭제 ${formatDate(post.deletedAt)}`}
+                                        </div>
+                                    </div>
+                                    <div className="d-flex align-items-center gap-3 mb-3 text-secondary">
+                                        <span><i className="bi bi-eye me-1"></i>{post.viewCount ?? 0}</span>
+                                        <span><i className="bi bi-chat-dots me-1"></i>{post.commentCount ?? 0}</span>
+                                        <span><i className="bi bi-heart me-1"></i>{post.likeCount ?? 0}</span>
+                                        <span><i className="bi bi-star-fill me-1"></i>{post.starAvg ? post.starAvg.toFixed(1) : 0}</span>
+                                    </div>
+                                    <div className="admin-section-box p-3 admin-post-detail-content">{post.content}</div>
+                                    {post.images?.length > 0 && (
+                                        <div className="d-flex flex-wrap gap-2 mt-3">
+                                            {post.images.map((imageKey) => (
+                                                <img key={imageKey} src={`${IMAGE_BASE_URL}/${imageKey}`}
+                                                    alt="게시글 이미지" className="admin-post-detail-thumb" />
+                                            ))}
+                                        </div>
+                                    )}
+                                </>
+                            )}
+                        </div>
+                        <div className="modal-footer border-0">
+                            {post && !post.isDeleted && (
+                                <button className="btn admin-btn admin-btn-primary admin-btn-sm"
+                                    onClick={() => navigate(`/post/detail?postId=${post.postId}`)}>
+                                    <i className="bi bi-box-arrow-up-right me-1"></i>게시글 페이지로 이동
+                                </button>
+                            )}
+                            <button className="btn admin-btn admin-btn-outline admin-btn-sm" onClick={() => setDetail(null)}>닫기</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    };
+
+    const renderCommentsModal = () => (
+        <div className="modal show fade d-block admin-modal-backdrop" tabIndex={-1}>
+            <div className="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+                <div className="modal-content admin-modal-content">
+                    <div className="modal-header border-0">
+                        <h5 className="modal-title admin-detail-title text-truncate">
+                            <i className="bi bi-chat-dots me-2"></i>댓글 관리 — {comments.post.title}
+                        </h5>
+                        <button type="button" className="btn-close admin-modal-close-icon" aria-label="닫기"
+                            onClick={() => setComments(null)} />
+                    </div>
+                    <div className="modal-body">
+                        {comments.loading ? (
+                            <div className="text-center py-5 fs-5">
+                                <div className="spinner-border text-primary me-2" role="status"></div>로딩 중...
+                            </div>
+                        ) : comments.list.length === 0 ? (
+                            <div className="text-center text-secondary py-5">댓글이 없습니다.</div>
+                        ) : (
+                            <div className="table-responsive">
+                                <table className="table admin-table align-middle mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>ID</th>
+                                            <th>작성자</th>
+                                            <th>내용</th>
+                                            <th className="text-center">평점</th>
+                                            <th>작성일</th>
+                                            <th>상태</th>
+                                            <th className="text-center">관리</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {comments.list.map((comment) => (
+                                            <tr key={comment.commentId}>
+                                                <td>{comment.commentId}</td>
+                                                <td>{comment.memberId}</td>
+                                                <td className="admin-comment-content" title={comment.content}>{comment.content}</td>
+                                                <td className="text-center">
+                                                    <i className="bi bi-star-fill text-warning me-1"></i>{comment.star ?? 0}
+                                                </td>
+                                                <td>{formatDate(comment.createdAt)}</td>
+                                                <td><StatusBadge isDeleted={comment.isDeleted} /></td>
+                                                <td className="text-center">
+                                                    {comment.isDeleted ? (
+                                                        <button className="btn admin-btn-icon admin-btn-outline" title="댓글 복구"
+                                                            onClick={() => restoreComment(comment.commentId)}>
+                                                            <i className="bi bi-arrow-counterclockwise"></i>
+                                                        </button>
+                                                    ) : (
+                                                        <button className="btn admin-btn-icon admin-btn-danger" title="댓글 삭제"
+                                                            onClick={() => removeComment(comment.commentId)}>
+                                                            <i className="bi bi-trash3"></i>
+                                                        </button>
+                                                    )}
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
+                        <Pagination total={comments.totalElements} page={comments.page}
+                            onChange={(p) => loadComments(comments.post, p)} />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
 
     return (
         <div className="admin-page-spacer">
-            {showConfirm && (
-                <div className="modal show fade d-block admin-modal-backdrop" tabIndex={-1}>
-                    <div className="modal-dialog modal-dialog-centered">
-                        <div className="modal-content admin-modal-content">
-                            <div className="modal-header border-0">
-                                <h5 className="modal-title text-danger fw-semibold">
-                                    <i className="bi bi-trash3 me-2"></i>게시글 삭제
-                                </h5>
-                                <button type="button" className="btn-close admin-modal-close-icon" aria-label="닫기"
-                                    onClick={() => setShowConfirm(false)} />
-                            </div>
-                            <div className="modal-body text-center">
-                                <p className="fs-5 mb-3 text-dark">정말 <span className="fw-bold text-danger">삭제</span>하시겠습니까?</p>
-                                <div className="d-flex justify-content-center gap-3 mt-4">
-                                    <button className="btn btn-outline-secondary px-4" onClick={() => setShowConfirm(false)}>취소</button>
-                                    <button className="btn btn-danger px-4 shadow-sm" onClick={removePost}>
-                                        <i className="bi bi-trash3 me-1"></i> 삭제
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            )}
+            {confirm && renderConfirmModal()}
+            {detail && renderDetailModal()}
+            {comments && renderCommentsModal()}
             <div className="container admin-post-container">
                 <AdminPageHeader title="여행지 관리" />
-                <div className="row g-4">
-                    <div className="col-12">
-                        <div className="panel-bg p-4 rounded-4 h-100 shadow-sm admin-post-panel">
-                            <PostList
-                                title={<span className="text-info"><i className="bi bi-search me-1"></i>게시글 목록</span>}
-                                posts={esPosts} loading={esLoading} error={esError}
-                                categoryColors={categoryColors} regionColors={regionColors}
-                                formatDate={formatDate} onRemove={handleRemove} onClickCard={handleGoDetail}
-                            />
-                            <Pagination total={esDocCount} page={esPage} onChange={handleEsPageChange} pageSize={ES_PAGE_SIZE} />
-                        </div>
+                <div className="d-flex align-items-center gap-2 mb-3">
+                    {DELETED_FILTERS.map((f) => (
+                        <button key={f.key}
+                            className={`btn admin-btn admin-btn-sm ${filterKey === f.key ? "admin-btn-primary" : "admin-btn-outline"}`}
+                            onClick={() => handleFilterChange(f.key)}>
+                            {f.label}
+                        </button>
+                    ))}
+                    <span className="ms-auto text-secondary small">총 {totalElements}건</span>
+                </div>
+                <div className="admin-table-card">
+                    <div className="table-responsive">
+                        <table className="table admin-table align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>제목</th>
+                                    <th>작성자</th>
+                                    <th className="text-center">조회</th>
+                                    <th className="text-center">댓글</th>
+                                    <th className="text-center">좋아요</th>
+                                    <th className="text-center">평점</th>
+                                    <th>작성일</th>
+                                    <th>상태</th>
+                                    <th className="text-center">관리</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {loading ? (
+                                    <tr>
+                                        <td colSpan={10} className="text-center py-5">
+                                            <div className="spinner-border text-primary me-2" role="status"></div>로딩 중...
+                                        </td>
+                                    </tr>
+                                ) : error ? (
+                                    <tr>
+                                        <td colSpan={10} className="text-center text-danger py-5">에러 발생: {error.message}</td>
+                                    </tr>
+                                ) : posts.length === 0 ? (
+                                    <tr>
+                                        <td colSpan={10} className="text-center text-secondary py-5">게시글이 없습니다.</td>
+                                    </tr>
+                                ) : (
+                                    posts.map((post) => (
+                                        <tr key={post.postId}>
+                                            <td>{post.postId}</td>
+                                            <td>
+                                                <button className="admin-post-title-btn text-truncate" title={post.title}
+                                                    onClick={() => openDetail(post.postId)}>
+                                                    {post.title}
+                                                </button>
+                                            </td>
+                                            <td>{post.memberId}</td>
+                                            <td className="text-center">{post.viewCount ?? 0}</td>
+                                            <td className="text-center">{post.commentCount ?? 0}</td>
+                                            <td className="text-center">{post.likeCount ?? 0}</td>
+                                            <td className="text-center">
+                                                <i className="bi bi-star-fill text-warning me-1"></i>{post.starAvg ? post.starAvg.toFixed(1) : 0}
+                                            </td>
+                                            <td>{formatDate(post.createdAt)}</td>
+                                            <td>
+                                                <StatusBadge isDeleted={post.isDeleted} />
+                                                {post.isDeleted && post.deletedAt && (
+                                                    <div className="text-secondary small">{formatDate(post.deletedAt)}</div>
+                                                )}
+                                            </td>
+                                            <td className="text-center">
+                                                <div className="d-inline-flex gap-1">
+                                                    <button className="btn admin-btn-icon admin-btn-outline" title="댓글 관리"
+                                                        onClick={() => loadComments(post, 0)}>
+                                                        <i className="bi bi-chat-dots"></i>
+                                                    </button>
+                                                    {post.isDeleted ? (
+                                                        <>
+                                                            <button className="btn admin-btn-icon admin-btn-outline" title="복구"
+                                                                onClick={() => restorePost(post.postId)}>
+                                                                <i className="bi bi-arrow-counterclockwise"></i>
+                                                            </button>
+                                                            <button className="btn admin-btn-icon admin-btn-danger" title="영구 삭제"
+                                                                onClick={() => setConfirm({ type: "permanent", post })}>
+                                                                <i className="bi bi-trash3-fill"></i>
+                                                            </button>
+                                                        </>
+                                                    ) : (
+                                                        <button className="btn admin-btn-icon admin-btn-danger" title="삭제"
+                                                            onClick={() => setConfirm({ type: "delete", post })}>
+                                                            <i className="bi bi-trash3"></i>
+                                                        </button>
+                                                    )}
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    ))
+                                )}
+                            </tbody>
+                        </table>
                     </div>
                 </div>
-
+                <Pagination total={totalElements} page={page} onChange={setPage} />
             </div>
         </div>
     );

--- a/src/api/adminPostApi.js
+++ b/src/api/adminPostApi.js
@@ -1,0 +1,33 @@
+import apiClient from './client';
+
+// 전체 게시글 목록 (삭제 여부 필터, 페이징) — deleted 생략 시 전체
+export const getAdminPosts = ({ deleted, page, size, sort } = {}) =>
+  apiClient.get('/api/v1/admin/posts', { params: { deleted, page, size, sort } });
+
+// 삭제 포함 게시글 상세 조회
+export const getAdminPost = (postId) =>
+  apiClient.get(`/api/v1/admin/posts/${postId}`);
+
+// 게시글 강제 삭제 (작성자 확인 없는 소프트 삭제)
+export const deleteAdminPost = (postId) =>
+  apiClient.delete(`/api/v1/admin/posts/${postId}`);
+
+// 게시글 복구
+export const restoreAdminPost = (postId) =>
+  apiClient.patch(`/api/v1/admin/posts/${postId}/restore`);
+
+// 게시글 영구 삭제 (DB + S3)
+export const permanentDeleteAdminPost = (postId) =>
+  apiClient.delete(`/api/v1/admin/posts/${postId}/permanent`);
+
+// 전체 댓글 목록 (게시글/삭제 여부 필터, 페이징)
+export const getAdminComments = ({ postId, deleted, page, size, sort } = {}) =>
+  apiClient.get('/api/v1/admin/comments', { params: { postId, deleted, page, size, sort } });
+
+// 댓글 강제 삭제
+export const deleteAdminComment = (commentId) =>
+  apiClient.delete(`/api/v1/admin/comments/${commentId}`);
+
+// 댓글 복구
+export const restoreAdminComment = (commentId) =>
+  apiClient.patch(`/api/v1/admin/comments/${commentId}/restore`);

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -59,64 +59,42 @@
   pointer-events: none;
 }
 
-/* 관리자 게시글 카드 (AdminPostManagement) */
-.admin-post-card {
-  transition: box-shadow 0.18s, transform 0.16s, background 0.16s, border 0.13s;
-  border: 1.5px solid #f0f0f7;
-  background: var(--card-bg);
-  border-radius: 1.1rem;
-  min-height: 88px;
-  box-shadow: var(--card-shadow);
-  position: relative;
+/* 관리자 게시글 테이블/모달 (AdminPostManagement) */
+.admin-post-title-btn {
+  display: inline-block;
+  background: none;
+  border: none;
+  padding: 0;
+  font-weight: 600;
+  color: var(--page-title-color);
+  max-width: 320px;
+  text-align: left;
 }
 
-.admin-post-card:hover,
-.admin-post-card:focus {
-  box-shadow: 0 8px 28px 0 rgba(123, 82, 255, 0.16), 0 2px 16px rgba(60, 0, 128, 0.04);
-  border-color: #a084ee;
-  background: #f6f3ff;
-  transform: translateY(-2px) scale(1.012);
-  cursor: pointer;
+.admin-post-title-btn:hover,
+.admin-post-title-btn:focus {
+  text-decoration: underline;
 }
 
-.admin-post-card-title-row {
-  font-size: 1.12rem;
-  margin-bottom: 6px;
+.admin-post-detail-content {
+  white-space: pre-wrap;
+  max-height: 260px;
+  overflow-y: auto;
 }
 
-.admin-post-card-title {
-  max-width: 75%;
+.admin-post-detail-thumb {
+  width: 96px;
+  height: 72px;
+  object-fit: cover;
+  border-radius: var(--radius-card-sm);
+  border: 1px solid var(--admin-border);
 }
 
-.admin-post-card-title-text {
-  color: #222;
-  font-weight: bold;
-  font-family: var(--font-display);
-}
-
-.admin-post-card-date {
-  font-size: 0.95rem;
+.admin-comment-content {
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.admin-post-card-meta {
-  font-size: 0.97rem;
-  min-height: 36px;
-}
-
-.admin-post-card-author {
-  color: #222;
-}
-
-.admin-post-card-stat {
-  font-size: 1rem;
-  font-weight: 500;
-}
-
-.admin-post-card-star {
-  color: #ffc107;
-  font-size: 1rem;
-  font-weight: 500;
 }
 
 /* ===== 관리자 페이지 공통 (AdminPage / AdminPostManagement) ===== */
@@ -127,11 +105,6 @@
 .admin-post-container {
   max-width: 1500px;
   padding-bottom: 40px;
-}
-
-.admin-post-panel {
-  background: rgba(250, 251, 255, 0.97);
-  min-height: 540px;
 }
 
 .admin-modal-backdrop {


### PR DESCRIPTION
## 관련 이슈
closes #83

## 변경 사항
- `src/api/adminPostApi.js` 신설 — 신규 관리자 API 8개 바인딩 (posts 목록/상세/삭제/복구/영구삭제, comments 목록/삭제/복구)
- `AdminPostManagement.jsx` 개편
  - 데이터 소스: 검색 API(`/api/v1/search/posts`) → 관리자 API(`/api/v1/admin/posts`)
  - 목록 DTO에 category/region/닉네임이 없어 카드 → **테이블 레이아웃 전환** (회원 관리의 `admin-table` 체계와 통일). 컬럼: ID/제목/작성자ID/조회/댓글/좋아요/평점/작성일/상태/관리
  - **삭제 여부 필터** (전체/활성/삭제됨) + 총 건수 표시
  - **상세 모달** — `GET /admin/posts/{id}` (삭제된 글 포함, category/region 배지·본문·이미지·삭제일). 활성 글은 "게시글 페이지로 이동" 버튼 제공
  - **소프트 삭제**(확인 모달) / **복구** / **영구 삭제**(DB+S3 경고 모달)
  - **댓글 관리 모달** — 게시글별 댓글 조회(`GET /admin/comments?postId=`) + 강제 삭제/복구
  - 삭제/복구로 마지막 페이지가 비면 이전 페이지로 자동 이동
- `main.css` — 미사용 `admin-post-card*`/`admin-post-panel` 제거, `admin-post-title-btn`·`admin-post-detail-content`·`admin-post-detail-thumb`·`admin-comment-content` 추가 (토큰 변수만 사용, hex 없음)

## 작업 방법
- 로컬 Swagger(`web-api-service` 그룹)에서 신규 admin 엔드포인트 파라미터/DTO 스키마 확인 후 바인딩 (`AdminPostResponse.ListDTO`에는 category/region 없음 → 상세 모달에서만 표기)
- 응답 접근은 공통 래퍼 패턴(`data.result` / `data.result.content`) 유지
- 기존 `deletePost`(일반 삭제 API) 의존 제거 → `deleteAdminPost`(강제 삭제)로 대체. `src/api/` 기존 파일은 수정하지 않음

## 테스트
- `npm run build` 통과 (신규 경고 없음)
- 프로덕션 빌드 + Playwright(API 목킹, 가짜 admin JWT)로 E2E 검증:
  - 목록 로드 `GET /api/v1/admin/posts?page=0&size=10` → 3행 렌더
  - 필터 클릭 `?deleted=true` / `?deleted=false` 전달 확인
  - 상세 모달 `GET /admin/posts/2` (삭제된 글) 렌더
  - 댓글 모달 `GET /admin/comments?postId=2` → `DELETE /admin/comments/100` → `PATCH /admin/comments/101/restore` (각 후 재조회)
  - `PATCH /admin/posts/2/restore`, `DELETE /admin/posts/2/permanent`(확인 모달 경유), `DELETE /admin/posts/1`(소프트) 호출 확인
  - 콘솔/페이지 에러 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)