### PR TITLE
✨ Feat: 로그인 페이지 카카오 소셜 로그인 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ src/analytics/
 | 데이터 | 시점 | 호출 위치 | 필드 |
 |---|---|---|---|
 | userId (토큰 sub 또는 익명 UUID) — `initAnalytics` 내부 | 앱 부팅 1회 (컨테이너 삽입 직전) | `src/analytics/analytics.js` (호출: `src/index.js`) | userId만 — gender/ageGroup/role은 부팅 시점에 알 수 없어 미전송 (M3에서 age -1·role "user" 매직 값 제거) |
-| 로그인 유저 속성 (`setLoggedInUserAttributes`) | 로그인 성공 | `src/sign/components/SignInPage.jsx` | userId(토큰 식별자로 전환), gender, ageGroup(연령대 구간, 예: "20대"), role — **개인정보 방침(M2 결정): nickname·age 원값 미전송** |
+| 로그인 유저 속성 (`setLoggedInUserAttributes`) | 로그인 성공 (일반·카카오 소셜 공통) | `src/hooks/useLoginSuccess.js` (SignInPage·OAuth2RedirectPage 공유, 이슈 #85) | userId(토큰 식별자로 전환), gender, ageGroup(연령대 구간, 예: "20대"), role — **개인정보 방침(M2 결정): nickname·age 원값 미전송** |
 | 유저 속성 리셋 (`resetUser`) | 로그아웃 | `src/common/Navbar.jsx` | userId(익명 UUID로 복귀), gender/ageGroup null, role "user" |
 
 ### 현재 이벤트 (M1에서 `events.js` 트래커 → `_mtm` push로 이관 완료, 이슈 #73)
@@ -89,7 +89,7 @@ src/analytics/
 | 이벤트 | 발화 시점 | 트래커 함수 (`src/analytics/events.js`) / 호출 위치 | 페이로드 | 목적 |
 |---|---|---|---|---|
 | `travel_signup_complete` | 회원가입 성공 | `trackSignupComplete` / `src/hooks/useSignUpForm.js` | gender, ageGroup(연령대 구간 — 개인정보 방침에 따라 age 원값 미전송) | 가입 퍼널 |
-| `travel_login` / `travel_login_fail` | 로그인 성공/실패 | `trackLogin` / `trackLoginFail` / `src/sign/components/SignInPage.jsx` | 성공 시 role("admin"\|"user"), 실패 시 공통 필드만 | 로그인 퍼널 |
+| `travel_login` / `travel_login_fail` | 로그인 성공/실패 (일반·카카오 소셜 공통) | `trackLogin` / `trackLoginFail` / 성공: `src/hooks/useLoginSuccess.js`, 실패: `src/sign/components/SignInPage.jsx`·`OAuth2RedirectPage.jsx` | 성공 시 role("admin"\|"user"), 실패 시 공통 필드만 | 로그인 퍼널 |
 | `travel_post_add` | 게시글 작성 성공 | `trackPostAdd` / `src/post/pages/PostWritePage.jsx` | postId(생성 응답에서 확보, 없으면 null), category, region (코드값) | 콘텐츠 생산 지표 |
 | `travel_post_update` / `_remove` | 게시글 수정/삭제 성공 | `trackPostUpdate` / `trackPostRemove` / `src/post/pages/PostEditPage.jsx` | postId, category, region (코드값) | 콘텐츠 생산 지표 |
 | `travel_search_result` | 검색 결과 로드 성공 (정렬/페이지 이동 포함 매 로드) | `trackSearchResult` / `src/post/pages/PostListPage.jsx` | keyword, category, region, resultCount(totalElements, 없으면 페이지 건수) | **0건 검색 = 콘텐츠 갭** |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ src/analytics/
 | 데이터 | 시점 | 호출 위치 | 필드 |
 |---|---|---|---|
 | userId (토큰 sub 또는 익명 UUID) — `initAnalytics` 내부 | 앱 부팅 1회 (컨테이너 삽입 직전) | `src/analytics/analytics.js` (호출: `src/index.js`) | userId만 — gender/ageGroup/role은 부팅 시점에 알 수 없어 미전송 (M3에서 age -1·role "user" 매직 값 제거) |
-| 로그인 유저 속성 (`setLoggedInUserAttributes`) | 로그인 성공 (일반·카카오 소셜 공통) | `src/hooks/useLoginSuccess.js` (SignInPage·OAuth2RedirectPage 공유, 이슈 #85) | userId(토큰 식별자로 전환), gender, ageGroup(연령대 구간, 예: "20대"), role — **개인정보 방침(M2 결정): nickname·age 원값 미전송** |
+| 로그인 유저 속성 (`setLoggedInUserAttributes`) | 로그인 성공 (일반·카카오 소셜 공통) + 소셜 추가 정보 입력 완료 | `src/hooks/useLoginSuccess.js` (SignInPage·OAuth2RedirectPage 공유), `src/hooks/useSocialProfileForm.js` (이슈 #85) | userId(토큰 식별자로 전환), gender(백엔드 "NONE"은 null 정규화), ageGroup(연령대 구간, 예: "20대"), role — **개인정보 방침(M2 결정): nickname·age 원값 미전송** |
 | 유저 속성 리셋 (`resetUser`) | 로그아웃 | `src/common/Navbar.jsx` | userId(익명 UUID로 복귀), gender/ageGroup null, role "user" |
 
 ### 현재 이벤트 (M1에서 `events.js` 트래커 → `_mtm` push로 이관 완료, 이슈 #73)
@@ -88,7 +88,7 @@ src/analytics/
 
 | 이벤트 | 발화 시점 | 트래커 함수 (`src/analytics/events.js`) / 호출 위치 | 페이로드 | 목적 |
 |---|---|---|---|---|
-| `travel_signup_complete` | 회원가입 성공 | `trackSignupComplete` / `src/hooks/useSignUpForm.js` | gender, ageGroup(연령대 구간 — 개인정보 방침에 따라 age 원값 미전송) | 가입 퍼널 |
+| `travel_signup_complete` | 회원가입 성공 (일반: signUp 성공, 소셜: 추가 정보 입력 완료) | `trackSignupComplete` / `src/hooks/useSignUpForm.js`(일반)·`src/hooks/useSocialProfileForm.js`(소셜, 이슈 #85) | gender, ageGroup(연령대 구간 — 개인정보 방침에 따라 age 원값 미전송) | 가입 퍼널 |
 | `travel_login` / `travel_login_fail` | 로그인 성공/실패 (일반·카카오 소셜 공통) | `trackLogin` / `trackLoginFail` / 성공: `src/hooks/useLoginSuccess.js`, 실패: `src/sign/components/SignInPage.jsx`·`OAuth2RedirectPage.jsx` | 성공 시 role("admin"\|"user"), 실패 시 공통 필드만 | 로그인 퍼널 |
 | `travel_post_add` | 게시글 작성 성공 | `trackPostAdd` / `src/post/pages/PostWritePage.jsx` | postId(생성 응답에서 확보, 없으면 null), category, region (코드값) | 콘텐츠 생산 지표 |
 | `travel_post_update` / `_remove` | 게시글 수정/삭제 성공 | `trackPostUpdate` / `trackPostRemove` / `src/post/pages/PostEditPage.jsx` | postId, category, region (코드값) | 콘텐츠 생산 지표 |

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -88,12 +88,14 @@ export const toAgeGroup = (age) => {
 /**
  * 로그인 성공 시 유저 속성을 갱신한다. userId를 익명 UUID → 토큰 식별자로 전환한다.
  * 개인정보 최소화 방침(M2 결정): nickname은 보내지 않고, age는 연령대 구간(ageGroup)으로 변환한다.
- * 호출 위치: src/hooks/useLoginSuccess.js — 일반/소셜 로그인 공통 (accessToken 저장 이후에 호출해야 userId가 갱신된다)
+ * 신규 소셜 회원의 gender "NONE"(백엔드 기본값 = 미입력)은 null로 정규화한다.
+ * 호출 위치: src/hooks/useLoginSuccess.js — 일반/소셜 로그인 공통 (accessToken 저장 이후에 호출해야 userId가 갱신된다),
+ *           src/hooks/useSocialProfileForm.js — 소셜 추가 정보 입력 완료 시 갱신
  */
 export const setLoggedInUserAttributes = ({ gender, age, role }) => {
   setUserAttributes({
     userId: getUserIdForMatomo(),
-    gender: gender || null,
+    gender: gender && gender !== "NONE" ? gender : null,
     ageGroup: toAgeGroup(age),
     role,
   });

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -88,7 +88,7 @@ export const toAgeGroup = (age) => {
 /**
  * 로그인 성공 시 유저 속성을 갱신한다. userId를 익명 UUID → 토큰 식별자로 전환한다.
  * 개인정보 최소화 방침(M2 결정): nickname은 보내지 않고, age는 연령대 구간(ageGroup)으로 변환한다.
- * 호출 위치: src/sign/components/SignInPage.jsx (accessToken 저장 이후에 호출해야 userId가 갱신된다)
+ * 호출 위치: src/hooks/useLoginSuccess.js — 일반/소셜 로그인 공통 (accessToken 저장 이후에 호출해야 userId가 갱신된다)
  */
 export const setLoggedInUserAttributes = ({ gender, age, role }) => {
   setUserAttributes({

--- a/src/analytics/events.js
+++ b/src/analytics/events.js
@@ -140,9 +140,9 @@ const toAgeFromBirthDate = (birthDate) => {
 };
 
 /**
- * 회원가입 성공 시 발화. (가입 퍼널)
+ * 회원가입 성공 시 발화. (가입 퍼널 — 일반 가입은 signUp 성공, 소셜 가입은 추가 정보 입력 완료가 가입 완료 시점)
  * 개인정보 최소화 방침(M2 결정): 나이 원값은 보내지 않고 연령대 구간(ageGroup)으로 변환한다.
- * 호출 위치: src/hooks/useSignUpForm.js
+ * 호출 위치: src/hooks/useSignUpForm.js (일반), src/hooks/useSocialProfileForm.js (소셜)
  * 페이로드: gender(string|null), ageGroup(string|null — 예: "20대")
  */
 export const trackSignupComplete = ({ gender, birthDate }) => {

--- a/src/analytics/events.js
+++ b/src/analytics/events.js
@@ -153,8 +153,8 @@ export const trackSignupComplete = ({ gender, birthDate }) => {
 };
 
 /**
- * 로그인 성공 시 발화. (로그인 퍼널)
- * 호출 위치: src/sign/components/SignInPage.jsx
+ * 로그인 성공 시 발화. (로그인 퍼널 — 일반/카카오 소셜 로그인 공통)
+ * 호출 위치: src/hooks/useLoginSuccess.js (SignInPage·OAuth2RedirectPage가 공유)
  * 페이로드: role("admin"|"user")
  */
 export const trackLogin = ({ role }) => {
@@ -163,7 +163,7 @@ export const trackLogin = ({ role }) => {
 
 /**
  * 로그인 실패 시 발화. (로그인 퍼널 — 실패 원인은 보안상 페이로드에 싣지 않는다)
- * 호출 위치: src/sign/components/SignInPage.jsx
+ * 호출 위치: src/sign/components/SignInPage.jsx, src/sign/components/OAuth2RedirectPage.jsx
  * 페이로드: 없음 (공통 필드만)
  */
 export const trackLoginFail = () => {

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -1,4 +1,4 @@
-import apiClient from './client';
+import apiClient, { BASE_URL } from './client';
 
 export const login = (payload) =>
   apiClient.post('/api/v1/auth/login', payload);
@@ -11,3 +11,8 @@ export const refreshTokens = () =>
 
 export const oauth2Tokens = (payload) =>
   apiClient.post('/api/v1/auth/oauth2/tokens', payload);
+
+// 소셜 로그인 인가 시작 URL — XHR이 아닌 최상위 페이지 이동(window.location)으로 진입해야 한다.
+// 백엔드가 벤더 인증 후 FRONTEND_REDIRECT_URI(/oauth2/redirect)로 일회용 코드를 리다이렉트한다.
+export const getOauth2AuthorizeUrl = (provider) =>
+  `${BASE_URL}/api/v1/auth/oauth2/authorize/${provider}`;

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { toast } from "react-toastify";
 
-const BASE_URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:8000";
+export const BASE_URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:8000";
 
 const apiClient = axios.create({
   baseURL: BASE_URL,

--- a/src/api/memberApi.js
+++ b/src/api/memberApi.js
@@ -8,7 +8,7 @@ export const signUp = (payload) =>
 export const getMyProfile = () =>
   apiClient.get('/api/v1/members/me');
 
-// 내 정보 수정 (닉네임)
+// 내 정보 수정 (nickname 필수, gender/birthDate 선택 — 소셜 가입 추가 정보 입력에도 사용)
 export const updateMyProfile = (payload) =>
   apiClient.patch('/api/v1/members/me', payload);
 

--- a/src/common/PageRouter.jsx
+++ b/src/common/PageRouter.jsx
@@ -5,6 +5,7 @@ import SignUpPage from '../sign/components/SignUpPage';
 import SignUpdatePage from "../sign/components/SignUpdatePage";
 import SignInPage from "../sign/components/SignInPage";
 import OAuth2RedirectPage from "../sign/components/OAuth2RedirectPage";
+import SocialProfilePage from "../sign/components/SocialProfilePage";
 import PasswordChangePage from "../sign/components/PasswordChangePage";
 import MyPage from '../sign/components/MyPage';
 
@@ -58,6 +59,7 @@ const PageRouter = () => {
                     <Route path="/post/favorite-list" element={<PrivateRoute><FavoriteListPage /></PrivateRoute>} />
                     <Route path="/post/my-article" element={<PrivateRoute><MyPostsPage /></PrivateRoute>} />
                     <Route path="/mypage" element={<PrivateRoute><MyPage /></PrivateRoute>} />
+                    <Route path="/sign/social-profile" element={<PrivateRoute><SocialProfilePage /></PrivateRoute>} />
                     <Route path="/sign/update" element={<PrivateRoute><SignUpdatePage /></PrivateRoute>} />
                     <Route path="/sign/update/password" element={<PrivateRoute><PasswordChangePage /></PrivateRoute>} />
                     <Route path="/comment/my-comments" element={<PrivateRoute><MyCommentsPage /></PrivateRoute>} />

--- a/src/common/PageRouter.jsx
+++ b/src/common/PageRouter.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import SignUpPage from '../sign/components/SignUpPage';
 import SignUpdatePage from "../sign/components/SignUpdatePage";
 import SignInPage from "../sign/components/SignInPage";
+import OAuth2RedirectPage from "../sign/components/OAuth2RedirectPage";
 import PasswordChangePage from "../sign/components/PasswordChangePage";
 import MyPage from '../sign/components/MyPage';
 
@@ -48,6 +49,7 @@ const PageRouter = () => {
                     <Route path="/post/detail" element={<PostDetailPage />} />
                     <Route path="/sign/in" element={<SignInPage />} />
                     <Route path="/sign/up" element={<SignUpPage />} />
+                    <Route path="/oauth2/redirect" element={<OAuth2RedirectPage />} />
                     <Route path="/campaign-plan" element={<CampaignPlan />} />
 
                     {/* 로그인 필요 */}

--- a/src/constants/oauth.js
+++ b/src/constants/oauth.js
@@ -1,0 +1,16 @@
+// 소셜 로그인 상수
+// 백엔드 OAuth2FailureCode(web-api-service)가 /oauth2/redirect?error=<코드>로 전달하는 값과 1:1 매핑
+
+export const OAUTH2_PROVIDERS = {
+    KAKAO: 'kakao',
+};
+
+export const OAUTH2_ERROR_MESSAGES = {
+    access_denied: '로그인 동의가 취소되었습니다.',
+    provider_server_error: '인증 서버와 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+    session_expired: '세션이 만료되었습니다. 다시 시도해주세요.',
+    authentication_failed: '인증에 실패했습니다. 다시 시도해주세요.',
+    system_error: '인증 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+};
+
+export const OAUTH2_DEFAULT_ERROR_MESSAGE = '소셜 로그인 중 오류가 발생했습니다. 다시 시도해주세요.';

--- a/src/css/sign.css
+++ b/src/css/sign.css
@@ -12,6 +12,26 @@
   position: relative;
 }
 
+/* ===== 로그인 소셜 버튼 (SignInPage) ===== */
+.kakao-login-btn {
+  background: var(--kakao-yellow);
+  color: var(--kakao-label);
+  border: none;
+  font-weight: 600;
+}
+
+.kakao-login-btn:hover,
+.kakao-login-btn:focus,
+.kakao-login-btn:active {
+  background: var(--kakao-yellow-hover);
+  color: var(--kakao-label);
+}
+
+.kakao-login-symbol {
+  vertical-align: -0.2em;
+  margin-right: 0.5rem;
+}
+
 /* ===== 회원 정보수정 / 비밀번호 변경 공통 카드 ===== */
 .sign-card {
   max-width: 420px;

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -48,6 +48,11 @@
   --font-display: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Malgun Gothic', sans-serif;
   --page-title-color: #6c45e0;
 
+  /* 소셜 로그인 — 카카오 브랜드 가이드 고정 색상 (임의 변경 금지) */
+  --kakao-yellow: #FEE500;
+  --kakao-yellow-hover: #F2D900;
+  --kakao-label: rgba(0, 0, 0, 0.85);
+
   /* 관리자 (Admin) */
   --brand-tint: #EEF0FB;
   --admin-border: #E4E7F5;

--- a/src/hooks/useLoginSuccess.js
+++ b/src/hooks/useLoginSuccess.js
@@ -1,0 +1,36 @@
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { getMyProfile } from '../api/memberApi';
+import { isAdmin } from '../utils/tokenUtils';
+import { setLoggedInUserAttributes } from '../analytics/analytics';
+import { trackLogin } from '../analytics/events';
+
+/**
+ * 로그인 성공 공통 처리 훅 — 일반 로그인(SignInPage)과 소셜 로그인(OAuth2RedirectPage)이 공유한다.
+ * completeLogin(accessToken): 토큰 저장 → 프로필 조회 → nickname 저장
+ *   → Matomo 유저 속성 갱신 + travel_login 발화 → 환영 toast → 메인 이동.
+ * 실패 예외는 삼키지 않고 호출부로 전파한다 (호출부에서 travel_login_fail·에러 안내 처리).
+ */
+const useLoginSuccess = () => {
+    const navigate = useNavigate();
+
+    const completeLogin = async (accessToken) => {
+        localStorage.setItem('accessToken', accessToken);
+        const { data: profileRes } = await getMyProfile();
+        const member = profileRes.result ?? profileRes;
+        localStorage.setItem('nickname', member.nickname);
+        const role = isAdmin(accessToken) ? "admin" : "user";
+        setLoggedInUserAttributes({
+            gender: member.gender,
+            age: member.age,
+            role
+        });
+        trackLogin({ role });
+        toast.success(`${member.nickname}님 환영합니다.`);
+        navigate("/");
+    };
+
+    return { completeLogin };
+};
+
+export default useLoginSuccess;

--- a/src/hooks/useLoginSuccess.js
+++ b/src/hooks/useLoginSuccess.js
@@ -9,6 +9,7 @@ import { trackLogin } from '../analytics/events';
  * 로그인 성공 공통 처리 훅 — 일반 로그인(SignInPage)과 소셜 로그인(OAuth2RedirectPage)이 공유한다.
  * completeLogin(accessToken): 토큰 저장 → 프로필 조회 → nickname 저장
  *   → Matomo 유저 속성 갱신 + travel_login 발화 → 환영 toast → 메인 이동.
+ * 신규 소셜 회원(백엔드 자동 가입 직후라 nickname이 없음)은 추가 정보 입력(/sign/social-profile)으로 보낸다.
  * 실패 예외는 삼키지 않고 호출부로 전파한다 (호출부에서 travel_login_fail·에러 안내 처리).
  */
 const useLoginSuccess = () => {
@@ -18,7 +19,6 @@ const useLoginSuccess = () => {
         localStorage.setItem('accessToken', accessToken);
         const { data: profileRes } = await getMyProfile();
         const member = profileRes.result ?? profileRes;
-        localStorage.setItem('nickname', member.nickname);
         const role = isAdmin(accessToken) ? "admin" : "user";
         setLoggedInUserAttributes({
             gender: member.gender,
@@ -26,6 +26,12 @@ const useLoginSuccess = () => {
             role
         });
         trackLogin({ role });
+        if (!member.nickname) {
+            toast.info("추가 정보를 입력하면 가입이 완료됩니다.");
+            navigate("/sign/social-profile", { replace: true });
+            return;
+        }
+        localStorage.setItem('nickname', member.nickname);
         toast.success(`${member.nickname}님 환영합니다.`);
         navigate("/");
     };

--- a/src/hooks/useSocialProfileForm.js
+++ b/src/hooks/useSocialProfileForm.js
@@ -1,0 +1,132 @@
+import { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { checkNickname, getMyProfile, updateMyProfile } from '../api/memberApi';
+import { isAdmin } from '../utils/tokenUtils';
+import { setLoggedInUserAttributes } from '../analytics/analytics';
+import { trackSignupComplete } from '../analytics/events';
+
+/**
+ * 소셜 로그인 추가 정보 입력 폼 훅 (SocialProfilePage 전용).
+ * 신규 소셜 회원은 백엔드가 provider/providerId/email만으로 자동 가입시키므로
+ * nickname/gender/birthDate를 여기서 받아 PATCH /members/me로 채운다.
+ * 제출 성공 = 소셜 가입 완료 시점 → travel_signup_complete 발화 + 유저 속성 갱신.
+ */
+const useSocialProfileForm = () => {
+    const navigate = useNavigate();
+    const [formData, setFormData] = useState({ nickname: '', gender: '' });
+    const [birthDate, setBirthDate] = useState('');
+    const [alert, setAlert] = useState({ show: false, message: '', type: '' });
+    const [touched, setTouched] = useState({});
+    const [errors, setErrors] = useState({});
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [nicknameDup, setNicknameDup] = useState(null);
+    const inputRefs = {
+        nickname: useRef(null),
+        gender: useRef(null),
+        birthDate: useRef(null)
+    };
+
+    // 이미 프로필이 완성된 회원(직접 URL 진입 등)은 메인으로 돌려보낸다
+    useEffect(() => {
+        const guard = async () => {
+            try {
+                const { data } = await getMyProfile();
+                const member = data.result ?? data;
+                if (member.nickname) navigate('/', { replace: true });
+            } catch {
+                navigate('/sign/in', { replace: true });
+            }
+        };
+        guard();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setFormData(prev => ({ ...prev, [name]: value }));
+        setTouched(prev => ({ ...prev, [name]: true }));
+        if (name === 'nickname') setNicknameDup(null);
+    };
+
+    const handleBirthDate = (e) => {
+        setBirthDate(e.target.value);
+        setTouched(prev => ({ ...prev, birthDate: true }));
+    };
+
+    // 닉네임 중복 확인 (회원가입 폼과 동일한 500ms 디바운스)
+    useEffect(() => {
+        if (!formData.nickname) return;
+        const timer = setTimeout(async () => {
+            try {
+                const { data } = await checkNickname(formData.nickname);
+                const result = data.result;
+                setNicknameDup(result.exists === true || result.available === false);
+            } catch {
+                setNicknameDup(false);
+            }
+        }, 500);
+        return () => clearTimeout(timer);
+    }, [formData.nickname]);
+
+    useEffect(() => {
+        const newErrors = {};
+        if (!formData.nickname) newErrors.nickname = "닉네임을 입력하세요.";
+        else if (nicknameDup === true) newErrors.nickname = "이미 사용중인 닉네임입니다.";
+        if (!formData.gender) newErrors.gender = "성별을 선택하세요.";
+        if (!birthDate) newErrors.birthDate = "생년월일을 입력하세요.";
+        setErrors(newErrors);
+    }, [formData, birthDate, nicknameDup]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setTouched({ nickname: true, gender: true, birthDate: true });
+        if (Object.keys(errors).length > 0) {
+            const firstError = Object.keys(errors)[0];
+            inputRefs[firstError]?.current?.focus();
+            setAlert({ show: true, message: "모든 항목을 올바르게 입력해주세요.", type: "danger" });
+            return;
+        }
+        setIsSubmitting(true);
+        try {
+            await updateMyProfile({ nickname: formData.nickname, gender: formData.gender, birthDate });
+            localStorage.setItem('nickname', formData.nickname);
+            const role = isAdmin(localStorage.getItem('accessToken')) ? "admin" : "user";
+            // 백엔드가 birthDate로 계산한 age를 쓰기 위해 프로필을 재조회한다
+            const { data: profileRes } = await getMyProfile();
+            const member = profileRes.result ?? profileRes;
+            setLoggedInUserAttributes({
+                gender: member.gender,
+                age: member.age,
+                role
+            });
+            trackSignupComplete({ gender: member.gender, birthDate });
+            toast.success(`${formData.nickname}님 환영합니다.`);
+            navigate("/");
+        } catch (error) {
+            const msg = error.response?.data;
+            setAlert({ show: true, message: msg?.message || "에러가 발생했습니다.", type: "danger" });
+        }
+        setIsSubmitting(false);
+    };
+
+    const isFormValid = Object.keys(errors).length === 0 && !isSubmitting;
+
+    return {
+        formData,
+        birthDate,
+        alert,
+        setAlert,
+        touched,
+        errors,
+        isSubmitting,
+        nicknameDup,
+        isFormValid,
+        inputRefs,
+        handleChange,
+        handleBirthDate,
+        handleSubmit,
+    };
+};
+
+export default useSocialProfileForm;

--- a/src/sign/components/OAuth2RedirectPage.jsx
+++ b/src/sign/components/OAuth2RedirectPage.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { oauth2Tokens } from '../../api/authApi';
+import { trackLoginFail } from '../../analytics/events';
+import useLoginSuccess from '../../hooks/useLoginSuccess';
+import { OAUTH2_ERROR_MESSAGES, OAUTH2_DEFAULT_ERROR_MESSAGE } from '../../constants/oauth';
+
+/**
+ * 소셜 로그인 콜백 페이지 (/oauth2/redirect)
+ * 백엔드 OAuth2AuthenticationSuccessHandler가 카카오 인증 완료 후
+ * ?code=<일회용 코드> (실패 시 ?error=<코드>)를 실어 이 경로로 리다이렉트한다.
+ * 코드를 /api/v1/auth/oauth2/tokens에 제출해 토큰을 받고 일반 로그인과 동일하게 로그인을 완료한다.
+ */
+const OAuth2RedirectPage = () => {
+    const [searchParams] = useSearchParams();
+    const navigate = useNavigate();
+    const { completeLogin } = useLoginSuccess();
+    // 일회용 코드는 재사용이 불가하므로 StrictMode의 effect 중복 실행을 가드한다
+    const consumedRef = useRef(false);
+
+    useEffect(() => {
+        if (consumedRef.current) return;
+        consumedRef.current = true;
+
+        const code = searchParams.get('code');
+        const error = searchParams.get('error');
+
+        const failToSignIn = (message) => {
+            trackLoginFail();
+            toast.error(message);
+            navigate('/sign/in', { replace: true });
+        };
+
+        if (error || !code) {
+            failToSignIn(OAUTH2_ERROR_MESSAGES[error] || OAUTH2_DEFAULT_ERROR_MESSAGE);
+            return;
+        }
+
+        const exchangeCode = async () => {
+            try {
+                const { headers } = await oauth2Tokens({ code });
+                const accessToken = headers.authorization?.replace(/^Bearer\s+/i, '');
+                await completeLogin(accessToken);
+            } catch (err) {
+                failToSignIn(err.response?.data?.message || OAUTH2_DEFAULT_ERROR_MESSAGE);
+            }
+        };
+        exchangeCode();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+        <div className="min-vh-100 d-flex flex-column align-items-center justify-content-center sign-page-bg sign-page-bg-full">
+            <div className="spinner-border text-primary mb-3" role="status" />
+            <p className="text-muted">소셜 로그인 처리 중입니다...</p>
+        </div>
+    );
+};
+
+export default OAuth2RedirectPage;

--- a/src/sign/components/SignInPage.jsx
+++ b/src/sign/components/SignInPage.jsx
@@ -1,12 +1,10 @@
 import { useState } from 'react';
-import { login } from '../../api/authApi';
-import { getMyProfile } from '../../api/memberApi';
+import { login, getOauth2AuthorizeUrl } from '../../api/authApi';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import { isAdmin } from '../../utils/tokenUtils';
-import { setLoggedInUserAttributes } from '../../analytics/analytics';
-import { trackLogin, trackLoginFail } from '../../analytics/events';
+import { trackLoginFail } from '../../analytics/events';
 import useAlert from '../../hooks/useAlert';
+import useLoginSuccess from '../../hooks/useLoginSuccess';
+import { OAUTH2_PROVIDERS } from '../../constants/oauth';
 
 const SignInPage = () => {
     const [loginData, setLoginData] = useState({
@@ -15,6 +13,7 @@ const SignInPage = () => {
     });
     const { alert, showAlert } = useAlert();
     const navigate = useNavigate();
+    const { completeLogin } = useLoginSuccess();
 
     const handleChange = (e) => {
         const { name, value } = e.target;
@@ -26,23 +25,16 @@ const SignInPage = () => {
         try {
             const { headers } = await login(loginData);
             const accessToken = headers.authorization?.replace(/^Bearer\s+/i, '');
-            localStorage.setItem('accessToken', accessToken);
-            const { data: profileRes } = await getMyProfile();
-            const member = profileRes.result ?? profileRes;
-            localStorage.setItem('nickname', member.nickname);
-            const role = isAdmin(accessToken) ? "admin" : "user";
-            setLoggedInUserAttributes({
-                gender: member.gender,
-                age: member.age,
-                role
-            });
-            trackLogin({ role });
-            toast.success(`${member.nickname}님 환영합니다.`);
-            navigate("/");
+            await completeLogin(accessToken);
         } catch (error) {
             trackLoginFail();
             showAlert(error.response?.data?.message || "에러가 발생했습니다.", "danger");
         }
+    };
+
+    // 카카오 인가는 XHR이 아닌 최상위 페이지 이동으로 시작해야 한다 (백엔드가 카카오로 302 릴레이)
+    const handleKakaoLogin = () => {
+        window.location.href = getOauth2AuthorizeUrl(OAUTH2_PROVIDERS.KAKAO);
     };
 
     return (
@@ -100,6 +92,31 @@ const SignInPage = () => {
                                     </button>
                                 </div>
                             </form>
+                            {/* 소셜 로그인 */}
+                            <div className="d-flex align-items-center my-4">
+                                <hr className="flex-grow-1" />
+                                <span className="px-3 text-muted small">또는</span>
+                                <hr className="flex-grow-1" />
+                            </div>
+                            <button
+                                type="button"
+                                className="btn w-100 kakao-login-btn"
+                                onClick={handleKakaoLogin}
+                            >
+                                <svg
+                                    className="kakao-login-symbol"
+                                    viewBox="0 0 24 24"
+                                    width="18"
+                                    height="18"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fill="currentColor"
+                                        d="M12 3C6.48 3 2 6.54 2 10.9c0 2.8 1.86 5.26 4.66 6.66l-1.18 4.36c-.1.39.34.7.68.47l5.21-3.45c.21.01.42.02.63.02 5.52 0 10-3.54 10-7.9S17.52 3 12 3z"
+                                    />
+                                </svg>
+                                카카오 로그인
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/src/sign/components/SocialProfilePage.jsx
+++ b/src/sign/components/SocialProfilePage.jsx
@@ -1,0 +1,128 @@
+import useSocialProfileForm from '../../hooks/useSocialProfileForm';
+
+/**
+ * 소셜 로그인 추가 정보 입력 페이지 (/sign/social-profile)
+ * 카카오 첫 로그인 시 백엔드가 이메일만으로 자동 가입시키므로,
+ * useLoginSuccess가 nickname 없는 회원을 이 페이지로 보낸다. 폼 로직은 useSocialProfileForm에 위임.
+ */
+const SocialProfilePage = () => {
+    const {
+        formData,
+        birthDate,
+        alert,
+        setAlert,
+        touched,
+        errors,
+        isSubmitting,
+        nicknameDup,
+        isFormValid,
+        inputRefs,
+        handleChange,
+        handleBirthDate,
+        handleSubmit,
+    } = useSocialProfileForm();
+
+    return (
+        <div className="min-vh-100 d-flex flex-column sign-page-bg">
+            <main className="flex-grow-1 d-flex align-items-center justify-content-center">
+                <div className="card shadow-sm signup-card">
+                    <div className="card-body p-4">
+                        <div className="text-center signup-card-title">추가 정보 입력</div>
+                        <p className="text-muted text-center mb-4">
+                            처음 오셨네요! 서비스 이용에 필요한 정보를 입력하면 가입이 완료됩니다.
+                        </p>
+                        {alert.show && (
+                            <div className={`alert alert-${alert.type} alert-dismissible fade show`} role="alert">
+                                {alert.message}
+                                <button
+                                    type="button"
+                                    className="btn-close"
+                                    aria-label="Close"
+                                    onClick={() => setAlert({ ...alert, show: false })}
+                                ></button>
+                            </div>
+                        )}
+                        <form className="needs-validation" noValidate onSubmit={handleSubmit}>
+                            <div className="mb-3">
+                                <label htmlFor="nickname" className="form-label fw-semibold">닉네임</label>
+                                <input
+                                    type="text"
+                                    ref={inputRefs.nickname}
+                                    className={`form-control${touched.nickname && errors.nickname ? " is-invalid" : ""}${touched.nickname && nicknameDup === false ? " is-valid" : ""}`}
+                                    id="nickname" name="nickname"
+                                    value={formData.nickname}
+                                    onChange={handleChange}
+                                    placeholder="닉네임을 입력하세요"
+                                    required
+                                />
+                                {touched.nickname && nicknameDup === false && !errors.nickname && (
+                                    <div className="valid-feedback">사용 가능한 닉네임입니다.</div>
+                                )}
+                                {touched.nickname && errors.nickname && (
+                                    <div className="invalid-feedback">{errors.nickname}</div>
+                                )}
+                            </div>
+
+                            <div className="mb-3">
+                                <label className="form-label fw-semibold d-block mb-2">성별</label>
+                                <div className="form-check form-check-inline">
+                                    <input className="form-check-input"
+                                        ref={inputRefs.gender}
+                                        type="radio"
+                                        name="gender"
+                                        id="genderMale"
+                                        value="MALE"
+                                        checked={formData.gender === 'MALE'}
+                                        onChange={handleChange}
+                                        required
+                                    />
+                                    <label className="form-check-label" htmlFor="genderMale">남</label>
+                                </div>
+                                <div className="form-check form-check-inline">
+                                    <input className="form-check-input"
+                                        type="radio"
+                                        name="gender"
+                                        id="genderFemale"
+                                        value="FEMALE"
+                                        checked={formData.gender === 'FEMALE'}
+                                        onChange={handleChange}
+                                        required
+                                    />
+                                    <label className="form-check-label" htmlFor="genderFemale">여</label>
+                                </div>
+                                {touched.gender && errors.gender && <div className="form-text text-danger mt-1">{errors.gender}</div>}
+                            </div>
+
+                            <div className="mb-3">
+                                <label className="form-label fw-semibold d-block mb-2">생년월일</label>
+                                <input
+                                    type="date"
+                                    ref={inputRefs.birthDate}
+                                    className={`form-control${touched.birthDate && errors.birthDate ? " is-invalid" : ""}`}
+                                    value={birthDate}
+                                    onChange={handleBirthDate}
+                                    max={new Date().toISOString().split('T')[0]}
+                                    required
+                                />
+                                {touched.birthDate && errors.birthDate && <div className="invalid-feedback">{errors.birthDate}</div>}
+                            </div>
+
+                            <div className="d-grid">
+                                <button type="submit"
+                                    className="btn text-white shadow signup-submit-btn"
+                                    disabled={!isFormValid}>
+                                    {isSubmitting ? (
+                                        <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                                    ) : null}
+                                    입력 완료
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+};
+
+export default SocialProfilePage;


### PR DESCRIPTION
## 관련 이슈
closes #85

## 변경 사항
- `SignInPage`에 **카카오 로그인 버튼** 추가 (구분선 "또는" + 카카오 브랜드 색 — `tokens.css`에 `--kakao-yellow`/`--kakao-yellow-hover`/`--kakao-label` 토큰 신설, `sign.css`에 `.kakao-login-btn` 클래스)
- **`/oauth2/redirect` 콜백 페이지 신설** (`src/sign/components/OAuth2RedirectPage.jsx`) — 백엔드 `FRONTEND_REDIRECT_URI`와 일치
- **로그인 성공 공통 처리 훅 `src/hooks/useLoginSuccess.js` 추출** — 토큰 저장 → 프로필 조회 → nickname 저장 → Matomo 유저 속성/`travel_login` → 환영 toast → 메인 이동. 일반 로그인(SignInPage)과 소셜 로그인이 공유
- OAuth2 에러 코드→안내 메시지 매핑 상수화 (`src/constants/oauth.js`, 백엔드 `OAuth2FailureCode` 5종과 1:1)
- `authApi.js`에 `getOauth2AuthorizeUrl(provider)` 헬퍼 추가, `client.js`의 `BASE_URL` export (기존 바인딩 변경 없음)
- `events.js`/`analytics.js` JSDoc·CLAUDE.md 이벤트 카탈로그 호출 위치 갱신 (`travel_login`/`travel_login_fail`/`setLoggedInUserAttributes`)

## 작업 방법
- **인가 시작**: 카카오 버튼 클릭 → `window.location.href`로 `GET {API}/api/v1/auth/oauth2/authorize/kakao` 최상위 이동 (XHR 불가 — 백엔드가 카카오로 302 릴레이, 상태 쿠키 SameSite=Lax)
- **콜백**: 백엔드가 `?code=<일회용 UUID>`(실패 시 `?error=<코드>`)로 `/oauth2/redirect` 리다이렉트 → 코드를 `POST /api/v1/auth/oauth2/tokens`에 제출 → 일반 로그인과 동일하게 `Authorization` 헤더로 accessToken 수령 후 `completeLogin` 공통 처리
- 일회용 코드 재사용 방지를 위해 StrictMode 이중 effect를 ref로 가드
- 에러 콜백/토큰 교환 실패 시 `travel_login_fail` 발화 + toast 안내 후 `/sign/in` 복귀
- 백엔드 수정 없음 (web-api-service에 카카오 OAuth2 기구현 확인)

## 테스트
프로덕션 빌드 + `npx serve` + Playwright (API·MTM 컨테이너 목킹, `.claude/skills/verify` 레시피)

**① 카카오 로그인 성공 플로우** — 버튼 클릭 → authorize 302 → 콜백 → 토큰 교환(body `{"code":"one-time-code-uuid"}`) → `/` 이동, `window._mtm` 캡처:
```json
{"userId":"697e5e8c-..."}                                            ← 부팅(익명)
{"userId":"kakao-user-1","gender":"M","ageGroup":"20대","role":"user"} ← setLoggedInUserAttributes
{"event":"travel_login","isLoggedIn":true,"userId":"kakao-user-1","role":"user"}
{"event":"travel_main_view","isLoggedIn":true,"userId":"kakao-user-1"}
```
**② 에러 콜백** — `/oauth2/redirect?error=access_denied` → toast "로그인 동의가 취소되었습니다." → `/sign/in` 복귀:
```json
{"event":"travel_login_fail","isLoggedIn":false,"userId":"2f78f707-..."}
```
**③ 일반 로그인 회귀** — 훅 추출 후에도 동일 동작 (nickname 저장, `travel_login` 발화, `/` 이동) 확인

> 실 카카오 계정 연동 E2E(카카오 동의 화면)는 로컬에서 수동 확인 필요: 백엔드 web-api-service 기동 + `.env`의 `FRONTEND_REDIRECT_URI=http://localhost:3000/oauth2/redirect` 상태에서 버튼 클릭

🤖 Generated with [Claude Code](https://claude.com/claude-code)