### PR TITLE
✨ Feat: 관리자 로그 DB·모니터링 화면 개편 + 트래킹 processId 주입

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,9 @@ REACT_APP_MATOMO_URL=http://localhost:9080
 # MTM 컨테이너 ID (예: container_2yv5mH8U) — 미설정 시 컨테이너 삽입이 스킵됨
 REACT_APP_MATOMO_CONTAINER_ID=container_2yv5mH8U
 
+# Kibana (관리자 모니터링) — 둘 중 하나라도 없으면 대시보드 대신 설정 안내가 노출됨
+REACT_APP_KIBANA_URL=http://localhost:8085
+REACT_APP_KIBANA_DASHBOARD_ID=8190ef3f-b5be-4988-bfee-7aa7744a8f79
+
 # 앱
 REACT_APP_APP_NAME=TripNow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,8 @@ src/analytics/
 | `travel_error` | 렌더 크래시 / 목록 로드 실패(에러 화면 노출) | `trackError` / `src/components/ErrorBoundary.jsx`(render) · `src/post/pages/PostListPage.jsx`(api) | errorType("render"\|"api"), message, path | 사용자 체감 장애 |
 
 > 공통 필드(`isLoggedIn`, `userId`)는 `pushEvent`가 모든 이벤트에 자동 주입하므로 표에서 생략.
+> `processId`(로그 파이프라인 프로세스 id)도 표에서 생략 — `events.js`의 `EVENT_PROCESS_IDS` 매핑(조회/체류 5 `travel-view`, 검색 6 `travel-search`, 전환/액션 7 `travel-action`, 에러 8 `travel-error`, 검색 결과 카드 클릭 9 `travel-list-click`, 랭킹 클릭 10 `travel-ranking`)으로 `pushCatalogEvent`가 자동 주입한다. 백엔드 로그 프로세스 id가 바뀌면 `events.js`의 `LOG_PROCESS_IDS` 상수만 갱신.
+> 프로세스 분리 기준: Matomo `e_n`/`e_v` 슬롯 의미가 프로세스 내에서 동일해야 Format 규칙이 성립한다 — `list_item_click`(e_v=position)과 `ranking_click`(e_n=label, e_v=rank)은 이 이유로 `travel-search`(e_n=keyword, e_v=resultCount)에서 분리됨.
 
 ---
 
@@ -257,6 +259,10 @@ REACT_APP_IMAGE_BASE_URL=<이미지 베이스 URL>
 # Matomo
 REACT_APP_MATOMO_URL=http://localhost:9080
 REACT_APP_MATOMO_CONTAINER_ID=<MTM 컨테이너 ID>   # 예) container_2yv5mH8U — 미설정 시 컨테이너 삽입 스킵 (M3에서 도입, fallback 없음)
+
+# Kibana (관리자 > 모니터링 화면 임베드)
+REACT_APP_KIBANA_URL=http://localhost:8085
+REACT_APP_KIBANA_DASHBOARD_ID=<대시보드 UUID>      # 둘 중 하나라도 없으면 iframe 대신 설정 안내 노출 (fallback 없음)
 
 # 앱
 REACT_APP_APP_NAME=TripNow

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,14 +18,15 @@ http {
     }
 
     location /api/ {
-      proxy_pass http://14.63.178.161:8000/api;  # bff 서버(스프링) 주소와 포트
+      # 주의: proxy_pass 끝의 '/'가 없으면 /api/users -> /apiusers 로 전달됨
+      proxy_pass http://14.63.178.161:8000/api/;  # bff 서버(스프링) 주소와 포트
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       client_max_body_size 50M;
     }
-    
+
     location /images/ {
     alias /home/ubuntu/work/images/;
     }

--- a/src/admin/AdminMenu.jsx
+++ b/src/admin/AdminMenu.jsx
@@ -8,7 +8,7 @@ const MENU_ITEMS = [
     { key: 'member', label: '회원 관리', icon: <FaUsers /> },
     { key: 'process', label: '프로세스 관리', icon: <FaCogs /> },
     { key: 'log', label: '로그 DB', icon: <FaDatabase /> },
-    { key: 'monitoring', label: 'Monitoring', icon: <FaChartLine /> },
+    { key: 'monitoring', label: '모니터링', icon: <FaChartLine /> },
 ];
 
 const AdminMenu = ({ onMenuClick, activeMenu }) => {
@@ -25,12 +25,6 @@ const AdminMenu = ({ onMenuClick, activeMenu }) => {
                     {item.label}
                 </button>
             ))}
-            {/* <button className="list-group-item list-group-item-action" onClick={() => window.open(process.env.REACT_APP_MATOMO_URL)}>
-                Matomo
-            </button>
-            <button className="list-group-item list-group-item-action" onClick={() => window.open('http://14.63.178.160:8085')}>
-                Kibana
-            </button> */}
         </div>
     );
 };

--- a/src/analytics/events.js
+++ b/src/analytics/events.js
@@ -5,7 +5,9 @@ import { pushEvent, toAgeGroup } from "./analytics";
  * - 이벤트명은 반드시 이 상수로만 사용한다 (문자열 리터럴 금지).
  * - 트래커 함수는 이벤트당 1개. 페이로드 조립은 전부 이 파일 안에서 하고,
  *   호출부는 항상 1줄 호출만 한다.
- * - 공통 필드(isLoggedIn, userId)는 pushEvent가 자동 주입하므로 여기서 넣지 않는다.
+ * - 공통 필드(isLoggedIn, userId)는 pushEvent가 자동 주입하고,
+ *   processId(로그 파이프라인 프로세스 id)는 아래 EVENT_PROCESS_IDS 매핑으로
+ *   pushCatalogEvent가 자동 주입하므로 트래커에서 직접 넣지 않는다.
  * - 값이 없으면 null을 보낸다 ("없음" 같은 매직 문자열 금지).
  */
 export const EVENT_NAMES = {
@@ -28,6 +30,48 @@ export const EVENT_NAMES = {
   RANKING_CLICK: "travel_ranking_click",
   ERROR: "travel_error",
 };
+
+/**
+ * 로그 파이프라인 프로세스 ID. 백엔드 로그 관리 시스템의 log-processes와 1:1 대응한다.
+ * 백엔드에서 프로세스를 재생성해 id가 바뀌면 이 상수만 갱신한다.
+ */
+export const LOG_PROCESS_IDS = {
+  VIEW: 5, // travel-view: 조회/체류
+  SEARCH: 6, // travel-search: 검색 (search_click·search_result — e_n=keyword, e_v=resultCount)
+  ACTION: 7, // travel-action: 전환/액션
+  ERROR: 8, // travel-error: 에러
+  LIST_CLICK: 9, // travel-list-click: 검색 결과 카드 클릭 (e_v=position이라 travel-search에서 분리)
+  RANKING: 10, // travel-ranking: 메인 랭킹 카드 클릭 (e_n=label·e_v=rank라 travel-search에서 분리)
+};
+
+/** 이벤트 → 로그 프로세스 매핑. 이벤트를 추가하면 여기에도 반드시 등록한다. */
+const EVENT_PROCESS_IDS = {
+  [EVENT_NAMES.MAIN_VIEW]: LOG_PROCESS_IDS.VIEW,
+  [EVENT_NAMES.DETAIL_PAGEVIEW]: LOG_PROCESS_IDS.VIEW,
+  [EVENT_NAMES.DETAIL_EXIT]: LOG_PROCESS_IDS.VIEW,
+  [EVENT_NAMES.SEARCH_CLICK]: LOG_PROCESS_IDS.SEARCH,
+  [EVENT_NAMES.SEARCH_RESULT]: LOG_PROCESS_IDS.SEARCH,
+  [EVENT_NAMES.LIST_ITEM_CLICK]: LOG_PROCESS_IDS.LIST_CLICK,
+  [EVENT_NAMES.RANKING_CLICK]: LOG_PROCESS_IDS.RANKING,
+  [EVENT_NAMES.SIGNUP_COMPLETE]: LOG_PROCESS_IDS.ACTION,
+  [EVENT_NAMES.LOGIN]: LOG_PROCESS_IDS.ACTION,
+  [EVENT_NAMES.LOGIN_FAIL]: LOG_PROCESS_IDS.ACTION,
+  [EVENT_NAMES.POST_ADD]: LOG_PROCESS_IDS.ACTION,
+  [EVENT_NAMES.POST_UPDATE]: LOG_PROCESS_IDS.ACTION,
+  [EVENT_NAMES.POST_REMOVE]: LOG_PROCESS_IDS.ACTION,
+  [EVENT_NAMES.FAVORITE_ADD]: LOG_PROCESS_IDS.ACTION,
+  [EVENT_NAMES.FAVORITE_REMOVE]: LOG_PROCESS_IDS.ACTION,
+  [EVENT_NAMES.COMMENT_ADD]: LOG_PROCESS_IDS.ACTION,
+  [EVENT_NAMES.COMMENT_REMOVE]: LOG_PROCESS_IDS.ACTION,
+  [EVENT_NAMES.ERROR]: LOG_PROCESS_IDS.ERROR,
+};
+
+/**
+ * processId를 주입해 push한다. 이 파일의 모든 트래커는 pushEvent 대신 이 함수를 쓴다.
+ * 매핑에 없는 이벤트는 null로 보내 파이프라인 미등록 이벤트를 드러낸다.
+ */
+const pushCatalogEvent = (eventName, payload = {}) =>
+  pushEvent(eventName, { processId: EVENT_PROCESS_IDS[eventName] ?? null, ...payload });
 
 /** 게시글 ID는 항상 number로 보낸다. 캐스팅 불가하면 null. */
 const toPostId = (value) => {
@@ -53,7 +97,7 @@ const buildPostPayload = (post) => ({
  * 페이로드: 없음 (visit_time·referrer는 Matomo 기본 수집과 중복이라 보내지 않는다)
  */
 export const trackMainView = () => {
-  pushEvent(EVENT_NAMES.MAIN_VIEW);
+  pushCatalogEvent(EVENT_NAMES.MAIN_VIEW);
 };
 
 /**
@@ -62,7 +106,7 @@ export const trackMainView = () => {
  * 페이로드: category(string|null), region(string|null), keyword(string|null)
  */
 export const trackSearchClick = ({ category, region, keyword }) => {
-  pushEvent(EVENT_NAMES.SEARCH_CLICK, {
+  pushCatalogEvent(EVENT_NAMES.SEARCH_CLICK, {
     category: orNull(category),
     region: orNull(region),
     keyword: orNull(keyword),
@@ -75,7 +119,7 @@ export const trackSearchClick = ({ category, region, keyword }) => {
  * 페이로드: postId(number|null), category, region, title
  */
 export const trackDetailPageview = (post) => {
-  pushEvent(EVENT_NAMES.DETAIL_PAGEVIEW, buildPostPayload(post));
+  pushCatalogEvent(EVENT_NAMES.DETAIL_PAGEVIEW, buildPostPayload(post));
 };
 
 /**
@@ -84,7 +128,7 @@ export const trackDetailPageview = (post) => {
  * 페이로드: postId(number|null), staySeconds(number), title
  */
 export const trackDetailExit = ({ postId, staySeconds, title }) => {
-  pushEvent(EVENT_NAMES.DETAIL_EXIT, { postId: toPostId(postId), staySeconds, title: orNull(title) });
+  pushCatalogEvent(EVENT_NAMES.DETAIL_EXIT, { postId: toPostId(postId), staySeconds, title: orNull(title) });
 };
 
 /**
@@ -93,7 +137,7 @@ export const trackDetailExit = ({ postId, staySeconds, title }) => {
  * 페이로드: postId(number|null), category, region, title
  */
 export const trackFavoriteAdd = (post) => {
-  pushEvent(EVENT_NAMES.FAVORITE_ADD, buildPostPayload(post));
+  pushCatalogEvent(EVENT_NAMES.FAVORITE_ADD, buildPostPayload(post));
 };
 
 /**
@@ -102,7 +146,7 @@ export const trackFavoriteAdd = (post) => {
  * 페이로드: postId(number|null), category, region, title
  */
 export const trackFavoriteRemove = (post) => {
-  pushEvent(EVENT_NAMES.FAVORITE_REMOVE, buildPostPayload(post));
+  pushCatalogEvent(EVENT_NAMES.FAVORITE_REMOVE, buildPostPayload(post));
 };
 
 /**
@@ -111,7 +155,7 @@ export const trackFavoriteRemove = (post) => {
  * 페이로드: postId(number|null), category, region, title, star(number|null — 별점 1~5)
  */
 export const trackCommentAdd = ({ postId, category, region, title, star }) => {
-  pushEvent(EVENT_NAMES.COMMENT_ADD, {
+  pushCatalogEvent(EVENT_NAMES.COMMENT_ADD, {
     ...buildPostPayload({ postId, category, region, title }),
     star: Number.isFinite(Number(star)) && star !== null && star !== "" ? Number(star) : null,
   });
@@ -123,7 +167,7 @@ export const trackCommentAdd = ({ postId, category, region, title, star }) => {
  * 페이로드: postId(number|null), category, region, title
  */
 export const trackCommentRemove = ({ postId, category, region, title }) => {
-  pushEvent(EVENT_NAMES.COMMENT_REMOVE, buildPostPayload({ postId, category, region, title }));
+  pushCatalogEvent(EVENT_NAMES.COMMENT_REMOVE, buildPostPayload({ postId, category, region, title }));
 };
 
 /** 생년월일(yyyy-MM-dd)로 만 나이를 계산한다. 파싱 불가하면 null. */
@@ -146,7 +190,7 @@ const toAgeFromBirthDate = (birthDate) => {
  * 페이로드: gender(string|null), ageGroup(string|null — 예: "20대")
  */
 export const trackSignupComplete = ({ gender, birthDate }) => {
-  pushEvent(EVENT_NAMES.SIGNUP_COMPLETE, {
+  pushCatalogEvent(EVENT_NAMES.SIGNUP_COMPLETE, {
     gender: orNull(gender),
     ageGroup: toAgeGroup(toAgeFromBirthDate(birthDate)),
   });
@@ -158,7 +202,7 @@ export const trackSignupComplete = ({ gender, birthDate }) => {
  * 페이로드: role("admin"|"user")
  */
 export const trackLogin = ({ role }) => {
-  pushEvent(EVENT_NAMES.LOGIN, { role: orNull(role) });
+  pushCatalogEvent(EVENT_NAMES.LOGIN, { role: orNull(role) });
 };
 
 /**
@@ -167,7 +211,7 @@ export const trackLogin = ({ role }) => {
  * 페이로드: 없음 (공통 필드만)
  */
 export const trackLoginFail = () => {
-  pushEvent(EVENT_NAMES.LOGIN_FAIL);
+  pushCatalogEvent(EVENT_NAMES.LOGIN_FAIL);
 };
 
 /**
@@ -176,7 +220,7 @@ export const trackLoginFail = () => {
  * 페이로드: postId(number|null — 생성 응답에서 확보), category, region (코드값)
  */
 export const trackPostAdd = ({ postId, category, region }) => {
-  pushEvent(EVENT_NAMES.POST_ADD, {
+  pushCatalogEvent(EVENT_NAMES.POST_ADD, {
     postId: toPostId(postId),
     category: orNull(category),
     region: orNull(region),
@@ -189,7 +233,7 @@ export const trackPostAdd = ({ postId, category, region }) => {
  * 페이로드: postId(number|null), category, region (코드값)
  */
 export const trackPostUpdate = ({ postId, category, region }) => {
-  pushEvent(EVENT_NAMES.POST_UPDATE, {
+  pushCatalogEvent(EVENT_NAMES.POST_UPDATE, {
     postId: toPostId(postId),
     category: orNull(category),
     region: orNull(region),
@@ -202,7 +246,7 @@ export const trackPostUpdate = ({ postId, category, region }) => {
  * 페이로드: postId(number|null), category, region (코드값)
  */
 export const trackPostRemove = ({ postId, category, region }) => {
-  pushEvent(EVENT_NAMES.POST_REMOVE, {
+  pushCatalogEvent(EVENT_NAMES.POST_REMOVE, {
     postId: toPostId(postId),
     category: orNull(category),
     region: orNull(region),
@@ -216,7 +260,7 @@ export const trackPostRemove = ({ postId, category, region }) => {
  * 페이로드: keyword, category, region, resultCount(number — 전체 건수, 서버가 안 주면 현재 페이지 건수)
  */
 export const trackSearchResult = ({ keyword, category, region, resultCount }) => {
-  pushEvent(EVENT_NAMES.SEARCH_RESULT, {
+  pushCatalogEvent(EVENT_NAMES.SEARCH_RESULT, {
     keyword: orNull(keyword),
     category: orNull(category),
     region: orNull(region),
@@ -230,7 +274,7 @@ export const trackSearchResult = ({ keyword, category, region, resultCount }) =>
  * 페이로드: postId(number|null), position(number — 현재 페이지 내 순번, 1부터), keyword
  */
 export const trackListItemClick = ({ postId, position, keyword }) => {
-  pushEvent(EVENT_NAMES.LIST_ITEM_CLICK, {
+  pushCatalogEvent(EVENT_NAMES.LIST_ITEM_CLICK, {
     postId: toPostId(postId),
     position,
     keyword: orNull(keyword),
@@ -244,7 +288,7 @@ export const trackListItemClick = ({ postId, position, keyword }) => {
  *           label(string|null — post는 제목, region/category는 코드값), postId(number|null — post일 때만)
  */
 export const trackRankingClick = ({ rankType, rank, label, postId }) => {
-  pushEvent(EVENT_NAMES.RANKING_CLICK, {
+  pushCatalogEvent(EVENT_NAMES.RANKING_CLICK, {
     rankType,
     rank: Number.isFinite(Number(rank)) && rank !== null && rank !== undefined ? Number(rank) : null,
     label: orNull(label),
@@ -259,7 +303,7 @@ export const trackRankingClick = ({ rankType, rank, label, postId }) => {
  * 페이로드: errorType("render"|"api"), message(string|null), path(string — window.location.pathname)
  */
 export const trackError = ({ errorType, message, path }) => {
-  pushEvent(EVENT_NAMES.ERROR, {
+  pushCatalogEvent(EVENT_NAMES.ERROR, {
     errorType: orNull(errorType),
     message: orNull(message),
     path: orNull(path),

--- a/src/css/log.css
+++ b/src/css/log.css
@@ -150,6 +150,88 @@
   overflow-x: hidden;
 }
 
+/* ===== 처리 기록 상세 (LogDetail) ===== */
+.log-detail-card {
+  background: var(--card-bg);
+  border: 1px solid var(--admin-border);
+  border-radius: var(--radius-card-sm);
+  overflow: hidden;
+  margin: 4px 0;
+}
+
+.log-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: var(--brand-tint);
+  border-bottom: 1px solid var(--admin-border);
+}
+
+.log-detail-title {
+  font-weight: 600;
+  color: var(--page-title-color);
+}
+
+.log-detail-count {
+  color: var(--admin-muted);
+  font-size: 0.85rem;
+}
+
+.log-detail-grid {
+  display: grid;
+  grid-template-columns: minmax(140px, max-content) 1fr;
+}
+
+.log-detail-key {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--admin-muted);
+  padding: 8px 20px 8px 16px;
+  border-bottom: 1px solid var(--admin-border);
+  word-break: break-all;
+}
+
+.log-detail-value {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  padding: 8px 16px 8px 0;
+  border-bottom: 1px solid var(--admin-border);
+  word-break: break-word;
+  min-width: 0;
+}
+
+/* 마지막 행(key + value 2칸)은 구분선 제거 */
+.log-detail-grid > div:nth-last-child(-n+2) {
+  border-bottom: none;
+}
+
+.log-detail-value-null {
+  color: var(--admin-muted);
+  font-style: italic;
+}
+
+.log-detail-value-accent {
+  color: var(--page-title-color);
+  font-weight: 600;
+}
+
+.log-detail-value-pre {
+  margin: 0;
+  font-size: 0.85rem;
+  background: var(--admin-row-hover);
+  border-radius: var(--radius-btn);
+  padding: 8px 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.log-detail-raw {
+  padding: 12px 16px;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
 /* ===== 중복 제거 (DeduplicationRow / InputDeduplication) ===== */
 .dedup-row-card {
   box-shadow: var(--card-shadow);
@@ -186,17 +268,71 @@
   margin: 0 auto;
 }
 
-/* ===== Kibana 모니터링 ===== */
-.kibana-container {
-  width: 80vw;
-  height: 100vh;
-  margin-top: -75px;
-  padding: 0;
+/* ===== Kibana 모니터링 (Monitoring) ===== */
+.kibana-frame {
+  position: relative;
+  width: 100%;
+  /* 상단 오프셋(admin-page-root 마진 + p-4 + log-page-padding + 페이지 헤더)과 하단 여백을 뺀 높이 */
+  height: calc(100vh - 220px);
+  min-height: 460px;
+  background: var(--card-bg);
+  border-radius: var(--radius-card-sm);
+  box-shadow: var(--card-shadow);
   overflow: hidden;
 }
 
+/* 넓게 보기 — 사이드바까지 덮는 전체 화면 오버레이 */
+.kibana-frame-expanded {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-floating);
+  height: 100%;
+  border-radius: 0;
+}
+
 .kibana-iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
   border: none;
-  width: 80vw;
-  height: 100vh;
+}
+
+.kibana-collapse-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 1;
+  box-shadow: var(--card-shadow-lg);
+}
+
+/* 로딩 / 연결 실패 / 설정 없음 — iframe을 가리는 불투명 오버레이 */
+.kibana-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  text-align: center;
+  background: var(--card-bg);
+}
+
+.kibana-overlay-icon {
+  font-size: 2rem;
+  color: var(--admin-muted);
+}
+
+.kibana-overlay-title {
+  margin: 0;
+  font-weight: 700;
+  color: var(--page-title-color);
+}
+
+.kibana-overlay-desc {
+  margin: 0;
+  color: var(--admin-muted);
+  font-size: 0.9rem;
+  line-height: 1.6;
 }

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -46,6 +46,7 @@
 
   /* 타이포그래피 */
   --font-display: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Malgun Gothic', sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
   --page-title-color: #6c45e0;
 
   /* 소셜 로그인 — 카카오 브랜드 가이드 고정 색상 (임의 변경 금지) */

--- a/src/log/components/db/LogDetail.jsx
+++ b/src/log/components/db/LogDetail.jsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+/** logData 값 하나를 타입에 맞게 렌더링 (null/boolean/number/object 구분) */
+const ValueCell = ({ value }) => {
+    if (value === null || value === undefined) {
+        return <span className="log-detail-value-null">null</span>;
+    }
+    if (typeof value === 'boolean' || typeof value === 'number') {
+        return <span className="log-detail-value-accent">{String(value)}</span>;
+    }
+    if (typeof value === 'object') {
+        return <pre className="log-detail-value-pre">{JSON.stringify(value, null, 2)}</pre>;
+    }
+    return <span>{String(value)}</span>;
+};
+
+ValueCell.propTypes = {
+    value: PropTypes.any,
+};
+
+/**
+ * 처리 기록 상세(logData) 뷰.
+ * detail이 없으면 로딩, detail.error면 에러, 그 외에는 key-value 표를 보여주고
+ * 헤더의 토글 버튼으로 원본 JSON 보기로 전환할 수 있다.
+ */
+const LogDetail = ({ detail }) => {
+    const [showRawJson, setShowRawJson] = useState(false);
+
+    if (!detail) {
+        return (
+            <div className="log-detail-card p-3 text-center text-muted">
+                <span className="spinner-border spinner-border-sm me-2" role="status" />
+                불러오는 중...
+            </div>
+        );
+    }
+
+    if (detail.error) {
+        return (
+            <div className="log-detail-card p-3 text-center text-danger">
+                <i className="bi bi-exclamation-triangle me-2" />
+                {detail.error}
+            </div>
+        );
+    }
+
+    const entries = Object.entries(detail.logData || {});
+
+    return (
+        <div className="log-detail-card">
+            <div className="log-detail-header">
+                <i className="bi bi-braces log-detail-title" />
+                <span className="log-detail-title">원본 로그 데이터</span>
+                <span className="log-detail-count">{entries.length}개 필드</span>
+                <button
+                    type="button"
+                    className="admin-btn admin-btn-sm admin-btn-outline ms-auto"
+                    onClick={() => setShowRawJson(prev => !prev)}
+                >
+                    <i className={`bi ${showRawJson ? 'bi-table' : 'bi-code-slash'} me-1`} />
+                    {showRawJson ? '표로 보기' : 'JSON으로 보기'}
+                </button>
+            </div>
+            {entries.length === 0 ? (
+                <div className="p-3 text-center text-muted">로그 데이터가 없습니다.</div>
+            ) : showRawJson ? (
+                <pre className="log-table-detail-pre log-detail-raw">
+                    {JSON.stringify(detail.logData, null, 2)}
+                </pre>
+            ) : (
+                <div className="log-detail-grid">
+                    {entries.map(([key, value]) => (
+                        <React.Fragment key={key}>
+                            <div className="log-detail-key">{key}</div>
+                            <div className="log-detail-value"><ValueCell value={value} /></div>
+                        </React.Fragment>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+LogDetail.propTypes = {
+    detail: PropTypes.shape({
+        error: PropTypes.string,
+        logData: PropTypes.object,
+    }),
+};
+
+export default LogDetail;

--- a/src/log/components/db/LogManagement.jsx
+++ b/src/log/components/db/LogManagement.jsx
@@ -4,10 +4,33 @@ import { getHistories, getHistory } from '../../../api/log/historyApi';
 import AdminPageHeader from '../../../admin/AdminPageHeader';
 import LogTable from './LogTable';
 
+const PAGE_SIZE = 10;
+
+// 컬럼 키 → 백엔드 정렬 프로퍼티 (Spring Data ES가 @Field명 @timestamp/log_process_name/fail_info.fail_rule_name으로 변환)
+// historyId는 ES 자동 생성 랜덤 id라 정렬 의미가 없어 제외
+const SORT_PROPERTIES = {
+    timestamp: 'timestamp',
+    logProcessName: 'logProcessName',
+    failRuleName: 'failInfo.failRuleName',
+};
+
+const toSortParam = ({ key, direction }) => {
+    const property = SORT_PROPERTIES[key];
+    return property ? `${property},${direction}` : undefined;
+};
+
 const LogManagement = ({ onMenuClick }) => {
     const [successList, setSuccessList] = useState([]);
     const [failFilterList, setFailFilterList] = useState([]);
     const [failDedupList, setFailDedupList] = useState([]);
+
+    const [successPage, setSuccessPage] = useState(0);
+    const [failFilterPage, setFailFilterPage] = useState(0);
+    const [failDedupPage, setFailDedupPage] = useState(0);
+
+    const [successTotalPages, setSuccessTotalPages] = useState(0);
+    const [failFilterTotalPages, setFailFilterTotalPages] = useState(0);
+    const [failDedupTotalPages, setFailDedupTotalPages] = useState(0);
 
     const [expandedSuccessRowId, setExpandedSuccessRowId] = useState(null);
     const [expandedFailFilterRowId, setExpandedFailFilterRowId] = useState(null);
@@ -17,39 +40,40 @@ const LogManagement = ({ onMenuClick }) => {
     const [failFilterDetails, setFailFilterDetails] = useState({});
     const [failDedupDetails, setFailDedupDetails] = useState({});
 
-    const [successSortConfig, setSuccessSortConfig] = useState({ key: 'historyId', direction: 'desc' });
-    const [failFilterSortConfig, setFailFilterSortConfig] = useState({ key: 'historyId', direction: 'desc' });
-    const [failDedupSortConfig, setFailDedupSortConfig] = useState({ key: 'historyId', direction: 'desc' });
+    const [successSortConfig, setSuccessSortConfig] = useState({ key: 'timestamp', direction: 'desc' });
+    const [failFilterSortConfig, setFailFilterSortConfig] = useState({ key: 'timestamp', direction: 'desc' });
+    const [failDedupSortConfig, setFailDedupSortConfig] = useState({ key: 'timestamp', direction: 'desc' });
+
+    const loadList = async (params, setList, setTotalPages, errorMessage) => {
+        try {
+            const { data } = await getHistories({ ...params, size: PAGE_SIZE });
+            setList(data.result.content);
+            setTotalPages(data.result.totalPages);
+        } catch {
+            toast.error(errorMessage);
+        }
+    };
 
     useEffect(() => {
-        const load = async () => {
-            try {
-                const { data } = await getHistories({ status: 'SUCCESS', size: 100 });
-                setSuccessList(data.result.content);
-            } catch {
-                toast.error("성공 기록을 불러오지 못했습니다.");
-            }
-            try {
-                const { data } = await getHistories({ status: 'FAIL', stage: 'FILTER', size: 100 });
-                setFailFilterList(data.result.content);
-            } catch {
-                toast.error("필터 실패 기록을 불러오지 못했습니다.");
-            }
-            try {
-                const { data } = await getHistories({ status: 'FAIL', stage: 'DEDUP', size: 100 });
-                setFailDedupList(data.result.content);
-            } catch {
-                toast.error("중복제거 실패 기록을 불러오지 못했습니다.");
-            }
-        };
-        load();
-    }, []);
+        loadList({ status: 'SUCCESS', page: successPage, sort: toSortParam(successSortConfig) },
+            setSuccessList, setSuccessTotalPages, "성공 기록을 불러오지 못했습니다.");
+    }, [successPage, successSortConfig]);
+
+    useEffect(() => {
+        loadList({ status: 'FAIL', stage: 'FILTER', page: failFilterPage, sort: toSortParam(failFilterSortConfig) },
+            setFailFilterList, setFailFilterTotalPages, "필터 실패 기록을 불러오지 못했습니다.");
+    }, [failFilterPage, failFilterSortConfig]);
+
+    useEffect(() => {
+        loadList({ status: 'FAIL', stage: 'DEDUP', page: failDedupPage, sort: toSortParam(failDedupSortConfig) },
+            setFailDedupList, setFailDedupTotalPages, "중복제거 실패 기록을 불러오지 못했습니다.");
+    }, [failDedupPage, failDedupSortConfig]);
 
     const loadDetail = async (historyId, cache, setCache) => {
         if (cache[historyId]) return;
         try {
             const { data } = await getHistory(historyId);
-            setCache(prev => ({ ...prev, [historyId]: data.result.logData }));
+            setCache(prev => ({ ...prev, [historyId]: { logData: data.result.logData } }));
         } catch {
             setCache(prev => ({ ...prev, [historyId]: { error: '로그 데이터를 불러오지 못했습니다.' } }));
         }
@@ -70,24 +94,35 @@ const LogManagement = ({ onMenuClick }) => {
         // eslint-disable-next-line
     }, [expandedFailDedupRowId]);
 
+    // 페이지 이동 시 펼쳐진 상세를 접는다 (다른 페이지의 행이 남아 보이는 것 방지)
+    const handleSuccessPageChange = (p) => { setSuccessPage(p); setExpandedSuccessRowId(null); };
+    const handleFailFilterPageChange = (p) => { setFailFilterPage(p); setExpandedFailFilterRowId(null); };
+    const handleFailDedupPageChange = (p) => { setFailDedupPage(p); setExpandedFailDedupRowId(null); };
+
+    // 정렬 변경은 서버 재조회 — 1페이지로 리셋하고 펼쳐진 상세를 접는다
+    const handleSuccessSortChange = (config) => { setSuccessSortConfig(config); handleSuccessPageChange(0); };
+    const handleFailFilterSortChange = (config) => { setFailFilterSortConfig(config); handleFailFilterPageChange(0); };
+    const handleFailDedupSortChange = (config) => { setFailDedupSortConfig(config); handleFailDedupPageChange(0); };
+
+    // historyId는 ES 자동 생성 랜덤 id라 정렬 제외 (SORT_PROPERTIES 참조)
     const columnsSuccess = [
-        { key: 'historyId', label: 'History ID', width: '20%', sortable: true },
+        { key: 'historyId', label: 'History ID', width: '20%' },
         { key: 'logProcessName', label: 'Process', width: '20%', sortable: true },
-        { key: 'createdAt', label: '생성 시간', sortable: true },
+        { key: 'timestamp', label: '생성 시간', sortable: true },
     ];
 
     const columnsFailFilter = [
-        { key: 'historyId', label: 'History ID', width: '15%', sortable: true },
+        { key: 'historyId', label: 'History ID', width: '15%' },
         { key: 'logProcessName', label: 'Process', width: '15%', sortable: true },
         { key: 'failRuleName', label: '실패 원인', width: '20%', sortable: true },
-        { key: 'createdAt', label: '생성 시간', sortable: true },
+        { key: 'timestamp', label: '생성 시간', sortable: true },
     ];
 
     const columnsFailDedup = [
-        { key: 'historyId', label: 'History ID', width: '15%', sortable: true },
+        { key: 'historyId', label: 'History ID', width: '15%' },
         { key: 'logProcessName', label: 'Process', width: '15%', sortable: true },
         { key: 'failRuleName', label: '실패 원인', width: '20%', sortable: true },
-        { key: 'createdAt', label: '생성 시간', sortable: true },
+        { key: 'timestamp', label: '생성 시간', sortable: true },
     ];
 
     return (
@@ -102,10 +137,13 @@ const LogManagement = ({ onMenuClick }) => {
                         expandedRowId={expandedSuccessRowId}
                         setExpandedRowId={setExpandedSuccessRowId}
                         sortConfig={successSortConfig}
-                        setSortConfig={setSuccessSortConfig}
+                        setSortConfig={handleSuccessSortChange}
                         columns={columnsSuccess}
                         details={successDetails}
                         color="primary"
+                        page={successPage}
+                        totalPages={successTotalPages}
+                        onPageChange={handleSuccessPageChange}
                     />
                 </div>
                 <div className="col-12 mb-4">
@@ -115,10 +153,13 @@ const LogManagement = ({ onMenuClick }) => {
                         expandedRowId={expandedFailFilterRowId}
                         setExpandedRowId={setExpandedFailFilterRowId}
                         sortConfig={failFilterSortConfig}
-                        setSortConfig={setFailFilterSortConfig}
+                        setSortConfig={handleFailFilterSortChange}
                         columns={columnsFailFilter}
                         details={failFilterDetails}
                         color="danger"
+                        page={failFilterPage}
+                        totalPages={failFilterTotalPages}
+                        onPageChange={handleFailFilterPageChange}
                     />
                 </div>
                 <div className="col-12 mb-4">
@@ -128,10 +169,13 @@ const LogManagement = ({ onMenuClick }) => {
                         expandedRowId={expandedFailDedupRowId}
                         setExpandedRowId={setExpandedFailDedupRowId}
                         sortConfig={failDedupSortConfig}
-                        setSortConfig={setFailDedupSortConfig}
+                        setSortConfig={handleFailDedupSortChange}
                         columns={columnsFailDedup}
                         details={failDedupDetails}
                         color="warning"
+                        page={failDedupPage}
+                        totalPages={failDedupTotalPages}
+                        onPageChange={handleFailDedupPageChange}
                     />
                 </div>
             </div>

--- a/src/log/components/db/LogTable.jsx
+++ b/src/log/components/db/LogTable.jsx
@@ -1,27 +1,49 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { formatDate } from '../../../utils/dateUtils';
+import LogDetail from './LogDetail';
+
+/** 최대 5개의 페이지 번호를 현재 페이지 중심으로 보여주는 페이지네이션 (page는 0부터) */
+const LogPagination = ({ page, totalPages, onChange }) => {
+    if (!totalPages || totalPages <= 1) return null;
+    const WINDOW = 5;
+    const start = Math.max(0, Math.min(page - Math.floor(WINDOW / 2), totalPages - WINDOW));
+    const pages = Array.from({ length: Math.min(WINDOW, totalPages) }, (_, idx) => start + idx);
+    return (
+        <nav className="d-flex justify-content-center mt-3">
+            <ul className="pagination pagination-sm mb-0">
+                <li className={`page-item${page === 0 ? ' disabled' : ''}`}>
+                    <button className="page-link" onClick={() => onChange(page - 1)} disabled={page === 0}>이전</button>
+                </li>
+                {pages.map((p) => (
+                    <li key={p} className={`page-item${page === p ? ' active' : ''}`}>
+                        <button className="page-link" onClick={() => onChange(p)}>{p + 1}</button>
+                    </li>
+                ))}
+                <li className={`page-item${page === totalPages - 1 ? ' disabled' : ''}`}>
+                    <button className="page-link" onClick={() => onChange(page + 1)} disabled={page === totalPages - 1}>다음</button>
+                </li>
+            </ul>
+        </nav>
+    );
+};
+
+LogPagination.propTypes = {
+    page: PropTypes.number.isRequired,
+    totalPages: PropTypes.number.isRequired,
+    onChange: PropTypes.func.isRequired,
+};
 
 const LogTable = ({
     title, data, expandedRowId, setExpandedRowId,
-    sortConfig, setSortConfig, columns, color, details
+    sortConfig, setSortConfig, columns, color, details,
+    page, totalPages, onPageChange,
 }) => {
     const handleSort = (key) => {
         const newConfig = sortConfig.key === key
             ? { key, direction: sortConfig.direction === 'asc' ? 'desc' : 'asc' }
             : { key, direction: 'asc' };
         setSortConfig(newConfig);
-    };
-
-    const getSortedList = () => {
-        const { key, direction } = sortConfig;
-        if (!key) return data;
-        return [...data].sort((a, b) => {
-            let aValue = a[key];
-            let bValue = b[key];
-            if (aValue < bValue) return direction === 'asc' ? -1 : 1;
-            if (aValue > bValue) return direction === 'asc' ? 1 : -1;
-            return 0;
-        });
     };
 
     const renderSortIcon = (key) => {
@@ -32,8 +54,6 @@ const LogTable = ({
             </span>
         );
     };
-
-    const sortedList = getSortedList();
 
     return (
         <div>
@@ -59,15 +79,15 @@ const LogTable = ({
                         </tr>
                     </thead>
                     <tbody className="text-center">
-                        {sortedList.length === 0 ? (
+                        {data.length === 0 ? (
                             <tr><td colSpan={columns.length} className="text-muted">데이터가 없습니다.</td></tr>
                         ) : (
-                            sortedList.flatMap(row => [
+                            data.flatMap(row => [
                                 <tr key={row.historyId} className="log-table-row-clickable" onClick={() => setExpandedRowId(expandedRowId === row.historyId ? null : row.historyId)}>
                                     {columns.map(col => (
                                         <td key={col.key}>
                                             {col.render ? col.render(row) : (
-                                                col.key === 'createdAt'
+                                                col.key === 'timestamp'
                                                     ? formatDate(row[col.key])
                                                     : row[col.key]
                                             )}
@@ -77,12 +97,7 @@ const LogTable = ({
                                 expandedRowId === row.historyId && (
                                     <tr key={`${row.historyId}-expanded`} className="admin-table-detail-row">
                                         <td colSpan={columns.length} className="text-start">
-                                            <strong>Log Data:</strong>
-                                            <pre
-                                                className="mb-0 mt-2 log-table-detail-pre"
-                                            >
-                                                {details?.[row.historyId] ? JSON.stringify(details[row.historyId], null, 2) : '불러오는 중...'}
-                                            </pre>
+                                            <LogDetail detail={details?.[row.historyId]} />
                                         </td>
                                     </tr>
                                 )
@@ -92,8 +107,33 @@ const LogTable = ({
                 </table>
                 </div>
             </div>
+            <LogPagination page={page} totalPages={totalPages} onChange={onPageChange} />
         </div>
     );
+};
+
+LogTable.propTypes = {
+    title: PropTypes.string.isRequired,
+    data: PropTypes.array.isRequired,
+    expandedRowId: PropTypes.string,
+    setExpandedRowId: PropTypes.func.isRequired,
+    sortConfig: PropTypes.shape({
+        key: PropTypes.string,
+        direction: PropTypes.oneOf(['asc', 'desc']),
+    }).isRequired,
+    setSortConfig: PropTypes.func.isRequired,
+    columns: PropTypes.arrayOf(PropTypes.shape({
+        key: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        width: PropTypes.string,
+        sortable: PropTypes.bool,
+        render: PropTypes.func,
+    })).isRequired,
+    color: PropTypes.string.isRequired,
+    details: PropTypes.object,
+    page: PropTypes.number.isRequired,
+    totalPages: PropTypes.number.isRequired,
+    onPageChange: PropTypes.func.isRequired,
 };
 
 export default LogTable;

--- a/src/log/components/monitoring/Kibana.jsx
+++ b/src/log/components/monitoring/Kibana.jsx
@@ -1,18 +1,173 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import AdminPageHeader from '../../../admin/AdminPageHeader';
+
+const KIBANA_URL = process.env.REACT_APP_KIBANA_URL;
+const KIBANA_DASHBOARD_ID = process.env.REACT_APP_KIBANA_DASHBOARD_ID;
+
+// cross-origin iframe은 로드 실패해도 onError가 오지 않아, 제한 시간 내 onLoad가 없으면 연결 실패로 간주한다
+const LOAD_TIMEOUT_MS = 10000;
+
+// Kibana 대시보드 임베드 URL
+// _g: 자동 새로고침(60초) + 기본 시간 범위(최근 7일), show-*: 대시보드 내 시간/검색 UI 노출
+const KIBANA_GLOBAL_STATE = '(refreshInterval:(pause:!t,value:60000),time:(from:now-7d/d,to:now))';
+
+const buildDashboardUrl = () => {
+    if (!KIBANA_URL || !KIBANA_DASHBOARD_ID) return null;
+    const params = [
+        'embed=true',
+        `_g=${encodeURIComponent(KIBANA_GLOBAL_STATE)}`,
+        'show-top-menu=true',
+        'show-query-input=true',
+        'show-time-filter=true',
+    ].join('&');
+    return `${KIBANA_URL}/app/dashboards#/view/${KIBANA_DASHBOARD_ID}?${params}`;
+};
 
 const Kibana = () => {
+    const dashboardUrl = buildDashboardUrl();
+
+    const [status, setStatus] = useState('loading'); // loading | ready | error
+    const [expanded, setExpanded] = useState(false);
+    const [reloadKey, setReloadKey] = useState(0);
+    const timerRef = useRef(null);
+
+    // 로드 감시 타이머 — 마운트 및 새로고침(reloadKey)마다 재시작
+    useEffect(() => {
+        if (!dashboardUrl) return undefined;
+        setStatus('loading');
+        timerRef.current = setTimeout(
+            () => setStatus(prev => (prev === 'loading' ? 'error' : prev)),
+            LOAD_TIMEOUT_MS
+        );
+        return () => clearTimeout(timerRef.current);
+    }, [dashboardUrl, reloadKey]);
+
+    // 넓게 보기: Esc로 닫기 + 뒤 페이지 스크롤 잠금
+    useEffect(() => {
+        if (!expanded) return undefined;
+        const handleKeyDown = (e) => {
+            if (e.key === 'Escape') setExpanded(false);
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        document.body.style.overflow = 'hidden';
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            document.body.style.overflow = '';
+        };
+    }, [expanded]);
+
+    const handleLoaded = () => {
+        clearTimeout(timerRef.current);
+        setStatus('ready');
+    };
+
+    const handleReload = () => setReloadKey(prev => prev + 1);
+
+    // 환경변수 미설정 — 대시보드를 만들 수 없으므로 안내만 노출
+    if (!dashboardUrl) {
+        return (
+            <div className="container log-page-padding">
+                <AdminPageHeader title="모니터링" />
+                <div className="kibana-frame">
+                    <div className="kibana-overlay">
+                        <i className="bi bi-gear kibana-overlay-icon" />
+                        <p className="kibana-overlay-title">Kibana 설정이 없습니다</p>
+                        <p className="kibana-overlay-desc">
+                            <code>REACT_APP_KIBANA_URL</code>, <code>REACT_APP_KIBANA_DASHBOARD_ID</code>를
+                            <br />
+                            .env에 설정한 뒤 앱을 다시 시작해 주세요.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
     return (
-        <div className="kibana-container">
-            <iframe src="http://14.63.178.160:8085/app/dashboards#/view/cda75653-fe83-4bcf-b630-8f11acae0996?embed=false&_g=(refreshInterval:(pause:!t,value:5000),time:(from:now-3h,to:now))&_a=()&show-top-menu=true&show-query-input=true&show-time-filter=true"
-                height="100%"
-                width="100%"
-                className="kibana-iframe"
-                allowFullScreen
-            >
-            </iframe>
+        <div className="container log-page-padding">
+            <AdminPageHeader title="모니터링">
+                <button
+                    type="button"
+                    className="btn admin-btn admin-btn-outline admin-btn-sm"
+                    onClick={handleReload}
+                >
+                    <i className="bi bi-arrow-clockwise" /> 새로고침
+                </button>
+                <button
+                    type="button"
+                    className="btn admin-btn admin-btn-outline admin-btn-sm"
+                    onClick={() => setExpanded(true)}
+                >
+                    <i className="bi bi-arrows-fullscreen" /> 넓게 보기
+                </button>
+                <a
+                    className="btn admin-btn admin-btn-primary admin-btn-sm"
+                    href={dashboardUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    <i className="bi bi-box-arrow-up-right" /> 새 탭에서 열기
+                </a>
+            </AdminPageHeader>
 
+            <div className={`kibana-frame${expanded ? ' kibana-frame-expanded' : ''}`}>
+                {expanded && (
+                    <button
+                        type="button"
+                        className="btn admin-btn admin-btn-outline admin-btn-sm kibana-collapse-btn"
+                        onClick={() => setExpanded(false)}
+                    >
+                        <i className="bi bi-fullscreen-exit" /> 축소 (Esc)
+                    </button>
+                )}
+
+                {status === 'loading' && (
+                    <div className="kibana-overlay">
+                        <div className="spinner-border text-primary" role="status" />
+                        <p className="kibana-overlay-desc">대시보드를 불러오는 중입니다...</p>
+                    </div>
+                )}
+
+                {status === 'error' && (
+                    <div className="kibana-overlay">
+                        <i className="bi bi-exclamation-triangle kibana-overlay-icon" />
+                        <p className="kibana-overlay-title">Kibana에 연결할 수 없습니다</p>
+                        <p className="kibana-overlay-desc">
+                            Kibana 서버가 실행 중인지, 로그인이 필요한지 확인해 주세요.
+                        </p>
+                        <div className="d-flex gap-2">
+                            <button
+                                type="button"
+                                className="btn admin-btn admin-btn-outline admin-btn-sm"
+                                onClick={handleReload}
+                            >
+                                다시 시도
+                            </button>
+                            <a
+                                className="btn admin-btn admin-btn-primary admin-btn-sm"
+                                href={dashboardUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                새 탭에서 열기
+                            </a>
+                        </div>
+                    </div>
+                )}
+
+                {/* sandbox: Kibana 동작에 필요한 최소 권한만 허용 (상위 프레임 탈취·top navigation 차단) */}
+                <iframe
+                    key={reloadKey}
+                    title="Kibana 로그 모니터링 대시보드"
+                    src={dashboardUrl}
+                    className="kibana-iframe"
+                    sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
+                    referrerPolicy="no-referrer"
+                    allowFullScreen
+                    onLoad={handleLoaded}
+                />
+            </div>
         </div>
-
     );
 };
 

--- a/src/main/components/CategoryRegionRankingCards.jsx
+++ b/src/main/components/CategoryRegionRankingCards.jsx
@@ -25,7 +25,7 @@ const CategoryRegionRankingCards = ({ top5Data }) => {
                     </div>
                     <div className="mainpage-ranking-cards-badge">
                         <span>
-                            Score: {data.score}
+                            Score: {data.score?.toFixed(1) ?? 0}
                         </span>
                     </div>
                 </div>

--- a/src/main/components/MainPageCard/MainPageCard.jsx
+++ b/src/main/components/MainPageCard/MainPageCard.jsx
@@ -86,6 +86,7 @@ const MainPageCard = ({ variant = 'primary', rank, postId, score, data, type }) 
               {/* start prop을 주면 react-countup이 렌더 중 ref가 붙기 전 인스턴스를 생성해 크래시 — preserveValue가 이전 값 유지를 담당 */}
               <CountUp
                 end={score ?? 0}
+                decimals={1}
                 duration={0.5}
                 separator=","
                 preserveValue // 리렌더링 중간값 유지
@@ -137,6 +138,7 @@ const MainPageCard = ({ variant = 'primary', rank, postId, score, data, type }) 
                 {/* start prop을 주면 react-countup이 렌더 중 ref가 붙기 전 인스턴스를 생성해 크래시 — preserveValue가 이전 값 유지를 담당 */}
                 <CountUp
                   end={score ?? 0}
+                  decimals={1}
                   duration={0.5}
                   separator=","
                   preserveValue // 리렌더링 중간값 유지


### PR DESCRIPTION
## 관련 이슈
closes #87

## 변경 사항

### 처리 기록(로그 DB) 화면
- `LogDetail.jsx` 신설 — logData를 key-value 그리드로 렌더(null/number/boolean/object 타입별 스타일), `JSON으로 보기` 토글, 로딩·에러 상태 포함
- 클라이언트 전체 로드(`size=100`) + 클라이언트 정렬 → **서버 사이드 페이징/정렬**(`size=10`, `LogPagination` 윈도우 5개)
- 정렬 기본값 `timestamp,desc`, `historyId`는 정렬 대상에서 제외
- 페이지/정렬 변경 시 펼쳐진 상세 접기
- `LogTable` PropTypes 정의

### 모니터링(Kibana) 화면
- 하드코딩된 Kibana 서버 IP·대시보드 UUID 제거 → `REACT_APP_KIBANA_URL` / `REACT_APP_KIBANA_DASHBOARD_ID` 환경변수화
- 로딩 / 연결 실패 / 설정 없음 오버레이 추가
- `새로고침`, `넓게 보기`(Esc 닫기 + 스크롤 잠금), `새 탭에서 열기` 액션 추가
- iframe `sandbox` / `referrerPolicy` 지정
- 사이드바 메뉴 라벨 `Monitoring` → `모니터링`, 주석 처리된 Matomo/Kibana 버튼 잔재 제거

### Matomo 트래킹
- `events.js`에 `LOG_PROCESS_IDS` 상수 + `EVENT_PROCESS_IDS` 매핑 추가 → `pushCatalogEvent`가 모든 이벤트에 `processId` 자동 주입
- CLAUDE.md 이벤트 카탈로그에 processId 규칙·프로세스 분리 기준 명시

### 기타
- `nginx.conf` `proxy_pass` 끝 슬래시 누락 수정
- 랭킹 점수 소수점 1자리 표기
- `tokens.css` `--font-mono` 토큰 추가, `.env.example` Kibana 변수 문서화


## 테스트
- `npm run build` 통과 — 변경 파일에서 신규 ESLint 경고 없음
- 처리 기록: 성공/필터 실패/중복제거 실패 3개 테이블의 페이지 이동, 컬럼 정렬(생성 시간·Process·실패 원인), 행 펼침 상세(표/JSON 토글), 로딩·에러 표시 확인
- 모니터링: 환경변수 설정 시 대시보드 임베드, 미설정 시 안내 노출, 새로고침·넓게 보기(Esc)·새 탭 열기 동작 확인
- 트래킹: `window._mtm` push 페이로드에 `processId`가 이벤트별 매핑대로 실리는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
